### PR TITLE
Problem: only sync handlers are possible

### DIFF
--- a/rails_event_store/lib/rails_event_store/active_job_dispatcher.rb
+++ b/rails_event_store/lib/rails_event_store/active_job_dispatcher.rb
@@ -54,7 +54,7 @@ module RailsEventStore
 
     def sync_proxy(klass)
       raise InvalidHandler.new(klass) unless klass.method_defined?(:call)
-      ->(e) { klass.new.call(e) }
+      klass.new
     end
 
     def async_proxy(klass)

--- a/rails_event_store/lib/rails_event_store/active_job_dispatcher.rb
+++ b/rails_event_store/lib/rails_event_store/active_job_dispatcher.rb
@@ -1,0 +1,67 @@
+require 'active_job'
+
+module RailsEventStore
+  class ActiveJobDispatcher
+    def call(subscriber, event)
+      subscriber.call(event)
+    end
+
+    def proxy_for(klass)
+      async_handler?(klass) ? async_proxy(klass) : sync_proxy(klass)
+    end
+
+    private
+    def async_handler?(klass)
+      klass < ActiveJob::Base
+    end
+
+    def sync_proxy(klass)
+      raise InvalidHandler.new(klass) unless klass.method_defined?(:call)
+      ->(e) { klass.new.call(e) }
+    end
+
+    def async_proxy(klass)
+      raise InvalidHandler.new(klass) unless klass.respond_to?(:perform_later)
+      enqueue_now?(klass) ? enqueue_now_proxy(klass) : enqueue_after_commit_proxy(klass)
+    end
+
+    def enqueue_now_proxy(klass)
+      ->(e) { klass.perform_later(YAML.dump(e)) }
+    end
+
+    def enqueue_after_commit_proxy(klass)
+      ->(e) {
+        if ActiveRecord::Base.connection.transaction_open?
+          ActiveRecord::Base.
+            connection.
+            current_transaction.
+            add_record( AsyncRecord.new(klass, e) )
+        else
+          klass.perform_later(YAML.dump(e))
+        end
+      }
+    end
+
+    def enqueue_now?(klass)
+      %w(
+        ActiveJob::QueueAdapters::InlineAdapter
+        ActiveJob::QueueAdapters::TestAdapter
+      ).include?(klass.queue_adapter.class.to_s)
+    end
+
+    class AsyncRecord
+      def initialize(klass, event)
+        @klass = klass
+        @event = event
+      end
+
+      def has_transactional_callbacks?
+        true
+      end
+
+      def committed!(*_, **__)
+        @klass.perform_later(YAML.dump(@event))
+      end
+    end
+  end
+end

--- a/rails_event_store/lib/rails_event_store/all.rb
+++ b/rails_event_store/lib/rails_event_store/all.rb
@@ -4,6 +4,7 @@ require 'rails_event_store/client'
 require 'rails_event_store/version'
 require 'rails_event_store/railtie'
 require 'rails_event_store/deprecations'
+require 'rails_event_store/active_job_dispatcher'
 
 module RailsEventStore
   Event                     = RubyEventStore::Event

--- a/rails_event_store/rails_event_store.gemspec
+++ b/rails_event_store/rails_event_store.gemspec
@@ -32,5 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aggregate_root', '= 0.15.0'
   spec.add_dependency 'activesupport', '>= 3.0'
   spec.add_dependency 'activemodel', '>= 3.0'
+  spec.add_dependency 'activejob', '>= 3.0'
   spec.add_development_dependency 'mutant-rspec', '~> 0.8.11'
 end

--- a/rails_event_store/spec/active_job_dispatcher_spec.rb
+++ b/rails_event_store/spec/active_job_dispatcher_spec.rb
@@ -56,7 +56,8 @@ module RailsEventStore
     end
 
     it "async proxy for defined adapter enqueue job immediately when no transaction is open" do
-      handler = ActiveJobDispatcher.new.proxy_for(AsyncHandler)
+      handler = ActiveJobDispatcher.new(proxy_strategy: AsyncProxyStrategy::AfterCommit.new)
+        .proxy_for(AsyncHandler)
 
       expect(handler.respond_to?(:call)).to be_truthy
       expect_to_have_enqueued_job(AsyncHandler) do
