### PR TITLE
Remove redundant "__global__" stream, slightly changing "all" semantics

### DIFF
--- a/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
@@ -27,14 +27,16 @@ module RailsEventStoreActiveRecord
           metadata: event.metadata,
           event_type: event.class,
         )
-        [{
-          stream:   stream_name,
-          position: position,
-          event_id: event.event_id
-        },{
+        events = [{
           stream: RubyEventStore::GLOBAL_STREAM,
           event_id: event.event_id
         }]
+        events.unshift({
+          stream:   stream_name,
+          position: position,
+          event_id: event.event_id
+        }) unless stream_name.eql?(RubyEventStore::GLOBAL_STREAM)
+        events
       end
       EventInStream.import(in_stream)
       self

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
@@ -32,7 +32,7 @@ module RailsEventStoreActiveRecord
           position: position,
           event_id: event.event_id
         },{
-          stream: ::RubyEventStore::GLOBAL_STREAM,
+          stream: RubyEventStore::GLOBAL_STREAM,
           event_id: event.event_id
         }]
       end
@@ -92,7 +92,7 @@ module RailsEventStoreActiveRecord
     end
 
     def read_all_streams_forward(after_event_id, count)
-      stream = EventInStream.where(stream: ::RubyEventStore::GLOBAL_STREAM)
+      stream = EventInStream.where(stream: RubyEventStore::GLOBAL_STREAM)
       unless after_event_id.equal?(:head)
         after_event = stream.find_by!(event_id: after_event_id)
         stream = stream.where('id > ?', after_event)
@@ -103,7 +103,7 @@ module RailsEventStoreActiveRecord
     end
 
     def read_all_streams_backward(before_event_id, count)
-      stream = EventInStream.where(stream: ::RubyEventStore::GLOBAL_STREAM)
+      stream = EventInStream.where(stream: RubyEventStore::GLOBAL_STREAM)
       unless before_event_id.equal?(:head)
         before_event = stream.find_by!(event_id: before_event_id)
         stream = stream.where('id < ?', before_event)

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
@@ -6,7 +6,8 @@ module RailsEventStoreActiveRecord
 
     def append_to_stream(events, stream_name, expected_version)
       events = normalize_to_array(events)
-      expected_version   = case expected_version
+      expected_version =
+        case expected_version
         when nil
           raise RubyEventStore::InvalidExpectedVersion
         when :none
@@ -16,7 +17,10 @@ module RailsEventStoreActiveRecord
           (eis && eis.position) || -1
         else
           expected_version
-      end
+        end
+
+      raise RubyEventStore::InvalidExpectedVersion if stream_name.eql?(RubyEventStore::GLOBAL_STREAM) && !expected_version.equal?(:any)
+
       in_stream = events.flat_map.with_index do |event, index|
         position = unless expected_version.equal?(:any)
           expected_version + index + POSITION_SHIFT

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
@@ -3,6 +3,7 @@ require 'activerecord-import'
 module RailsEventStoreActiveRecord
   class EventRepository
     POSITION_SHIFT = 1
+    GLOBAL_STREAM  = "__global__".freeze
 
     def append_to_stream(events, stream_name, expected_version)
       events = normalize_to_array(events)
@@ -32,7 +33,7 @@ module RailsEventStoreActiveRecord
           position: position,
           event_id: event.event_id
         },{
-          stream: "__global__",
+          stream: GLOBAL_STREAM,
           event_id: event.event_id
         }]
       end
@@ -92,7 +93,7 @@ module RailsEventStoreActiveRecord
     end
 
     def read_all_streams_forward(after_event_id, count)
-      stream = EventInStream.where(stream: "__global__")
+      stream = EventInStream.where(stream: GLOBAL_STREAM)
       unless after_event_id.equal?(:head)
         after_event = stream.find_by!(event_id: after_event_id)
         stream = stream.where('id > ?', after_event)
@@ -103,7 +104,7 @@ module RailsEventStoreActiveRecord
     end
 
     def read_all_streams_backward(before_event_id, count)
-      stream = EventInStream.where(stream: "__global__")
+      stream = EventInStream.where(stream: GLOBAL_STREAM)
       unless before_event_id.equal?(:head)
         before_event = stream.find_by!(event_id: before_event_id)
         stream = stream.where('id < ?', before_event)

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
@@ -5,6 +5,8 @@ module RailsEventStoreActiveRecord
     POSITION_SHIFT = 1
 
     def append_to_stream(events, stream_name, expected_version)
+      raise RubyEventStore::InvalidExpectedVersion if stream_name.eql?(RubyEventStore::GLOBAL_STREAM) && !expected_version.equal?(:any)
+
       events = normalize_to_array(events)
       expected_version =
         case expected_version
@@ -18,8 +20,6 @@ module RailsEventStoreActiveRecord
         else
           expected_version
         end
-
-      raise RubyEventStore::InvalidExpectedVersion if stream_name.eql?(RubyEventStore::GLOBAL_STREAM) && !expected_version.equal?(:any)
 
       in_stream = events.flat_map.with_index do |event, index|
         position = unless expected_version.equal?(:any)

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
@@ -3,7 +3,7 @@ require 'activerecord-import'
 module RailsEventStoreActiveRecord
   class EventRepository
     POSITION_SHIFT = 1
-    GLOBAL_STREAM  = "__global__".freeze
+    GLOBAL_STREAM  = "all".freeze
 
     def append_to_stream(events, stream_name, expected_version)
       events = normalize_to_array(events)

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
@@ -3,7 +3,6 @@ require 'activerecord-import'
 module RailsEventStoreActiveRecord
   class EventRepository
     POSITION_SHIFT = 1
