### PR TITLE
Make AggregateRoot#unpublished_events public

### DIFF
--- a/aggregate_root/lib/aggregate_root.rb
+++ b/aggregate_root/lib/aggregate_root.rb
@@ -26,12 +26,12 @@ module AggregateRoot
     @unpublished_events = nil
   end
 
-  private
-  attr_reader :loaded_from_stream_name
-
   def unpublished_events
     @unpublished_events ||= []
   end
+
+  private
+  attr_reader :loaded_from_stream_name
 
   def apply_strategy
     DefaultApplyStrategy.new


### PR DESCRIPTION
Because it is necessary for testing and that's the public interface for
exposing generated domain events.