### PR TITLE
Add RubyEventStore#when_any_of method

### DIFF
--- a/ruby_event_store/lib/ruby_event_store/projection.rb
+++ b/ruby_event_store/lib/ruby_event_store/projection.rb
@@ -25,8 +25,11 @@ module RubyEventStore
       self
     end
 
-    def when(event, handler)
-      @handlers[event] = handler
+    def when(events, handler)
+      Array(events).each do |event|
+        @handlers[event] = handler
+      end
+
       self
     end
 


### PR DESCRIPTION
There are the cases when it is needed to use one handler for many events
within RubyEventStore::Projection.
Passing array of events to #when method we can rewrite this:
```
  Projection.
  from_stream(stream_name).
  init( -> { { total: 0 } }).
  when(MoneyDeposited, ->(state, event) { state[:total] += event.data[:amount] }).
  when(MoneyWithdrawn, ->(state, event) { state[:total] += event.data[:amount] }).
  run(event_store)
```
to this:
```
  Projection.
  from_stream(stream_name).
  init( -> { { total: 0 } }).
  when([MoneyDeposited, MoneyWithdrawn], ->(state, event) { state[:total] += event.data[:amount] }).
  run(event_store)
```