@@ -68,7 +69,8 @@ module RailsEventStore
     end
 
     it "async proxy for defined adapter enqueue job only after transaction commit" do
-      handler = ActiveJobDispatcher.new.proxy_for(AsyncHandler)
+      handler = ActiveJobDispatcher.new(proxy_strategy: AsyncProxyStrategy::AfterCommit.new)
+        .proxy_for(AsyncHandler)
 
       expect(handler.respond_to?(:call)).to be_truthy
       expect_to_have_enqueued_job(AsyncHandler) do
@@ -82,7 +84,8 @@ module RailsEventStore
     end
 
     it "async proxy for defined adapter do not enqueue job after transaction rollback" do
-      handler = ActiveJobDispatcher.new.proxy_for(AsyncHandler)
+      handler = ActiveJobDispatcher.new(proxy_strategy: AsyncProxyStrategy::AfterCommit.new)
+        .proxy_for(AsyncHandler)
 
       expect_no_enqueued_job(AsyncHandler) do
         ActiveRecord::Base.transaction do

--- a/rails_event_store/spec/active_job_dispatcher_spec.rb
+++ b/rails_event_store/spec/active_job_dispatcher_spec.rb
@@ -7,69 +7,125 @@ module RailsEventStore
   RSpec.describe ActiveJobDispatcher do
     it_behaves_like :dispatcher, ActiveJobDispatcher.new
 
+    around do |example|
+      with_queue_adapter(ActiveJob::Base, :test) do
+        original_logger = ActiveJob::Base.logger
+        ActiveJob::Base.logger = Logger.new(nil) # Silence messages "[ActiveJob] Enqueued ...".
+        example.run
+        ActiveJob::Base.logger = original_logger
+      end
+    end
+
+    before(:each) do
+      CallableHandler.reset
+      AsyncHandler.reset
+    end
+
+    let!(:event) { RailsEventStore::Event.new }
+    let!(:yaml)  { YAML.dump(event) }
+
     it "builds sync proxy for callable class" do
       handler = ActiveJobDispatcher.new.proxy_for(CallableHandler)
       expect(handler.respond_to?(:call)).to be_truthy
-      expect_any_instance_of(CallableHandler).to receive(:call)
-      handler.call(DummyEvent.new)
+      expect_any_instance_of(CallableHandler).to receive(:call).and_call_original
+      expect_no_enqueued_job do
+        handler.call(event)
+      end
     end
 
     it "builds async proxy for ActiveJob::Base ancestors" do
-      AsyncHandler.queue_adapter = :test
-      AsyncHandler.queue_adapter.perform_enqueued_jobs = true
-      AsyncHandler.queue_adapter.perform_enqueued_at_jobs = true
       handler = ActiveJobDispatcher.new.proxy_for(AsyncHandler)
 
       expect(handler.respond_to?(:call)).to be_truthy
-      event = DummyEvent.new
-      yaml = YAML.dump(event)
+      expect_to_have_enqueued_job(AsyncHandler) do
+        handler.call(event)
+      end
       expect(AsyncHandler.received).to be_nil
-      expect(AsyncHandler).to receive(:perform_later).with(yaml).and_call_original
-      expect_any_instance_of(AsyncHandler).to receive(:perform).with(yaml)
-      handler.call(event)
+      perform_enqueued_jobs(AsyncHandler.queue_adapter)
       expect(AsyncHandler.received).to eq(yaml)
     end
 
-    it "async proxy for defined adapter enqueue job immidiatelly when no transaction is open" do
-      AsyncHandler.queue_adapter = DummyAdapter.new
-      AsyncHandler.queue_adapter.perform_enqueued_jobs = true
-      AsyncHandler.queue_adapter.perform_enqueued_at_jobs = true
-      handler = ActiveJobDispatcher.new.proxy_for(AsyncHandler)
+    it "async proxy for defined adapter enqueue job immediately when no transaction is open" do
+      with_queue_adapter(AsyncHandler, DummyAdapter.new) do
+        handler = ActiveJobDispatcher.new.proxy_for(AsyncHandler)
 
