### PR TITLE
Add missing methods to AsyncRecord

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,10 @@ matrix:
     env: TARGET=rails_event_store_active_record SCRIPT=test DATABASE_URL=postgres://localhost/rails_event_store_active_record?pool=5
   - rvm: 2.4.1
     env: TARGET=rails_event_store_active_record SCRIPT=test DATABASE_URL=mysql2://root:@127.0.0.1/rails_event_store_active_record?pool=5
+  - rvm: 2.4.1
+    env: TARGET=rails_event_store SCRIPT=test RAILS_VERSION=5.1.4
+  - rvm: 2.4.1
+    env: TARGET=rails_event_store SCRIPT=test RAILS_VERSION=5.0.6
 before_script:
   - psql -c 'create extension pgcrypto;' -U postgres
   - psql -c 'create database rails_event_store_active_record;' -U postgres

--- a/rails_event_store/Gemfile
+++ b/rails_event_store/Gemfile
@@ -4,3 +4,6 @@ gemspec
 gem 'ruby_event_store', path: '../ruby_event_store'
 gem 'rails_event_store_active_record', path: '../rails_event_store_active_record'
 gem 'aggregate_root', path: '../aggregate_root'
+if v = ENV['RAILS_VERSION']
+  gem 'rails', v
+end

--- a/rails_event_store/Makefile
+++ b/rails_event_store/Makefile
@@ -11,7 +11,7 @@ test: ## Run tests
 mutate: test  ## Run mutation tests
 	@echo "Running mutation tests - only 100% free mutation will be accepted"
 	@bundle exec mutant --include lib --require rails_event_store --use rspec "RailsEventStore*" \
-		--ignore-subject "RailsEventStore.const_missing"
+		--ignore-subject "RailsEventStore.const_missing" --ignore-subject "RailsEventStore::AsyncProxyStrategy::AfterCommit::AsyncRecord#rolledback!" --ignore-subject "RailsEventStore::AsyncProxyStrategy::AfterCommit::AsyncRecord#before_committed!"
 
 build:
 	@gem build -V rails_event_store.gemspec

--- a/rails_event_store/lib/rails_event_store/active_job_dispatcher.rb
+++ b/rails_event_store/lib/rails_event_store/active_job_dispatcher.rb
@@ -25,7 +25,7 @@ module RailsEventStore
           @klass.perform_later(YAML.dump(@event))
         end
 
-        def rolledback!
+        def rolledback!(**_)
         end
 
         def before_committed!

--- a/rails_event_store/lib/rails_event_store/active_job_dispatcher.rb
+++ b/rails_event_store/lib/rails_event_store/active_job_dispatcher.rb
@@ -24,6 +24,12 @@ module RailsEventStore
         def committed!
           @klass.perform_later(YAML.dump(@event))
         end
+
+        def rolledback!
+        end
+
+        def before_committed!
+        end
       end
     end
 


### PR DESCRIPTION
When transaction is rolled back AR calls `rollback!` on all records
added to transaction. The methods, even withou aby body, need to be
defined to avoid missing method error.

Fix for https://github.com/RailsEventStore/rails_event_store/issues/132