### PR TITLE
Make all the repo links to lead to RailsEventStore org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing to this repository
 
-Contribution Policy for this repository: [https://railseventstore.org/contributing/](http://railseventstore.org/contributing/)
+Contribution Policy for this repository: [https://railseventstore.org/contributing/](https://railseventstore.org/contributing/)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Rails Event Store
 
-[Rails Event Store (RES)](http://railseventstore.org/) is a library for publishing, consuming, storing and retrieving events. It's your best companion for going with an event-driven architecture for your Rails application.
+[Rails Event Store (RES)](https://railseventstore.org/) is a library for publishing, consuming, storing and retrieving events. It's your best companion for going with an event-driven architecture for your Rails application.
 
 You can use it:
 
 <ul>
-<li>as your <a href="http://railseventstore.org/docs/pubsub/">Publish-Subscribe bus</a></li>
+<li>as your <a href="https://railseventstore.org/docs/pubsub/">Publish-Subscribe bus</a></li>
 <li>to decouple core business logic from external concerns in Hexagonal style architectures</li>
-<li>as <a href="http://blog.arkency.com/2016/05/domain-events-over-active-record-callbacks/">an alternative to ActiveRecord callbacks and Observers</a></li>
+<li>as <a href="https://blog.arkency.com/2016/05/domain-events-over-active-record-callbacks/">an alternative to ActiveRecord callbacks and Observers</a></li>
 <li>as a communication layer between loosely coupled components</li>
 <li>to react to published events synchronously or asynchronously</li>
 <li>to extract side-effects (notifications, metrics etc) from your controllers and services into event handlers</li>
@@ -23,12 +23,12 @@ Documentation, tutorials and code samples are available at [https://railseventst
 ## Code status
 
 [![Build Status](https://travis-ci.org/RailsEventStore/rails_event_store.svg?branch=master)](https://travis-ci.org/RailsEventStore/rails_event_store)
-[![Gem Version](https://badge.fury.io/rb/rails_event_store.svg)](http://badge.fury.io/rb/rails_event_store)
+[![Gem Version](https://badge.fury.io/rb/rails_event_store.svg)](https://badge.fury.io/rb/rails_event_store)
 
 We're aiming for 100% mutation coverage in this project. This is why:
 
-* [Why I want to introduce mutation testing to the rails_event_store gem](http://blog.arkency.com/2015/04/why-i-want-to-introduce-mutation-testing-to-the-rails-event-store-gem/)
-* [Mutation testing and continuous integration](http://blog.arkency.com/2015/05/mutation-testing-and-continuous-integration/)
+* [Why I want to introduce mutation testing to the rails_event_store gem](https://blog.arkency.com/2015/04/why-i-want-to-introduce-mutation-testing-to-the-rails-event-store-gem/)
+* [Mutation testing and continuous integration](https://blog.arkency.com/2015/05/mutation-testing-and-continuous-integration/)
 
 Whenever you fix a bug or add a new feature, we require that the coverage doesn't go down.
 
@@ -38,20 +38,20 @@ This single repository hosts several gems. Check the contribution [guide](https:
 
 ## About
 
-<img src="http://arkency.com/images/arkency.png" alt="Arkency" width="60px" align="left" />
+<img src="https://arkency.com/images/arkency.png" alt="Arkency" width="60px" align="left" />
 
-This repository is funded and maintained by [Arkency](https://arkency.com). Check out our other [open-source projects](https://github.com/arkency).
+This repository is funded and maintained by [Arkency](https://arkency.com). Check out our other [open-source projects](https://github.com/arkency) and what else we have at [RES](https://github.com/RailsEventStore).
 
-Consider [hiring us](http://arkency.com/hire-us) and make sure to check out [our blog](http://blog.arkency.com).
+Consider [hiring us](https://arkency.com/hire-us) and make sure to check out [our blog](https://blog.arkency.com).
 
 ### Learn more about DDD & Event Sourcing
 
-Check our [Rails + Domain Driven Design Workshop](http://blog.arkency.com/domain-driven-rails-workshop-london/).
-Why You should attend? Robert has explained this in a [blogpost](http://blog.arkency.com/2016/12/why-would-you-even-want-to-listen-about-ddd/).
+Check our [Rails + Domain Driven Design Workshop](https://blog.arkency.com/domain-driven-rails-workshop-london/).
+Why You should attend? Robert has explained this in a [blogpost](https://blog.arkency.com/2016/12/why-would-you-even-want-to-listen-about-ddd/).
 
 
 Next edition will be held on **16-17th November 2017** in **London, UK**. Workshop will be held in English.
 
 ### Read about Domain Driven Rails
 
-You may also consider buying the [Domain-Driven Rails book](http://blog.arkency.com/domain-driven-rails/).
+You may also consider buying the [Domain-Driven Rails book](https://blog.arkency.com/domain-driven-rails/).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,7 +10,7 @@ We're following [Semantic Versioning](http://semver.org/#semantic-versioning-200
 
 We're making our best to describe and communicate breaking changes if such happen.
 
-All gems developed in RailsEventStore monorepo will be released with the same version number, even if changes affected only a subset of gems. This is close to the versioning policy of Rails. We do this for [convenience](http://blog.arkency.com/why-we-follow-rails-repo-structure-in-rails-event-store/) not only of maintainers but also to help triaging issues related to particular version.
+All gems developed in RailsEventStore monorepo will be released with the same version number, even if changes affected only a subset of gems. This is close to the versioning policy of Rails. We do this for [convenience](https://blog.arkency.com/why-we-follow-rails-repo-structure-in-rails-event-store/) not only of maintainers but also to help triaging issues related to particular version.
 
 ## Communicating changes
 
@@ -41,7 +41,7 @@ When describing changes, list all gems involved gems in the release. Explicitly 
   - loop over gems and build gem packages followed by RubyGems push for each
 
   You'll need to be [gem owner](https://rubygems.org/gems/rails_event_store) of each gem to complete this step.
-3. Bump version number in documentation section of [railseventstore.org](https://railseventstore.org). It's good practice to list changes in [documentation](http://railseventstore.org/docs/changelog/).
+3. Bump version number in documentation section of [railseventstore.org](https://railseventstore.org). It's good practice to list changes in [documentation](https://railseventstore.org/docs/changelog/).
 
 #### Opening work on new release soon after
 

--- a/aggregate_root/README.md
+++ b/aggregate_root/README.md
@@ -13,7 +13,7 @@ gem 'aggregate_root'
 ## Before use
 
 Choose your weapon now! Ekhm I mean choose your event store client.
-To do so add configuration in environment setup. Example using [RailsEventStore](https://github.com/arkency/rails_event_store/):
+To do so add configuration in environment setup. Example using [RailsEventStore](https://github.com/RailsEventStore/rails_event_store/):
 
 ```ruby
 AggregateRoot.configure do |config|
@@ -23,13 +23,13 @@ end
 
 Remember that this is only a default event store used by `AggregateRoot` module when no event store is given in `load` / `store` methods parameters.
 
-To use [RailsEventStore](https://github.com/arkency/rails_event_store/) add to Gemfile:
+To use [RailsEventStore](https://github.com/RailsEventStore/rails_event_store/) add to Gemfile:
 
 ```ruby
 gem 'rails_event_store'
 ```
 
-Then setup [RailsEventStore](https://github.com/arkency/rails_event_store/) as described in
+Then setup [RailsEventStore](https://github.com/RailsEventStore/rails_event_store/) as described in
 the [docs](https://railseventstore.org/docs/install/)
 
 ## Usage
@@ -111,14 +111,14 @@ in the same stream from which order has been loaded.
 
 #### Resources
 
-There're already few blog posts about building an event sourced applications with [rails_event_store](https://github.com/arkency/rails_event_store) and aggregate_root gems:
+There're already few blog posts about building an event sourced applications with [rails_event_store](https://github.com/RailsEventStore/rails_event_store) and aggregate_root gems:
 
-* [Why use Event Sourcing](http://blog.arkency.com/2015/03/why-use-event-sourcing/)
-* [The Event Store for Rails developers](http://blog.arkency.com/2015/04/the-event-store-for-rails-developers/)
-* [Fast introduction to Event Sourcing for Ruby programmers](http://blog.arkency.com/2015/03/fast-introduction-to-event-sourcing-for-ruby-programmers/)
-* [Building an Event Sourced application using rails_event_store](http://blog.arkency.com/2015/05/building-an-event-sourced-application-using-rails-event-store/)
-* [Using domain events as success/failure messages](http://blog.arkency.com/2015/05/using-domain-events-as-success-slash-failure-messages/)
-* [Subscribing for events in rails_event_store](http://blog.arkency.com/2015/06/subscribing-for-events-in-rails-event-store/)
-* [Testing an Event Sourced application](http://blog.arkency.com/2015/07/testing-event-sourced-application/)
-* [Testing Event Sourced application - the read side](http://blog.arkency.com/2015/09/testing-event-sourced-application-the-read-side/)
-* [One event to rule them all](http://blog.arkency.com/2016/01/one-event-to-rule-them-all/)
+* [Why use Event Sourcing](https://blog.arkency.com/2015/03/why-use-event-sourcing/)
+* [The Event Store for Rails developers](https://blog.arkency.com/2015/04/the-event-store-for-rails-developers/)
+* [Fast introduction to Event Sourcing for Ruby programmers](https://blog.arkency.com/2015/03/fast-introduction-to-event-sourcing-for-ruby-programmers/)
+* [Building an Event Sourced application using rails_event_store](https://blog.arkency.com/2015/05/building-an-event-sourced-application-using-rails-event-store/)
+* [Using domain events as success/failure messages](https://blog.arkency.com/2015/05/using-domain-events-as-success-slash-failure-messages/)
+* [Subscribing for events in rails_event_store](https://blog.arkency.com/2015/06/subscribing-for-events-in-rails-event-store/)
+* [Testing an Event Sourced application](https://blog.arkency.com/2015/07/testing-event-sourced-application/)
+* [Testing Event Sourced application - the read side](https://blog.arkency.com/2015/09/testing-event-sourced-application-the-read-side/)
+* [One event to rule them all](https://blog.arkency.com/2016/01/one-event-to-rule-them-all/)

--- a/bounded_context/spec/dummy_4_2_10/config/locales/en.yml
+++ b/bounded_context/spec/dummy_4_2_10/config/locales/en.yml
@@ -17,7 +17,7 @@
 # This would use the information in config/locales/es.yml.
 #
 # To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
+# available at https://guides.rubyonrails.org/i18n.html.
 
 en:
   hello: "Hello world"

--- a/bounded_context/spec/dummy_5_0_6/config/locales/en.yml
+++ b/bounded_context/spec/dummy_5_0_6/config/locales/en.yml
@@ -17,7 +17,7 @@
 # This would use the information in config/locales/es.yml.
 #
 # To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
+# available at https://guides.rubyonrails.org/i18n.html.
 
 en:
   hello: "Hello world"

--- a/bounded_context/spec/dummy_5_0_6/config/routes.rb
+++ b/bounded_context/spec/dummy_5_0_6/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/bounded_context/spec/dummy_5_1_4/config/locales/en.yml
+++ b/bounded_context/spec/dummy_5_1_4/config/locales/en.yml
@@ -27,7 +27,7 @@
 #   'true': 'foo'
 #
 # To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
+# available at https://guides.rubyonrails.org/i18n.html.
 
 en:
   hello: "Hello world"

--- a/bounded_context/spec/dummy_5_1_4/config/routes.rb
+++ b/bounded_context/spec/dummy_5_1_4/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/rails_event_store-rspec/README.md
+++ b/rails_event_store-rspec/README.md
@@ -172,12 +172,12 @@ expect(aggregate_root).to have_applied(event(OrderSubmitted)).once
 ## Code status
 
 [![Build Status](https://travis-ci.org/RailsEventStore/rails_event_store-rspec.svg?branch=master)](https://travis-ci.org/RailsEventStore/rails_event_store-rspec)
-[![Gem Version](https://badge.fury.io/rb/rails_event_store-rspec.svg)](http://badge.fury.io/rb/rails_event_store-rspec)
+[![Gem Version](https://badge.fury.io/rb/rails_event_store-rspec.svg)](https://badge.fury.io/rb/rails_event_store-rspec)
 
 We're aiming for 100% mutation coverage in this project. This is why:
 
-* [Why I want to introduce mutation testing to the rails_event_store gem](http://blog.arkency.com/2015/04/why-i-want-to-introduce-mutation-testing-to-the-rails-event-store-gem/)
-* [Mutation testing and continuous integration](http://blog.arkency.com/2015/05/mutation-testing-and-continuous-integration/)
+* [Why I want to introduce mutation testing to the rails_event_store gem](https://blog.arkency.com/2015/04/why-i-want-to-introduce-mutation-testing-to-the-rails-event-store-gem/)
+* [Mutation testing and continuous integration](https://blog.arkency.com/2015/05/mutation-testing-and-continuous-integration/)
 
 Whenever you fix a bug or add a new feature, we require that the coverage doesn't go down.
 

--- a/rails_event_store/CHANGELOG.md
+++ b/rails_event_store/CHANGELOG.md
@@ -24,7 +24,7 @@ Further changes can be tracked at [releases page](https://github.com/RailsEventS
 
 * Change: Allows to set the event repository used. #61
           Allow to avoid ActiveRecord dependency when not using rails_event_store_active_record's
-          event repository. See documentation for mode details http://railseventstore.arkency.com/docs/repository.html
+          event repository. See documentation for mode details https://railseventstore.arkency.com/docs/repository.html
 
 ### 0.14.0 (28.10.2016)
 
@@ -94,7 +94,7 @@ Further changes can be tracked at [releases page](https://github.com/RailsEventS
 
 ### 0.6.0 (11.04.2016)
 
-* Change: EventRepository moved to separate gem [rails_event_store_active_record](http://github.com/arkency/rails_event_store_active_record)
+* Change: EventRepository moved to separate gem [rails_event_store_active_record](https://github.com/RailsEventStore/rails_event_store_active_record)
 * Change: rails_event_store_active_record updated to version 0.5.1 - allows to use custom event class
 
 ### 0.5.0 (21.03.2016)

--- a/rails_event_store/rails_event_store.gemspec
+++ b/rails_event_store/rails_event_store.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Event Store in Ruby}
   spec.description   = %q{Implementation of Event Store in Ruby}
-  spec.homepage      = 'https://github.com/arkency/rails_event_store'
+  spec.homepage      = 'https://github.com/RailsEventStore/rails_event_store'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = 'exe'

--- a/rails_event_store_active_record/README.md
+++ b/rails_event_store_active_record/README.md
@@ -1,5 +1,5 @@
 # RailsEventStoreActiveRecord
 
- An Active Record based implementation of events repository for [Rails Event Store](http://github.com/RailsEventStore/rails_event_store/rails_event_store).
+ An Active Record based implementation of events repository for [Rails Event Store](https://github.com/RailsEventStore/rails_event_store/rails_event_store).
 
 This is the default repository used in `rails_event_store` gem.

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/generators/templates/v1_v2_migration_template.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/generators/templates/v1_v2_migration_template.rb
@@ -83,7 +83,7 @@ class MigrateResSchemaV1ToV2 < ActiveRecord::Migration<%= migration_version %>
   end
 
   def preserve_positions?(stream_name)
-    # http://railseventstore.org/docs/expected_version/
+    # https://railseventstore.org/docs/expected_version/
     #
     # return true if you use given stream for event sourcing
     #   (especially with AggregateRoot gem)

--- a/rails_event_store_active_record/rails_event_store_active_record.gemspec
+++ b/rails_event_store_active_record/rails_event_store_active_record.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Active Record events repository for Rails Event Store}
   spec.description   = %q{Implementation of events repository based on Rails Active Record for Rails Event Store'}
-  spec.homepage      = 'https://github.com/arkency/rails_event_store_active_record'
+  spec.homepage      = 'https://github.com/RailsEventStore/rails_event_store_active_record'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = 'exe'

--- a/ruby_event_store/ruby_event_store.gemspec
+++ b/ruby_event_store/ruby_event_store.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Event Store in Ruby}
   spec.description   = %q{Implementation of Event Store in Ruby}
-  spec.homepage      = 'https://github.com/arkency/ruby_event_store'
+  spec.homepage      = 'https://github.com/RailsEventStore/ruby_event_store'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = 'exe'


### PR DESCRIPTION
- another change: in 2017 we should avoid http (without s) everywhere where it's possible