-      expect(handler.respond_to?(:call)).to be_truthy
-      event = DummyEvent.new
-      yaml = YAML.dump(event)
-      expect(AsyncHandler.received).to be_nil
-      expect(AsyncHandler).to receive(:perform_later).with(yaml).and_call_original
-      expect_any_instance_of(AsyncHandler).to receive(:perform).with(yaml)
-      handler.call(event)
-      expect(AsyncHandler.received).to eq(yaml)
+        expect(handler.respond_to?(:call)).to be_truthy
+        expect_to_have_enqueued_job(AsyncHandler) do
+          handler.call(event)
+        end
+        expect(AsyncHandler.received).to be_nil
+        perform_enqueued_jobs(AsyncHandler.queue_adapter)
+        expect(AsyncHandler.received).to eq(yaml)
+      end
     end
 
     it "async proxy for defined adapter enqueue job only after transaction commit" do
-      AsyncHandler.queue_adapter = DummyAdapter.new
-      AsyncHandler.queue_adapter.perform_enqueued_jobs = true
-      AsyncHandler.queue_adapter.perform_enqueued_at_jobs = true
-      handler = ActiveJobDispatcher.new.proxy_for(AsyncHandler)
+      with_queue_adapter(AsyncHandler, DummyAdapter.new) do
+        handler = ActiveJobDispatcher.new.proxy_for(AsyncHandler)
 
-      expect(handler.respond_to?(:call)).to be_truthy
-      event = DummyEvent.new
-      yaml = YAML.dump(event)
-      expect(AsyncHandler).to receive(:perform_later).with(yaml).and_call_original
-      expect_any_instance_of(AsyncHandler).to receive(:perform).with(yaml)
-      ActiveRecord::Base.transaction do
-        handler.call(event)
+        expect(handler.respond_to?(:call)).to be_truthy
+        expect_to_have_enqueued_job(AsyncHandler) do
+          ActiveRecord::Base.transaction do
+            handler.call(event)
+          end
+        end
+        expect(AsyncHandler.received).to be_nil
+        perform_enqueued_jobs(AsyncHandler.queue_adapter)
+        expect(AsyncHandler.received).to eq(yaml)
+      end
+    end
+
+    it "async proxy for defined adapter do not enqueue job after transaction rollback" do
+      with_queue_adapter(AsyncHandler, DummyAdapter.new) do
+        handler = ActiveJobDispatcher.new.proxy_for(AsyncHandler)
+
+        expect_no_enqueued_job(AsyncHandler) do
+          ActiveRecord::Base.transaction do
+            handler.call(event)
+            raise ActiveRecord::Rollback
+          end
+        end
         expect(AsyncHandler.received).to be_nil
       end
-      expect(AsyncHandler.received).to eq(yaml)
+    end
+
+    def with_queue_adapter(job, queue_adapter, &proc)
+      raise unless block_given?
+      adapter = job.queue_adapter
+      job.queue_adapter = queue_adapter
+      yield
+      job.queue_adapter = adapter
+    end
+
+    def expect_no_enqueued_job(job = ActiveJob::Base, &proc)
+      raise unless block_given?
+      yield
+      expect(job.queue_adapter.enqueued_jobs).to be_empty
+    end
+
+    def expect_to_have_enqueued_job(job, &proc)
+        #expect {
+        #}.to have_enqueued_job(AsyncHandler)
+      raise unless block_given?
+      yield
+      found = job.queue_adapter.enqueued_jobs.select{|enqueued| enqueued[:job] == job}.count
+      expect(found).to eq(1)
+    end
+
+    def perform_enqueued_jobs(queue_adapter)
+      queue_adapter.enqueued_jobs.each do |enqueued|
+        enqueued[:job].perform_now(*enqueued[:args])
+      end
     end
 
     private
     DummyAdapter = Class.new(ActiveJob::QueueAdapters::TestAdapter)
-    DummyEvent = Class.new(RailsEventStore::Event)
 
     class CallableHandler
       @@received = nil
+      def self.reset
+        @@received = nil
+      end
       def self.received
         @@received
       end
@@ -80,6 +136,9 @@ module RailsEventStore
 
     class AsyncHandler < ActiveJob::Base
       @@received = nil
+      def self.reset
+        @@received = nil
+      end
       def self.received
         @@received
       end

