### PR TITLE
Proof of Concept of removing GLOBAL_STREAM

### DIFF
--- a/rails_event_store/lib/rails_event_store/all.rb
+++ b/rails_event_store/lib/rails_event_store/all.rb
@@ -19,7 +19,6 @@ module RailsEventStore
   InvalidHandler            = RubyEventStore::InvalidHandler
   InvalidPageStart          = RubyEventStore::InvalidPageStart
   InvalidPageSize           = RubyEventStore::InvalidPageSize
-  GLOBAL_STREAM             = RubyEventStore::GLOBAL_STREAM
   PAGE_SIZE                 = RubyEventStore::PAGE_SIZE
 
   mattr_reader :event_repository

--- a/rails_event_store/spec/middleware_integration_spec.rb
+++ b/rails_event_store/spec/middleware_integration_spec.rb
@@ -15,7 +15,7 @@ module RailsEventStore
         ->(env) { { server_name: env['SERVER_NAME'] }}))
       request.get('/')
 
-      event_store.read_events_forward(GLOBAL_STREAM).map(&:metadata).each do |metadata|
+      event_store.read_all_streams_forward.map(&:metadata).each do |metadata|
         expect(metadata[:server_name]).to  eq('example.org')
       end
     end

--- a/rails_event_store/spec/request_metadata_spec.rb
+++ b/rails_event_store/spec/request_metadata_spec.rb
@@ -11,8 +11,8 @@ module RailsEventStore
 
       TestRails.new.(->{ event_store.publish_event(FoobarEvent.new) })
 
-      expect(event_store.read_events_forward(GLOBAL_STREAM)).to_not be_empty
-      event_store.read_events_forward(GLOBAL_STREAM).map(&:metadata).each do |metadata|
+      expect(event_store.read_all_streams_forward).to_not be_empty
+      event_store.read_all_streams_forward.map(&:metadata).each do |metadata|
         expect(metadata[:remote_ip]).to  eq('127.0.0.1')
         expect(metadata[:request_id]).to match(UUID_REGEX)
       end

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
@@ -27,7 +27,7 @@ module RailsEventStoreActiveRecord
 
       ActiveRecord::Base.transaction(requires_new: true) do
         in_stream =
