### PR TITLE
Cleaner output of top-level tests.

### DIFF
--- a/rails_event_store/spec/request_metadata_spec.rb
+++ b/rails_event_store/spec/request_metadata_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 require 'support/test_rails'
 
 module RailsEventStore
-  DummyEvent = Class.new(RailsEventStore::Event)
+  FoobarEvent = Class.new(RailsEventStore::Event)
   UUID_REGEX = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
 
   RSpec.describe Client do
     specify 'no config' do
       event_store = Client.new
 
-      TestRails.new.(->{ event_store.publish_event(DummyEvent.new) })
+      TestRails.new.(->{ event_store.publish_event(FoobarEvent.new) })
 
       expect(event_store.read_events_forward(GLOBAL_STREAM)).to_not be_empty
       event_store.read_events_forward(GLOBAL_STREAM).map(&:metadata).each do |metadata|

--- a/rails_event_store_active_record/.rspec
+++ b/rails_event_store_active_record/.rspec
@@ -1,2 +1,0 @@
---format documentation
---color

--- a/rails_event_store_active_record/spec/migration_generator_spec.rb
+++ b/rails_event_store_active_record/spec/migration_generator_spec.rb
@@ -4,6 +4,13 @@ require 'fakefs/safe'
 
 module RailsEventStoreActiveRecord
   describe MigrationGenerator do
+    around(:each) do |example|
+      current_stdout = $stdout
+      $stdout = StringIO.new
+      example.call
+      $stdout = current_stdout
+    end
+
     specify do
       FakeFS.with_fresh do
         FakeFS::FileSystem.clone(File.expand_path('../../', __FILE__))


### PR DESCRIPTION
## Before
```
  Running basic tests - beware: this won't guarantee build pass
  ...........

  Finished in 0.01105 seconds (files took 0.14375 seconds to load)
  11 examples, 0 failures

  Running basic tests - beware: this won't guarantee build pass
  ...........................................................................................................

  Finished in 0.04064 seconds (files took 0.13198 seconds to load)
  107 examples, 0 failures

  Running basic tests - beware: this won't guarantee build pass
  /Users/pawel/Code/rails_event_store/rails_event_store/spec/request_metadata_spec.rb:5: warning: already initialized constant RailsEventStore::DummyEvent
  /Users/pawel/Code/rails_event_store/rails_event_store/spec/middleware_integration_spec.rb:8: warning: previous definition of DummyEvent was here
  ....................

  Finished in 0.38375 seconds (files took 0.52012 seconds to load)
  20 examples, 0 failures

  Running basic tests - beware: this won't guarantee build pass

  RailsEventStoreActiveRecord::EventRepository
    initialize with adapter
    provide own event implementation
    behaves like event_repository
      what you get is what you gave
      reads all stream events forward & backward
      has or has not domain event
      reads batch of events from all streams forward & backward
      data attributes are retrieved
      does not have deleted streams
      metadata attributes are retrieved
      knows last event in stream
      created event is stored in given stream
      just created is empty
      reads batch of events from stream forward & backward

  RailsEventStoreActiveRecord::MigrationGenerator
        create  b.migrate.20160809222222_create_event_store_events.rb
    should match /ActiveRecord::Migration$/
        create  b.migrate.20160809222222_create_event_store_events.rb
    should match /ActiveRecord::Migration\[4\.2\]$/

  Finished in 0.26362 seconds (files took 0.47256 seconds to load)
  15 examples, 0 failures

  Randomized with seed 63510
```

## After
```
  Running basic tests - beware: this won't guarantee build pass
  ...........

  Finished in 0.01031 seconds (files took 0.14748 seconds to load)
  11 examples, 0 failures

  Running basic tests - beware: this won't guarantee build pass
  ...........................................................................................................

  Finished in 0.03983 seconds (files took 0.13299 seconds to load)
  107 examples, 0 failures

  Running basic tests - beware: this won't guarantee build pass
  ....................

  Finished in 0.45222 seconds (files took 0.52036 seconds to load)
  20 examples, 0 failures

  Running basic tests - beware: this won't guarantee build pass
  ...............

  Finished in 0.22681 seconds (files took 0.48252 seconds to load)
  15 examples, 0 failures

  Randomized with seed 45421
```