--- a/rails_event_store/spec/active_job_dispatcher_spec.rb
+++ b/rails_event_store/spec/active_job_dispatcher_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+require 'active_job'
+require 'ruby_event_store'
+require 'ruby_event_store/spec/dispatcher_lint'
+
+module RailsEventStore
+  RSpec.describe ActiveJobDispatcher do
+    it_behaves_like :dispatcher, ActiveJobDispatcher.new
+
+    it "builds sync proxy for callable class" do
+      handler = ActiveJobDispatcher.new.proxy_for(CallableHandler)
+      expect(handler.respond_to?(:call)).to be_truthy
+      expect_any_instance_of(CallableHandler).to receive(:call)
+      handler.call(DummyEvent.new)
+    end
+
+    it "builds async proxy for ActiveJob::Base ancestors" do
+      AsyncHandler.queue_adapter = :test
+      AsyncHandler.queue_adapter.perform_enqueued_jobs = true
+      AsyncHandler.queue_adapter.perform_enqueued_at_jobs = true
+      handler = ActiveJobDispatcher.new.proxy_for(AsyncHandler)
+
+      expect(handler.respond_to?(:call)).to be_truthy
+      event = DummyEvent.new
+      yaml = YAML.dump(event)
+      expect(AsyncHandler.received).to be_nil
+      expect(AsyncHandler).to receive(:perform_later).with(yaml).and_call_original
+      expect_any_instance_of(AsyncHandler).to receive(:perform).with(yaml)
+      handler.call(event)
+      expect(AsyncHandler.received).to eq(yaml)
+    end
+
+    it "async proxy for defined adapter enqueue job immidiatelly when no transaction is open" do
+      AsyncHandler.queue_adapter = DummyAdapter.new
+      AsyncHandler.queue_adapter.perform_enqueued_jobs = true
+      AsyncHandler.queue_adapter.perform_enqueued_at_jobs = true
+      handler = ActiveJobDispatcher.new.proxy_for(AsyncHandler)
+
+      expect(handler.respond_to?(:call)).to be_truthy
+      event = DummyEvent.new
+      yaml = YAML.dump(event)
+      expect(AsyncHandler.received).to be_nil
+      expect(AsyncHandler).to receive(:perform_later).with(yaml).and_call_original
+      expect_any_instance_of(AsyncHandler).to receive(:perform).with(yaml)
+      handler.call(event)
+      expect(AsyncHandler.received).to eq(yaml)
+    end
+
+    it "async proxy for defined adapter enqueue job only after transaction commit" do
+      AsyncHandler.queue_adapter = DummyAdapter.new
+      AsyncHandler.queue_adapter.perform_enqueued_jobs = true
+      AsyncHandler.queue_adapter.perform_enqueued_at_jobs = true
+      handler = ActiveJobDispatcher.new.proxy_for(AsyncHandler)
+
+      expect(handler.respond_to?(:call)).to be_truthy
+      event = DummyEvent.new
+      yaml = YAML.dump(event)
+      expect(AsyncHandler).to receive(:perform_later).with(yaml).and_call_original
+      expect_any_instance_of(AsyncHandler).to receive(:perform).with(yaml)
+      ActiveRecord::Base.transaction do
+        handler.call(event)
+        expect(AsyncHandler.received).to be_nil
+      end
+      expect(AsyncHandler.received).to eq(yaml)
+    end
+
+    private
+    DummyAdapter = Class.new(ActiveJob::QueueAdapters::TestAdapter)
+    DummyEvent = Class.new(RailsEventStore::Event)
+
+    class CallableHandler
+      @@received = nil
+      def self.received
+        @@received
+      end
+      def call(event)
+        @@received = event
+      end
+    end
+
+    class AsyncHandler < ActiveJob::Base
+      @@received = nil
+      def self.received
+        @@received
+      end
+      def perform(event)
+        @@received = event
+      end
+    end
+  end
+end

--- a/ruby_event_store/lib/ruby_event_store/client.rb
+++ b/ruby_event_store/lib/ruby_event_store/client.rb
@@ -79,7 +79,7 @@ module RubyEventStore
     attr_reader :repository, :page_size, :event_broker, :metadata_proc, :clock
 
     def subscriber_or_proxy(subscriber)