-    GLOBAL_STREAM  = "all".freeze
 
     def append_to_stream(events, stream_name, expected_version)
       events = normalize_to_array(events)
@@ -33,7 +32,7 @@ module RailsEventStoreActiveRecord
           position: position,
           event_id: event.event_id
         },{
-          stream: GLOBAL_STREAM,
+          stream: ::RubyEventStore::GLOBAL_STREAM,
           event_id: event.event_id
         }]
       end
@@ -93,7 +92,7 @@ module RailsEventStoreActiveRecord
     end
 
     def read_all_streams_forward(after_event_id, count)
-      stream = EventInStream.where(stream: GLOBAL_STREAM)
+      stream = EventInStream.where(stream: ::RubyEventStore::GLOBAL_STREAM)
       unless after_event_id.equal?(:head)
         after_event = stream.find_by!(event_id: after_event_id)
         stream = stream.where('id > ?', after_event)
@@ -104,7 +103,7 @@ module RailsEventStoreActiveRecord
     end
 
     def read_all_streams_backward(before_event_id, count)
-      stream = EventInStream.where(stream: GLOBAL_STREAM)
+      stream = EventInStream.where(stream: ::RubyEventStore::GLOBAL_STREAM)
       unless before_event_id.equal?(:head)
         before_event = stream.find_by!(event_id: before_event_id)
         stream = stream.where('id < ?', before_event)

--- a/rails_event_store_active_record/spec/event_repository_spec.rb
+++ b/rails_event_store_active_record/spec/event_repository_spec.rb
@@ -100,17 +100,17 @@ module RailsEventStoreActiveRecord
         event_type: TestDomainEvent.name,
       )
       EventInStream.create!(
-        stream:   "__global__",
+        stream:   "all",
         position: 1,
         event_id: e1.id,
       )
       EventInStream.create!(
-        stream:   "__global__",
+        stream:   "all",
         position: 0,
         event_id: e2.id,
       )
       EventInStream.create!(
-        stream:   "__global__",
+        stream:   "all",
         position: 2,
         event_id: e3.id,
       )

--- a/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
+++ b/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
@@ -10,7 +10,8 @@ module RubyEventStore
     end
 
     def append_to_stream(events, stream_name, expected_version)
-      raise InvalidExpectedVersion if expected_version.nil?
+      raise InvalidExpectedVersion if expected_version.nil? ||
+        (!expected_version.equal?(:any) && stream_name.eql?(GLOBAL_STREAM))
       events = normalize_to_array(events)
       stream = read_stream_events_forward(stream_name)
       expected_version = case expected_version

--- a/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
@@ -373,12 +373,30 @@ RSpec.shared_examples :event_repository do |repository_class|
   end
 
   it 'allows appending to GLOBAL_STREAM explicitly' do
-    repository.append_to_stream(
-      event = TestDomainEvent.new(event_id: "df8b2ba3-4e2c-4888-8d14-4364855fa80e"),
-      "all",
-      -1
-    )
+    event = TestDomainEvent.new(event_id: "df8b2ba3-4e2c-4888-8d14-4364855fa80e")
+    repository.append_to_stream(event, "all", :any)
 
     expect(repository.read_all_streams_forward(:head, 10)).to eq([event])
+  end
+
+  specify 'GLOBAL_STREAM is unordered, one cannot expect specific version number to work' do
+    expect {
+      event = TestDomainEvent.new(event_id: "df8b2ba3-4e2c-4888-8d14-4364855fa80e")
+      repository.append_to_stream(event, "all", 42)
+    }.to raise_error(RubyEventStore::InvalidExpectedVersion)
+  end
+
+  specify 'GLOBAL_STREAM is unordered, one cannot expect :none to work' do
+    expect {
+      event = TestDomainEvent.new(event_id: "df8b2ba3-4e2c-4888-8d14-4364855fa80e")
+      repository.append_to_stream(event, "all", :none)
+    }.to raise_error(RubyEventStore::InvalidExpectedVersion)
+  end
+
+  specify 'GLOBAL_STREAM is unordered, one cannot expect :auto to work' do
+    expect {
+      event = TestDomainEvent.new(event_id: "df8b2ba3-4e2c-4888-8d14-4364855fa80e")
+      repository.append_to_stream(event, "all", :auto)
+    }.to raise_error(RubyEventStore::InvalidExpectedVersion)
   end
 end

--- a/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
@@ -372,4 +372,13 @@ RSpec.shared_examples :event_repository do |repository_class|
     end.to raise_error(RubyEventStore::EventDuplicatedInStream)
   end
 
+  it 'allows appending to GLOBAL_STREAM explicitly' do
+    repository.append_to_stream(
+      event = TestDomainEvent.new(event_id: "df8b2ba3-4e2c-4888-8d14-4364855fa80e"),
+      ::RubyEventStore::GLOBAL_STREAM,
+      -1
+    )
+
+    expect(repository.read_all_streams_forward(:head, 10)).to eq([event])
+  end
 end

--- a/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
@@ -375,7 +375,7 @@ RSpec.shared_examples :event_repository do |repository_class|
   it 'allows appending to GLOBAL_STREAM explicitly' do
     repository.append_to_stream(
       event = TestDomainEvent.new(event_id: "df8b2ba3-4e2c-4888-8d14-4364855fa80e"),
-      ::RubyEventStore::GLOBAL_STREAM,
+      "all",
       -1
     )
 


### PR DESCRIPTION
- addresses https://github.com/RailsEventStore/rails_event_store/issues/131
- no changes to migration in https://github.com/RailsEventStore/rails_event_store/issues/129, it might be slightly different if we decide on https://github.com/RailsEventStore/rails_event_store/issues/131#issuecomment-335634991