### PR TITLE
Make unpublished_events public and read-only

### DIFF
--- a/aggregate_root/lib/aggregate_root.rb
+++ b/aggregate_root/lib/aggregate_root.rb
@@ -7,7 +7,7 @@ module AggregateRoot
   def apply(*events)
     events.each do |event|
       apply_strategy.(self, event)
-      unpublished_events << event
+      unpublished << event
     end
   end
 
@@ -28,10 +28,14 @@ module AggregateRoot
     @unpublished_events = nil
   end
 
+  def unpublished_events
+    unpublished.each
+  end
+
   private
   attr_reader :loaded_from_stream_name
 
-  def unpublished_events
+  def unpublished
     @unpublished_events ||= []
   end
 

--- a/aggregate_root/spec/spec_helper.rb
+++ b/aggregate_root/spec/spec_helper.rb
@@ -25,10 +25,6 @@ class Order
     @status = :draft
   end
 
-  def expected_events
-    unpublished_events
-  end
-
   attr_accessor :status
   private
 
@@ -66,10 +62,6 @@ class OrderWithCustomStrategy
 
   def apply_strategy
     @apply_strategy ||= CustomOrderApplyStrategy.new
-  end
-
-  def expected_events
-    unpublished_events
   end
 
   attr_accessor :status


### PR DESCRIPTION
Instead of https://github.com/RailsEventStore/rails_event_store/pull/108