-      subscriber&.instance_of?(Class) ? event_broker.proxy_for(subscriber) : subscriber
+      subscriber.instance_of?(Class) ? event_broker.proxy_for(subscriber) : subscriber
     end
 
     def enrich_event_metadata(event)

--- a/ruby_event_store/lib/ruby_event_store/client.rb
+++ b/ruby_event_store/lib/ruby_event_store/client.rb
@@ -63,6 +63,16 @@ module RubyEventStore
       repository.read_all_streams_backward(page.start, page.count)
     end
 
+    def on(event_types, subscriber_klass, &proc)
+      proxy = event_broker.proxy_for(subscriber_klass)
+      subscribe(proxy, event_types, &proc)
+    end
+
+    def on_all_events(subscriber_klass, &proc)
+      proxy = event_broker.proxy_for(subscriber_klass)
+      subscribe_to_all_events(proxy, &proc)
+    end
+
     def subscribe(subscriber, event_types, &proc)
       event_broker.add_subscriber(subscriber, event_types).tap do |unsub|
         handle_subscribe(unsub, &proc)

--- a/ruby_event_store/lib/ruby_event_store/errors.rb
+++ b/ruby_event_store/lib/ruby_event_store/errors.rb
@@ -8,8 +8,8 @@ module RubyEventStore
   InvalidPageSize            = Class.new(ArgumentError)
 
   class InvalidHandler < StandardError
-    def initialize(subscriber)
-      super("#call method not found in #{subscriber.class} subscriber. Are you sure it is a valid subscriber?")
+    def initialize(subscriber_klass)
+      super("#call method not found in #{subscriber_klass} subscriber. Are you sure it is a valid subscriber?")
     end
   end
 end

--- a/ruby_event_store/lib/ruby_event_store/pub_sub/broker.rb
+++ b/ruby_event_store/lib/ruby_event_store/pub_sub/broker.rb
@@ -27,12 +27,16 @@ module RubyEventStore
         end
       end
 
+      def proxy_for(klass)
+        dispatcher.proxy_for(klass)
+      end
+
       private
       attr_reader :subscribers, :dispatcher
 
       def verify_subscriber(subscriber)
         raise SubscriberNotExist if subscriber.nil?
-        raise InvalidHandler.new(subscriber) unless subscriber.respond_to?(:call)
+        raise InvalidHandler.new(subscriber.class) unless subscriber.respond_to?(:call)
       end
 
       def subscribe(subscriber, event_types)

--- a/ruby_event_store/lib/ruby_event_store/pub_sub/dispatcher.rb
+++ b/ruby_event_store/lib/ruby_event_store/pub_sub/dispatcher.rb
@@ -4,6 +4,11 @@ module RubyEventStore
       def call(subscriber, event)
         subscriber.call(event)
       end
+
+      def proxy_for(klass)
+        raise InvalidHandler.new(klass) unless klass.method_defined?(:call)
+        ->(e) { klass.new.call(e) }
+      end
     end
   end
 end

--- a/ruby_event_store/lib/ruby_event_store/spec/dispatcher_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/dispatcher_lint.rb
@@ -6,4 +6,32 @@ RSpec.shared_examples :dispatcher do |dispatcher|
     expect(handler).to receive(:call).with(event)
     dispatcher.(handler, event)
   end
+
+  specify "returns callable proxy" do
+    event   = instance_double(::RubyEventStore::Event)
+
+    handler = dispatcher.proxy_for(HandlerClass)
+    expect(handler).to receive(:call).with(event).and_call_original
+    dispatcher.(handler, event)
+    expect(HandlerClass.received).to eq(event)
+  end
+
+  specify "fails to build proxy when no call method defined on class" do
+    message = "#call method not found " +
+      "in Fixnum subscriber." +
+      " Are you sure it is a valid subscriber?"
+
+    expect { dispatcher.proxy_for(Fixnum) }.to raise_error(::RubyEventStore::InvalidHandler, message)
+  end
+
+  private
+  class HandlerClass
+    @@received = nil
+    def self.received
+      @@received
+    end
+    def call(event)
+      @@received = event
+    end
+  end
 end

