### PR TITLE
Use local dependencies

### DIFF
--- a/aggregate_root/Gemfile
+++ b/aggregate_root/Gemfile
@@ -1,2 +1,4 @@
 source 'https://rubygems.org'
 gemspec
+
+gem 'ruby_event_store', path: '../ruby_event_store'

--- a/rails_event_store/Gemfile
+++ b/rails_event_store/Gemfile
@@ -1,2 +1,6 @@
 source 'https://rubygems.org'
 gemspec
+
+gem 'ruby_event_store', path: '../ruby_event_store'
+gem 'rails_event_store_active_record', path: '../rails_event_store_active_record'
+gem 'aggregate_root', path: '../aggregate_root'

--- a/rails_event_store_active_record/Gemfile
+++ b/rails_event_store_active_record/Gemfile
@@ -1,2 +1,4 @@
 source 'https://rubygems.org'
 gemspec
+
+gem 'ruby_event_store', path: '../ruby_event_store'


### PR DESCRIPTION
Currently rails_event_store uses released versions of ruby_event_store
and rails_event_store_active_record. This is inconvenient for
development and testing.

Thanks to this patch rails_event_store will use local dependencies from the repo.

It allows to change ruby_event_store and quickly test how the change affects
rails_event_store.

Also the CI will run the entire test suite with the most recent dependencies
rather than with the released ones.