### PR TITLE
RSpec matchers

### DIFF
--- a/rails_event_store/lib/rails_event_store/rspec.rb
+++ b/rails_event_store/lib/rails_event_store/rspec.rb
@@ -7,7 +7,9 @@ module RailsEventStore
 
       def matches?(target)
         @target = target
-        @expected === @target
+        matches_kind? &&
+        matches_data? &&
+        matches_metadata?
       end
 
       def failure_message
@@ -26,6 +28,34 @@ expected: not kind of #{@expected}
 
       def description
         "be an event of kind #{@expected}"
+      end
+
+      def with_data(data)
+        @target_data = data
+        self
+      end
+      alias :and_data :with_data
+
+      def with_metadata(metadata)
+        @target_metadata = metadata
+        self
+      end
+      alias :and_metadata :with_metadata
+
+      private
+
+      def matches_kind?
+        @expected === @target
+      end
+
+      def matches_data?
+        return true unless @target_data
+        @target_data.all? { |k, v| @target.data[k] == v }
+      end
+
+      def matches_metadata?
+        return true unless @target_metadata
+        @target_metadata.all? { |k, v| @target.metadata[k] == v }
       end
     end
 

--- a/rails_event_store/lib/rails_event_store/rspec.rb
+++ b/rails_event_store/lib/rails_event_store/rspec.rb
@@ -1,0 +1,38 @@
+module RailsEventStore
+  module RSpecMatchers
+    class BeEvent
+      def initialize(expected)
+        @expected = expected
+      end
+
+      def matches?(target)
+        @target = target
+        @expected === @target
+      end
+
+      def failure_message
+        %Q{
+expected: #{@expected}
+     got: #{@target.class}
+        }
+      end
+
+      def failure_message_when_negated
+        %Q{
+expected: not kind of #{@expected}
+     got: #{@target.class}
+        }
+      end
+
+      def description
+        "be an event of kind #{@expected}"
+      end
+    end
+
+    def be_event(expected)
+      BeEvent.new(expected)
+    end
+    alias :an_event :be_event
+  end
+end
+

--- a/rails_event_store/spec/rspec_matchers_spec.rb
+++ b/rails_event_store/spec/rspec_matchers_spec.rb
@@ -52,6 +52,56 @@ expected: not kind of CouponRedeemed
      got: CouponRedeemed
         })
       end
+
+      specify do
+        expect(CouponRedeemed.new(data: { code: '123' }))
+          .to(matcher(CouponRedeemed).with_data(code: '123'))
+      end
+
+      specify do
+        expect(CouponRedeemed.new(data: { code: '123' }))
+          .to_not(matcher(CouponRedeemed).with_data(code: '456'))
+      end
+
+      specify 'partial data match' do
+        expect(CouponRedeemed.new(data: { code: '123', foo: 1 }))
+          .to(matcher(CouponRedeemed).with_data(code: '123'))
+      end
+
+      specify do
+        expect(CouponRedeemed.new(data: { code: '123' }))
+          .to_not(matcher(CouponRedeemed).with_data(code: '123', bar: 2))
+      end
+
+      specify do
+        expect(CouponRedeemed.new(metadata: { request_id: 'abc' }))
+          .to(matcher(CouponRedeemed).with_metadata(request_id: 'abc'))
+      end
+
+      specify do
+        expect(CouponRedeemed.new(metadata: { request_id: 'abc' }))
+          .to_not(matcher(CouponRedeemed).with_metadata(request_id: 'def'))
+      end
+
+      specify 'partial metadata match' do
+        expect(CouponRedeemed.new(metadata: { request_id: 'abc', remote_ip: '1.2.3.4' }))
+          .to(matcher(CouponRedeemed).with_metadata(request_id: 'abc'))
+      end
+
+      specify do
+        expect(CouponRedeemed.new(metadata: { request_id: 'abc' }))
+          .to_not(matcher(CouponRedeemed).with_metadata(request_id: 'abc', remote_ip: '1.2.3.4'))
+      end
+
+      specify do
+        expect(CouponRedeemed.new(data: { code: '123' }, metadata: { request_id: '456' }))
+          .to(matcher(CouponRedeemed).with_data(code: '123').and_metadata(request_id: '456'))
+      end
+
+      specify do
+        expect(CouponRedeemed.new(data: { code: '123' }, metadata: { request_id: '456' }))
+          .to(matcher(CouponRedeemed).with_metadata(request_id: '456').and_data(code: '123'))
+      end
     end
   end
 end

--- a/rails_event_store/spec/rspec_matchers_spec.rb
+++ b/rails_event_store/spec/rspec_matchers_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+require 'rails_event_store/rspec'
+
+CouponActivated = Class.new(RailsEventStore::Event)
+CouponRedeemed  = Class.new(RailsEventStore::Event)
+
+module RailsEventStore
+  module RSpecMatchers
+    RSpec.describe 'matcher aliases' do
+      include ::RailsEventStore::RSpecMatchers
+
+      specify { expect(be_event(CouponRedeemed)).to be_kind_of(BeEvent) }
+      specify { expect(an_event(CouponRedeemed)).to be_kind_of(BeEvent) }
+    end
+
+    RSpec.describe BeEvent do
+      def matcher(expected)
+        BeEvent.new(expected)
+      end
+
+      specify do
+        expect(CouponRedeemed.new).to matcher(CouponRedeemed)
+      end
+
+      specify do
+        expect(CouponRedeemed.new).to_not matcher(CouponActivated)
+      end
+
+      specify do
+        _matcher = matcher(CouponActivated)
+        _matcher.matches?(CouponRedeemed.new)
+
+        expect(_matcher.description).to eq("be an event of kind CouponActivated")
+      end
+
+      specify do
+        _matcher = matcher(CouponActivated)
+        _matcher.matches?(CouponRedeemed.new)
+
+        expect(_matcher.failure_message).to eq(%q{
+expected: CouponActivated
+     got: CouponRedeemed
+        })
+      end
+
+      specify do
+        _matcher = matcher(CouponRedeemed)
+        _matcher.matches?(CouponRedeemed.new)
+
+        expect(_matcher.failure_message_when_negated).to eq(%q{
+expected: not kind of CouponRedeemed
+     got: CouponRedeemed
+        })
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR servers as a placeholder to reference committed code (in branch) and link to previous discussion in #64.

RSpec matchers should be implemented as a separate gem and work on that has started in https://github.com/yashke/ruby_event_store-rspec-matchers

 