-          events.flat_map.with_index do |event, index|
+          events.map.with_index do |event, index|
             position = expected_version + index + POSITION_SHIFT unless expected_version.equal?(:any)
 
             Event.create!(

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
@@ -101,7 +101,7 @@ module RailsEventStoreActiveRecord
     end
 
     def read_all_streams_forward(after_event_id, count)
-      events = Event.all
+      events = Event
       unless after_event_id.equal?(:head)
         after_event = Event.find(after_event_id)
         events = Event.where('position > ?', after_event.position)
@@ -112,7 +112,7 @@ module RailsEventStoreActiveRecord
     end
 
     def read_all_streams_backward(before_event_id, count)
-      events = Event.all
+      events = Event
       unless before_event_id.equal?(:head)
         before_event = Event.find(before_event_id)
         events = Event.where('position < ?', before_event.position)

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
@@ -11,8 +11,6 @@ module RailsEventStoreActiveRecord
     end
 
     def append_to_stream(events, stream_name, expected_version)
-      raise RubyEventStore::InvalidExpectedVersion if stream_name.eql?(RubyEventStore::GLOBAL_STREAM) && !expected_version.equal?(:any)
-
       events = normalize_to_array(events)
       expected_version =
         case expected_version
@@ -27,28 +25,26 @@ module RailsEventStoreActiveRecord
           raise RubyEventStore::InvalidExpectedVersion
         end
 
-      in_stream = events.flat_map.with_index do |event, index|
-        position = unless expected_version.equal?(:any)
-          expected_version + index + POSITION_SHIFT
-        end
-        Event.create!(
-          id: event.event_id,
-          data: event.data,
-          metadata: event.metadata,
-          event_type: event.class,
-        )
-        events = [{
-          stream: RubyEventStore::GLOBAL_STREAM,
-          event_id: event.event_id
-        }]
-        events.unshift({
-          stream:   stream_name,
-          position: position,
-          event_id: event.event_id
-        }) unless stream_name.eql?(RubyEventStore::GLOBAL_STREAM)
-        events
+      ActiveRecord::Base.transaction(requires_new: true) do
+        in_stream =
+          events.flat_map.with_index do |event, index|
+            position = expected_version + index + POSITION_SHIFT unless expected_version.equal?(:any)
+
+            Event.create!(
+              id: event.event_id,
+              data: event.data,
+              metadata: event.metadata,
+              event_type: event.class,
+            )
+
+            {
+              stream:   stream_name,
+              position: position,
+              event_id: event.event_id
+            }
+          end
+        EventInStream.import(in_stream) unless stream_name.nil?
       end
-      EventInStream.import(in_stream)
       self
     rescue ActiveRecord::RecordNotUnique => e
       if detect_pkey_index_violated(e)
@@ -66,9 +62,10 @@ module RailsEventStoreActiveRecord
     end
 
     def last_stream_event(stream_name)
-      build_event_entity(
-        EventInStream.where(stream: stream_name).order('position DESC, id DESC').first
-      )
+      stream = EventInStream.where(stream: stream_name).order('position DESC, id DESC').first
+      return unless stream
+
+      build_event_entity(stream.event)
     end
 
     def read_events_forward(stream_name, after_event_id, count)
@@ -79,7 +76,7 @@ module RailsEventStoreActiveRecord
       end
 
       stream.preload(:event).order('position ASC, id ASC').limit(count)
-        .map(&method(:build_event_entity))
+        .map { |r| build_event_entity(r.event) }
     end
 
     def read_events_backward(stream_name, before_event_id, count)
@@ -90,55 +87,54 @@ module RailsEventStoreActiveRecord
       end
 
       stream.preload(:event).order('position DESC, id DESC').limit(count)
-        .map(&method(:build_event_entity))
+        .map { |r| build_event_entity(r.event) }
     end
 
     def read_stream_events_forward(stream_name)
       EventInStream.preload(:event).where(stream: stream_name).order('position ASC, id ASC')
-        .map(&method(:build_event_entity))
+        .map { |r| build_event_entity(r.event) }
     end
 
     def read_stream_events_backward(stream_name)
       EventInStream.preload(:event).where(stream: stream_name).order('position DESC, id DESC')
-        .map(&method(:build_event_entity))
+        .map { |r| build_event_entity(r.event) }
     end
 
     def read_all_streams_forward(after_event_id, count)
-      stream = EventInStream.where(stream: RubyEventStore::GLOBAL_STREAM)
+      events = Event.all
       unless after_event_id.equal?(:head)
-        after_event = stream.find_by!(event_id: after_event_id)
-        stream = stream.where('id > ?', after_event)
+        after_event = Event.find(after_event_id)
+        events = Event.where('position > ?', after_event.position)
       end
 
-      stream.preload(:event).order('id ASC').limit(count)
+      events.order('position ASC').limit(count)
         .map(&method(:build_event_entity))
     end
 
     def read_all_streams_backward(before_event_id, count)
-      stream = EventInStream.where(stream: RubyEventStore::GLOBAL_STREAM)
+      events = Event.all
       unless before_event_id.equal?(:head)
-        before_event = stream.find_by!(event_id: before_event_id)
-        stream = stream.where('id < ?', before_event)
+        before_event = Event.find(before_event_id)
+        events = Event.where('position < ?', before_event.position)
       end
 
-      stream.preload(:event).order('id DESC').limit(count)
+      events.order('position DESC').limit(count)
         .map(&method(:build_event_entity))
     end
 
     private
 
     def detect_pkey_index_violated(e)
-      e.message.include?("for key 'PRIMARY'")       ||  # MySQL
-      e.message.include?("event_store_events_pkey") ||  # Postgresql
-      e.message.include?("event_store_events.id")       # Sqlite3
+      e.message.include?("index_event_store_events_on_id")  ||  # MySQL
+      e.message.include?("event_store_events_pkey")         ||  # Postgresql
+      e.message.include?("event_store_events.id")               # Sqlite3
     end
 
-    def build_event_entity(record)
-      return nil unless record
-      record.event.event_type.constantize.new(
-        event_id: record.event.id,
-        metadata: record.event.metadata,
-        data: record.event.data
+    def build_event_entity(event_record)
+      event_record.event_type.constantize.new(
+        event_id: event_record.id,
+        metadata: event_record.metadata,
+        data: event_record.data
       )
     end
 

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/generators/templates/migration_template.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/generators/templates/migration_template.rb
@@ -1,6 +1,8 @@
 class CreateEventStoreEvents < ActiveRecord::Migration<%= migration_version %>
   def change
     postgres = ActiveRecord::Base.connection.adapter_name == "PostgreSQL"
+    mysql    = ActiveRecord::Base.connection.adapter_name == "Mysql2"
+
     enable_extension "pgcrypto" if postgres
     create_table(:event_store_events_in_streams, force: false) do |t|
       t.string      :stream,      null: false
@@ -22,16 +24,30 @@ class CreateEventStoreEvents < ActiveRecord::Migration<%= migration_version %>
         t.text        :metadata
         t.text        :data,        null: false
         t.datetime    :created_at,  null: false
+        t.serial      :position,    null: false
       end
-    else
+    elsif mysql
       create_table(:event_store_events, id: false, force: false) do |t|
-        t.string :id, limit: 36, primary_key: true, null: false
+        t.string :id, limit: 36,    null: false
         t.string      :event_type,  null: false
         t.text        :metadata
         t.text        :data,        null: false
         t.datetime    :created_at,  null: false
+        t.integer     :position,    null: false, primary_key: true, auto_increment: true
       end
+      add_index :event_store_events, :id, unique: true
+    else
+      create_table(:event_store_events, id: false, force: false) do |t|
+        t.string :id, limit: 36,    null: false
+        t.string      :event_type,  null: false
+        t.text        :metadata
+        t.text        :data,        null: false
+        t.datetime    :created_at,  null: false
+        t.integer     :position,    null: false, primary_key: true
+      end
+      add_index :event_store_events, :id, unique: true
     end
     add_index :event_store_events, :created_at
+    add_index :event_store_events, :position, unique: true
   end
 end

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/legacy_event_repository.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/legacy_event_repository.rb
@@ -16,7 +16,6 @@ module RailsEventStoreActiveRecord
 
     def append_to_stream(events, stream_name, expected_version)
       validate_expected_version_is_not_auto(expected_version)
-      validate_expected_version_is_any_for_global_stream(expected_version, stream_name)
 
       case expected_version
       when :none
@@ -124,10 +123,6 @@ module RailsEventStoreActiveRecord
 
     def stream_non_empty?(stream_name)
       LegacyEvent.where(stream: stream_name).exists?
-    end
-
-    def validate_expected_version_is_any_for_global_stream(expected_version, stream_name)
-      raise RubyEventStore::InvalidExpectedVersion if stream_name.eql?(GLOBAL_STREAM) && !expected_version.equal?(:any)
     end
 
     def validate_stream_is_empty(stream_name)

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/legacy_event_repository.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/legacy_event_repository.rb
@@ -2,6 +2,8 @@ require 'active_record'
 
 module RailsEventStoreActiveRecord
   class LegacyEventRepository
+    GLOBAL_STREAM = 'all'.freeze
+
     class LegacyEvent < ::ActiveRecord::Base
       self.primary_key = :id
       self.table_name = 'event_store_events'
@@ -10,6 +12,7 @@ module RailsEventStoreActiveRecord
     end
 
     private_constant :LegacyEvent
+    private_constant :GLOBAL_STREAM
 
     def append_to_stream(events, stream_name, expected_version)
       validate_expected_version_is_not_auto(expected_version)
@@ -35,7 +38,7 @@ module RailsEventStoreActiveRecord
     end
 
     def delete_stream(stream_name)
-      LegacyEvent.where({stream: stream_name}).update_all(stream: RubyEventStore::GLOBAL_STREAM)
+      LegacyEvent.where({stream: stream_name}).update_all(stream: GLOBAL_STREAM)
     end
 
     def has_event?(event_id)
@@ -124,7 +127,7 @@ module RailsEventStoreActiveRecord
     end
 
     def validate_expected_version_is_any_for_global_stream(expected_version, stream_name)
-      raise RubyEventStore::InvalidExpectedVersion if stream_name.eql?(RubyEventStore::GLOBAL_STREAM) && !expected_version.equal?(:any)
+      raise RubyEventStore::InvalidExpectedVersion if stream_name.eql?(GLOBAL_STREAM) && !expected_version.equal?(:any)
     end
 
     def validate_stream_is_empty(stream_name)

--- a/rails_event_store_active_record/spec/event_repository_spec.rb
+++ b/rails_event_store_active_record/spec/event_repository_spec.rb
@@ -138,6 +138,13 @@ module RailsEventStoreActiveRecord
       end
     end
 
+    specify "explicit ORDER BY position" do
+      expect_query(/SELECT.*FROM.*event_store_events.*ORDER BY position ASC LIMIT.*/) do
+        repository = EventRepository.new
+        repository.read_all_streams_forward(:head, 1)
+      end
+    end
+
     specify "publishing only to global stream" do
       repository = EventRepository.new
       repository.append_to_stream(

--- a/rails_event_store_active_record/spec/event_repository_spec.rb
+++ b/rails_event_store_active_record/spec/event_repository_spec.rb
@@ -30,10 +30,10 @@ module RailsEventStoreActiveRecord
         event1 = TestDomainEvent.new(event_id: SecureRandom.uuid),
       ], 'stream', :auto)
       c1 = count_queries{ repository.read_all_streams_forward(:head, 2) }
-      expect(c1).to eq(2)
+      expect(c1).to eq(1)
 
       c2 = count_queries{ repository.read_all_streams_backward(:head, 2) }
-      expect(c2).to eq(2)
+      expect(c2).to eq(1)
 
       c3 = count_queries{ repository.read_stream_events_forward('stream') }
       expect(c3).to eq(2)

--- a/rails_event_store_active_record/spec/v1_v2_schema_migration_spec.rb
+++ b/rails_event_store_active_record/spec/v1_v2_schema_migration_spec.rb
@@ -24,19 +24,22 @@ RSpec.describe "v1_v2_migration" do
   MigrationRubyCode.gsub!("<%= migration_version %>", migration_version)
 
   specify do
-    establish_database_connection
-    load_database_schema
-    skip("in-memory sqlite cannot run this test") if ENV['DATABASE_URL'].include?(":memory:")
-    dump_current_schema
-    drop_existing_tables_to_clean_state
-    fill_data_using_older_gem
-    run_the_migration
-    reset_columns_information
-    verify_all_events_stream
-    verify_event_sourced_stream
-    verify_technical_stream
-    compare_new_schema
-    drop_legacy_database
+    begin
+      establish_database_connection
+      load_database_schema
+      skip("in-memory sqlite cannot run this test") if ENV['DATABASE_URL'].include?(":memory:")
+      dump_current_schema
+      drop_existing_tables_to_clean_state
+      fill_data_using_older_gem
+      run_the_migration
+      reset_columns_information
+      verify_all_events_stream
+      verify_event_sourced_stream
+      verify_technical_stream
+      compare_new_schema
+    ensure
+      drop_legacy_database
+    end
   end
 
   private

--- a/ruby_event_store/lib/ruby_event_store/client.rb
+++ b/ruby_event_store/lib/ruby_event_store/client.rb
@@ -12,7 +12,7 @@ module RubyEventStore
       @clock          = clock
     end
 
-    def publish_events(events, stream_name: GLOBAL_STREAM, expected_version: :any)
+    def publish_events(events, stream_name: nil, expected_version: :any)
       append_to_stream(events, stream_name: stream_name, expected_version: expected_version)
       events.each do |ev|
         event_broker.notify_subscribers(ev)
@@ -20,11 +20,11 @@ module RubyEventStore
       :ok
     end
 
-    def publish_event(event, stream_name: GLOBAL_STREAM, expected_version: :any)
+    def publish_event(event, stream_name: nil, expected_version: :any)
       publish_events([event], stream_name: stream_name, expected_version: expected_version)
     end
 
-    def append_to_stream(events, stream_name: GLOBAL_STREAM, expected_version: :any)
+    def append_to_stream(events, stream_name: nil, expected_version: :any)
       events = normalize_to_array(events)
       events.each{|event| enrich_event_metadata(event) }
       repository.append_to_stream(events, stream_name, expected_version)

--- a/ruby_event_store/lib/ruby_event_store/constants.rb
+++ b/ruby_event_store/lib/ruby_event_store/constants.rb
@@ -1,4 +1,3 @@
 module RubyEventStore
-  GLOBAL_STREAM = 'all'.freeze
   PAGE_SIZE = 100.freeze
 end

--- a/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
+++ b/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
@@ -10,7 +10,6 @@ module RubyEventStore
     end
 
     def append_to_stream(events, stream_name, expected_version)
-      raise InvalidExpectedVersion if !expected_version.equal?(:any) && stream_name.eql?(GLOBAL_STREAM)
       events = normalize_to_array(events)
       stream = read_stream_events_forward(stream_name)
       expected_version = case expected_version

--- a/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
@@ -378,34 +378,6 @@ RSpec.shared_examples :event_repository do |repository_class|
     end.to raise_error(RubyEventStore::EventDuplicatedInStream)
   end
 
-  it 'allows appending to GLOBAL_STREAM explicitly' do
-    event = TestDomainEvent.new(event_id: "df8b2ba3-4e2c-4888-8d14-4364855fa80e")
-    repository.append_to_stream(event, "all", :any)
-
-    expect(repository.read_all_streams_forward(:head, 10)).to eq([event])
-  end
-
-  specify 'GLOBAL_STREAM is unordered, one cannot expect specific version number to work' do
-    expect {
-      event = TestDomainEvent.new(event_id: "df8b2ba3-4e2c-4888-8d14-4364855fa80e")
-      repository.append_to_stream(event, "all", 42)
-    }.to raise_error(RubyEventStore::InvalidExpectedVersion)
-  end
-
-  specify 'GLOBAL_STREAM is unordered, one cannot expect :none to work' do
-    expect {
-      event = TestDomainEvent.new(event_id: "df8b2ba3-4e2c-4888-8d14-4364855fa80e")
-      repository.append_to_stream(event, "all", :none)
-    }.to raise_error(RubyEventStore::InvalidExpectedVersion)
-  end
-
-  specify 'GLOBAL_STREAM is unordered, one cannot expect :auto to work' do
-    expect {
-      event = TestDomainEvent.new(event_id: "df8b2ba3-4e2c-4888-8d14-4364855fa80e")
-      repository.append_to_stream(event, "all", :auto)
-    }.to raise_error(RubyEventStore::InvalidExpectedVersion)
-  end
-
   specify "only :none, :any, :auto and Integer allowed as expected_version" do
     [Object.new, SecureRandom.uuid, :foo].each do |invalid_expected_version|
       expect {

--- a/ruby_event_store/spec/actions/create_events_in_stream_spec.rb
+++ b/ruby_event_store/spec/actions/create_events_in_stream_spec.rb
@@ -63,7 +63,7 @@ module RubyEventStore
       client = RubyEventStore::Client.new(repository: InMemoryRepository.new)
       event = OrderCreated.new
       client.publish_event(event)
-      saved_events = client.read_stream_events_forward('all')
+      saved_events = client.read_all_streams_forward
       expect(saved_events[0]).to eq(event)
     end
   end

--- a/ruby_event_store/spec/client_spec.rb
+++ b/ruby_event_store/spec/client_spec.rb
@@ -20,14 +20,14 @@ module RubyEventStore
       client = RubyEventStore::Client.new(repository: InMemoryRepository.new)
       test_event = TestEvent.new
       expect(client.append_to_stream(test_event)).to eq(:ok)
-      expect(client.read_stream_events_forward(GLOBAL_STREAM)).to eq([test_event])
+      expect(client.read_all_streams_forward).to eq([test_event])
     end
 
     specify 'publish to default stream when not specified' do
       client = RubyEventStore::Client.new(repository: InMemoryRepository.new)
       test_event = TestEvent.new
       expect(client.publish_events([test_event])).to eq(:ok)
-      expect(client.read_stream_events_forward(GLOBAL_STREAM)).to eq([test_event])
+      expect(client.read_all_streams_forward).to eq([test_event])
     end
 
     specify 'delete_stream returns :ok when success' do
@@ -51,7 +51,7 @@ module RubyEventStore
       client = RubyEventStore::Client.new(repository: InMemoryRepository.new)
       test_event = TestEvent.new
       expect(client.publish_event(test_event)).to eq(:ok)
-      expect(client.read_stream_events_forward(GLOBAL_STREAM)).to eq([test_event])
+      expect(client.read_all_streams_forward).to eq([test_event])
     end
 
     specify 'publish first event, expect any stream state' do


### PR DESCRIPTION
- it is possible to append/publish an event without specifying a stream
- event_store_events now have position to set global order when reading
  all events (regardless of stream they were linked to)