--- a/ruby_event_store/lib/ruby_event_store/spec/dispatcher_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/dispatcher_lint.rb
@@ -18,10 +18,10 @@ RSpec.shared_examples :dispatcher do |dispatcher|
 
   specify "fails to build proxy when no call method defined on class" do
     message = "#call method not found " +
-      "in Fixnum subscriber." +
+      "in String subscriber." +
       " Are you sure it is a valid subscriber?"
 
-    expect { dispatcher.proxy_for(Fixnum) }.to raise_error(::RubyEventStore::InvalidHandler, message)
+    expect { dispatcher.proxy_for(String) }.to raise_error(::RubyEventStore::InvalidHandler, message)
   end
 
   private

--- a/ruby_event_store/lib/ruby_event_store/spec/event_broker_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/event_broker_lint.rb
@@ -120,4 +120,28 @@ RSpec.shared_examples :event_broker do |broker_class|
     broker_with_custom_dispatcher.notify_subscribers(event1)
     expect(dispatcher.dispatched).to eq([{subscriber: handler, event: event1}])
   end
+
+  it "returns callable proxy" do
+    proxy = broker.proxy_for(TestHandler)
+    expect(proxy.respond_to?(:call)).to be_truthy
+  end
+
+  specify "fails to build proxy when no call method defined on class" do
+    message = "#call method not found " +
+      "in InvalidTestHandler subscriber." +
+      " Are you sure it is a valid subscriber?"
+
+    expect { broker.proxy_for(InvalidTestHandler) }.to raise_error(::RubyEventStore::InvalidHandler, message)
+  end
+
+  private
+  class HandlerClass
+    @@received = nil
+    def self.received
+      @@received
+    end
+    def call(event)
+      @@received = event
+    end
+  end
 end

--- a/ruby_event_store/spec/client_spec.rb
+++ b/ruby_event_store/spec/client_spec.rb
@@ -158,5 +158,11 @@ module RubyEventStore
       expect(published.size).to eq(1)
       expect(published.first.metadata[:timestamp]).to eq(utc)
     end
+
+    specify 'throws exception if subscriber is not defined' do
+      client = RubyEventStore::Client.new(repository: InMemoryRepository.new)
+      expect { client.subscribe(nil, [])}.to raise_error(SubscriberNotExist)
+      expect { client.subscribe_to_all_events(nil)}.to raise_error(SubscriberNotExist)
+    end
   end
 end

--- a/ruby_event_store/spec/subscription_spec.rb
+++ b/ruby_event_store/spec/subscription_spec.rb
@@ -24,7 +24,11 @@ class CustomDispatcher
   end
 
   def call(subscriber, event)
-    @dispatched_events << {to: subscriber, event: event}
+    @dispatched_events << {to: subscriber.class, event: event}
+  end
+
+  def proxy_for(klass)
+    ->(e) { klass.new.call(e) }
   end
 end
 
@@ -107,7 +111,7 @@ module RubyEventStore
       client.subscribe(subscriber, [OrderCreated])
       event = OrderCreated.new
       client.publish_event(event)
-      expect(dispatcher.dispatched_events).to eq [{to: subscriber, event: event}]
+      expect(dispatcher.dispatched_events).to eq [{to: Subscribers::ValidHandler, event: event}]
     end
 
     specify 'lambda is an output of global subscribe methods' do
@@ -156,6 +160,88 @@ module RubyEventStore
 
       expect(received_event).to_not be_nil
       expect(received_event.metadata[:timestamp]).to eq(Time.at(0))
