### PR TITLE
Problem: excessive check if handler fulfils a contract at execution

### DIFF
--- a/ruby_event_store/lib/ruby_event_store/pub_sub/broker.rb
+++ b/ruby_event_store/lib/ruby_event_store/pub_sub/broker.rb
@@ -32,6 +32,7 @@ module RubyEventStore
 
       def verify_subscriber(subscriber)
         raise SubscriberNotExist if subscriber.nil?
+        raise InvalidHandler.new(subscriber) unless subscriber.respond_to?(:call)
       end
 
       def subscribe(subscriber, event_types)

--- a/ruby_event_store/lib/ruby_event_store/pub_sub/dispatcher.rb
+++ b/ruby_event_store/lib/ruby_event_store/pub_sub/dispatcher.rb
@@ -2,7 +2,6 @@ module RubyEventStore
   module PubSub
     class Dispatcher
       def call(subscriber, event)
-        raise InvalidHandler.new(subscriber) unless subscriber.respond_to?(:call)
         subscriber.call(event)
       end
     end

--- a/ruby_event_store/lib/ruby_event_store/spec/dispatcher_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/dispatcher_lint.rb
@@ -6,12 +6,4 @@ RSpec.shared_examples :dispatcher do |dispatcher|
     expect(handler).to receive(:call).with(event)
     dispatcher.(handler, event)
   end
-
-  specify "error when invalid subscriber passed" do
-    handler = double(:handler)
-    event   = instance_double(::RubyEventStore::Event)
-
-    expect { dispatcher.(handler, event) }.to raise_error(::RubyEventStore::InvalidHandler,
-      "#call method not found in RSpec::Mocks::Double subscriber. Are you sure it is a valid subscriber?")
-  end
 end

--- a/ruby_event_store/lib/ruby_event_store/spec/event_broker_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/event_broker_lint.rb
@@ -62,8 +62,7 @@ RSpec.shared_examples :event_broker do |broker_class|
               "in InvalidTestHandler subscriber." +
               " Are you sure it is a valid subscriber?"
     subscriber = InvalidTestHandler.new
-    broker.add_subscriber(subscriber, [Test1DomainEvent])
-    expect { broker.notify_subscribers(Test1DomainEvent.new) }.to raise_error(RubyEventStore::InvalidHandler, message)
+    expect { broker.add_subscriber(subscriber, [Test1DomainEvent]) }.to raise_error(RubyEventStore::InvalidHandler, message)
   end
 
   it 'raises error when no valid method on global handler' do
@@ -71,8 +70,7 @@ RSpec.shared_examples :event_broker do |broker_class|
               "in InvalidTestHandler subscriber." +
               " Are you sure it is a valid subscriber?"
     subscriber = InvalidTestHandler.new
-    broker.add_global_subscriber(subscriber)
-    expect { broker.notify_subscribers(Test1DomainEvent.new) }.to raise_error(RubyEventStore::InvalidHandler, message)
+    expect { broker.add_global_subscriber(subscriber) }.to raise_error(RubyEventStore::InvalidHandler, message)
   end
 
   it 'returns lambda as an output of global subscribe methods' do

--- a/ruby_event_store/spec/subscription_spec.rb
+++ b/ruby_event_store/spec/subscription_spec.rb
@@ -45,8 +45,7 @@ module RubyEventStore
         "in Subscribers::InvalidHandler subscriber." +
         " Are you sure it is a valid subscriber?"
 
-      client.subscribe(subscriber, [OrderCreated])
-      expect { client.publish_event(OrderCreated.new) }.to raise_error(InvalidHandler, message)
+      expect { client.subscribe(subscriber, [OrderCreated]) }.to raise_error(InvalidHandler, message)
     end
 
     specify 'throws exception if subscriber has not call method - handling all events' do
@@ -55,8 +54,7 @@ module RubyEventStore
         "in Subscribers::InvalidHandler subscriber." +
         " Are you sure it is a valid subscriber?"
 
-      client.subscribe_to_all_events(subscriber)
-      expect { client.publish_event(ProductAdded.new) }.to raise_error(InvalidHandler, message)
+      expect { client.subscribe_to_all_events(subscriber) }.to raise_error(InvalidHandler, message)
     end
 
     specify 'notifies subscribers listening on all events' do


### PR DESCRIPTION
Solution: Move check if handler fulfills a contract from execution to subscription

Excessive check if handler fullfils a contract (define `call` method) on each
handler call should be avoided. Instead of check on execution it will be
checked when handler's subscription is defined.