### PR TITLE
apply returns applied events

### DIFF
--- a/aggregate_root/lib/aggregate_root.rb
+++ b/aggregate_root/lib/aggregate_root.rb
@@ -4,9 +4,11 @@ require 'aggregate_root/configuration'
 require 'aggregate_root/default_apply_strategy'
 
 module AggregateRoot
-  def apply(event)
-    apply_strategy.(self, event)
-    unpublished_events << event
+  def apply(*events)
+    events.each do |event|
+      apply_strategy.(self, event)
+      unpublished_events << event
+    end
   end
 
   def load(stream_name, event_store: default_event_store)

--- a/aggregate_root/spec/aggregate_root_spec.rb
+++ b/aggregate_root/spec/aggregate_root_spec.rb
@@ -133,4 +133,23 @@ describe AggregateRoot do
     order.apply(order_created)
     expect(order.status).to eq :created
   end
+
+  it "should return applied events" do
+    order = Order.new
+    created = Orders::Events::OrderCreated.new
+    expired = Orders::Events::OrderExpired.new
+
+    applied = order.apply(created, expired)
+    expect(applied).to eq([created, expired])
+  end
+
+  it "should return only applied events" do
+    order = Order.new
+    created = Orders::Events::OrderCreated.new
+    order.apply(created)
+
+    expired = Orders::Events::OrderExpired.new
+    applied = order.apply(expired)
+    expect(applied).to eq([expired])
+  end
 end


### PR DESCRIPTION
that makes testing much easier when commands are used to build state.
Developers can easily opt-out by doing

```ruby
def apply(*events)
  super
  nil
end
```

in their class.

or by explicitly returning `nil` or `self`

```ruby
  def supply(quantity)
    raise NotRegistered unless @store_id
    apply(ProductSupplied.new(data: {
      store_id: @store_id,
      sku: @sku,
      quantity: quantity,
    }))
    nil
  end
```