+    end
+
+    specify 'throws exception if subscriber klass does not have call method - handling subscribed events' do
+      message = "#call method not found " +
+        "in Subscribers::InvalidHandler subscriber." +
+        " Are you sure it is a valid subscriber?"
+
+      expect { client.on([OrderCreated], Subscribers::InvalidHandler) }.to raise_error(InvalidHandler, message)
+    end
+
+    specify 'throws exception if subscriber klass have not call method - handling all events' do
+      message = "#call method not found " +
+        "in Subscribers::InvalidHandler subscriber." +
+        " Are you sure it is a valid subscriber?"
+
+      expect { client.on_all_events(Subscribers::InvalidHandler) }.to raise_error(InvalidHandler, message)
+    end
+
+    specify 'dispatch events to subscribers via proxy' do
+      dispatcher = CustomDispatcher.new
+      broker = PubSub::Broker.new(dispatcher: dispatcher)
+      client = RubyEventStore::Client.new(repository: repository, event_broker: broker)
+      client.on([OrderCreated], Subscribers::ValidHandler)
+      event = OrderCreated.new
+      client.publish_event(event)
+      expect(dispatcher.dispatched_events).to eq [{to: Proc, event: event}]
+    end
+
+    specify 'dispatch all events to subscribers via proxy' do
+      dispatcher = CustomDispatcher.new
+      broker = PubSub::Broker.new(dispatcher: dispatcher)
+      client = RubyEventStore::Client.new(repository: repository, event_broker: broker)
+      client.on_all_events(Subscribers::ValidHandler)
+      event = OrderCreated.new
+      client.publish_event(event)
+      expect(dispatcher.dispatched_events).to eq [{to: Proc, event: event}]
+    end
+
+    specify 'lambda is an output of global subscribe via proxy' do
+      dispatcher = CustomDispatcher.new
+      broker = PubSub::Broker.new(dispatcher: dispatcher)
+      client = RubyEventStore::Client.new(repository: repository, event_broker: broker)
+      result = client.on_all_events(Subscribers::ValidHandler)
+      expect(result).to respond_to(:call)
+    end
+
+    specify 'lambda is an output of subscribe via proxy' do
+      dispatcher = CustomDispatcher.new
+      broker = PubSub::Broker.new(dispatcher: dispatcher)
+      client = RubyEventStore::Client.new(repository: repository, event_broker: broker)
+      result = client.on([OrderCreated], Subscribers::ValidHandler)
+      expect(result).to respond_to(:call)
+    end
+
+    specify 'dynamic global subscription via proxy' do
+      event_1 = OrderCreated.new
+      event_2 = ProductAdded.new
+      dispatcher = CustomDispatcher.new
+      broker = PubSub::Broker.new(dispatcher: dispatcher)
+      client = RubyEventStore::Client.new(repository: repository, event_broker: broker)
+      result = client.on_all_events(Subscribers::ValidHandler) do
+        client.publish_event(event_1)
+      end
+      client.publish_event(event_2)
+      expect(dispatcher.dispatched_events).to eq [{to: Proc, event: event_1}]
+      expect(result).to respond_to(:call)
+      expect(client.read_all_streams_forward).to eq([event_1, event_2])
+    end
+
+    specify 'dynamic subscription' do
+      event_1 = OrderCreated.new
+      event_2 = ProductAdded.new
+      dispatcher = CustomDispatcher.new
+      broker = PubSub::Broker.new(dispatcher: dispatcher)
+      client = RubyEventStore::Client.new(repository: repository, event_broker: broker)
+      result = client.on([OrderCreated, ProductAdded], Subscribers::ValidHandler) do
+        client.publish_event(event_1)
+      end
+      client.publish_event(event_2)
+      expect(dispatcher.dispatched_events).to eq [{to: Proc, event: event_1}]
+      expect(result).to respond_to(:call)
+      expect(client.read_all_streams_forward).to eq([event_1, event_2])
     end
   end
 end

--- a/ruby_event_store/spec/subscription_spec.rb
+++ b/ruby_event_store/spec/subscription_spec.rb
@@ -167,7 +167,7 @@ module RubyEventStore
         "in Subscribers::InvalidHandler subscriber." +
         " Are you sure it is a valid subscriber?"
 
-      expect { client.on([OrderCreated], Subscribers::InvalidHandler) }.to raise_error(InvalidHandler, message)
+      expect { client.subscribe(Subscribers::InvalidHandler, [OrderCreated]) }.to raise_error(InvalidHandler, message)
     end
 
     specify 'throws exception if subscriber klass have not call method - handling all events' do
@@ -175,14 +175,14 @@ module RubyEventStore
         "in Subscribers::InvalidHandler subscriber." +
         " Are you sure it is a valid subscriber?"
 
-      expect { client.on_all_events(Subscribers::InvalidHandler) }.to raise_error(InvalidHandler, message)
+      expect { client.subscribe_to_all_events(Subscribers::InvalidHandler) }.to raise_error(InvalidHandler, message)
     end
 
     specify 'dispatch events to subscribers via proxy' do
       dispatcher = CustomDispatcher.new
       broker = PubSub::Broker.new(dispatcher: dispatcher)
       client = RubyEventStore::Client.new(repository: repository, event_broker: broker)
-      client.on([OrderCreated], Subscribers::ValidHandler)
+      client.subscribe(Subscribers::ValidHandler, [OrderCreated])
       event = OrderCreated.new
       client.publish_event(event)
       expect(dispatcher.dispatched_events).to eq [{to: Proc, event: event}]
@@ -192,7 +192,7 @@ module RubyEventStore
       dispatcher = CustomDispatcher.new
       broker = PubSub::Broker.new(dispatcher: dispatcher)
       client = RubyEventStore::Client.new(repository: repository, event_broker: broker)
-      client.on_all_events(Subscribers::ValidHandler)
+      client.subscribe_to_all_events(Subscribers::ValidHandler)
       event = OrderCreated.new
       client.publish_event(event)
       expect(dispatcher.dispatched_events).to eq [{to: Proc, event: event}]
@@ -202,7 +202,7 @@ module RubyEventStore
       dispatcher = CustomDispatcher.new
       broker = PubSub::Broker.new(dispatcher: dispatcher)
       client = RubyEventStore::Client.new(repository: repository, event_broker: broker)
-      result = client.on_all_events(Subscribers::ValidHandler)
+      result = client.subscribe_to_all_events(Subscribers::ValidHandler)
       expect(result).to respond_to(:call)
     end
 
@@ -210,7 +210,7 @@ module RubyEventStore
       dispatcher = CustomDispatcher.new
       broker = PubSub::Broker.new(dispatcher: dispatcher)
       client = RubyEventStore::Client.new(repository: repository, event_broker: broker)
-      result = client.on([OrderCreated], Subscribers::ValidHandler)
+      result = client.subscribe(Subscribers::ValidHandler, [OrderCreated])
       expect(result).to respond_to(:call)
     end
 
@@ -220,7 +220,7 @@ module RubyEventStore
       dispatcher = CustomDispatcher.new
       broker = PubSub::Broker.new(dispatcher: dispatcher)
       client = RubyEventStore::Client.new(repository: repository, event_broker: broker)
-      result = client.on_all_events(Subscribers::ValidHandler) do
+      result = client.subscribe_to_all_events(Subscribers::ValidHandler) do
         client.publish_event(event_1)
       end
       client.publish_event(event_2)
@@ -235,7 +235,7 @@ module RubyEventStore
       dispatcher = CustomDispatcher.new
       broker = PubSub::Broker.new(dispatcher: dispatcher)
       client = RubyEventStore::Client.new(repository: repository, event_broker: broker)
-      result = client.on([OrderCreated, ProductAdded], Subscribers::ValidHandler) do
+      result = client.subscribe(Subscribers::ValidHandler, [OrderCreated, ProductAdded]) do
         client.publish_event(event_1)
       end
       client.publish_event(event_2)


### PR DESCRIPTION
Solution: ActiveJob dispatcher and a new way of subscribing to domain events

`ActiveJobDispatcher` is a new dispatcher ready to use with RES as a replacement of `DefaultDispatcher`.
The main improvement is that if a handler class is an ancestor of `ActiveJob::Base` it will be handled asynchronously.
Also it defines a set of `ActiveJob` adapters for which enqueue of tasks to perform (handlers) need to be done only after transaction is committed.

The new way of subscribing to domain events:
- currently we have `subscribe(lambda_or_callable_class_instance, [domain_event], unsubscribe_proc)`, this will not allow us to use async jobs as we need to pass instance to RES client
- adding 2 new methods:
   - `on([domain_event], class_name, unsubscribe_proc)` and `on_all_events(class_name, unsubscribe_proc)`
   - for a klass given in `on` method a callable proxy will be created and will be passed to "old" `subscribe` method
   - dispatcher is responsible for creating a proxy - that allow customising the proxy based on dispatcher capabilities