### PR TITLE
support for declarative event handlers methods for aggregate root

### DIFF
--- a/aggregate_root/lib/aggregate_root.rb
+++ b/aggregate_root/lib/aggregate_root.rb
@@ -8,9 +8,7 @@ module AggregateRoot
     def on(*event_klasses, apply_strategy:  DefaultApplyStrategy.new, &block)
       event_klasses.each do |event_klass|
         handler_name = apply_strategy.handler_name_by_class(event_klass)
-        define_method handler_name do |event|
-          instance_exec event, &block
-        end
+        define_method handler_name, &block
         private handler_name
       end
     end

--- a/aggregate_root/lib/aggregate_root.rb
+++ b/aggregate_root/lib/aggregate_root.rb
@@ -4,6 +4,22 @@ require 'aggregate_root/configuration'
 require 'aggregate_root/default_apply_strategy'
 
 module AggregateRoot
+  module ClassMethods
+    def on(*event_klasses, apply_strategy:  DefaultApplyStrategy.new, &block)
+      event_klasses.each do |event_klass|
+        handler_name = apply_strategy.handler_name_by_class(event_klass)
+        define_method handler_name do |event|
+          instance_exec event, &block
+        end
+        private handler_name
+      end
+    end
+  end
+
+  def self.included(host_class)
+    host_class.extend(ClassMethods)
+  end
+
   def apply(*events)
     events.each do |event|
       apply_strategy.(self, event)

--- a/aggregate_root/lib/aggregate_root/default_apply_strategy.rb
+++ b/aggregate_root/lib/aggregate_root/default_apply_strategy.rb
@@ -15,11 +15,15 @@ module AggregateRoot
       end
     end
 
-    private
-    attr_reader :strict
+    def handler_name_by_class(event_class)
+      "apply_#{event_class.name.demodulize.underscore}"
+    end
 
     def handler_name(event)
-      "apply_#{event.class.name.demodulize.underscore}"
+      handler_name_by_class(event.class)
     end
+
+    private
+    attr_reader :strict
   end
 end

--- a/aggregate_root/spec/aggregate_root_spec.rb
+++ b/aggregate_root/spec/aggregate_root_spec.rb
@@ -189,4 +189,28 @@ describe AggregateRoot do
     expect(order.unpublished_events.respond_to?(:pop)).to eq(false)
     expect(order.unpublished_events.respond_to?(:unshift)).to eq(false)
   end
+
+  describe ".on" do
+    it "generates private apply handler method" do
+      check = double
+      expect(check).to receive(:call).with(instance_of(Orders::Events::SpanishInquisition))
+
+      Order.on(Orders::Events::SpanishInquisition) do |event|
+        check.call(event)
+        @status = :spanish_inqusition
+      end
+
+      order = Order.new
+      order.apply(Orders::Events::SpanishInquisition.new)
+      expect(order.status).to          eq :spanish_inqusition
+      expect(order.private_methods).to include :apply_spanish_inquisition
+    end
+  end
+
+  describe '.include' do
+    it 'extend class with AggregateRoot::ClassMethods' do
+      expect(Order).to receive(:extend).with(AggregateRoot::ClassMethods)
+      Order.include(AggregateRoot)
+    end
+  end
 end

--- a/aggregate_root/spec/spec_helper.rb
+++ b/aggregate_root/spec/spec_helper.rb
@@ -20,6 +20,7 @@ end
 
 class Order
   include AggregateRoot
+  include Orders::Events
 
   def initialize
     @status = :draft
@@ -28,11 +29,11 @@ class Order
   attr_accessor :status
   private
 
-  def apply_order_created(event)
+  on OrderCreated do |_event|
     @status = :created
   end
 
-  def apply_order_expired(event)
+  def apply_order_expired(_event)
     @status = :expired
   end
 end


### PR DESCRIPTION
I would like to introduce second way of declaring event handler methods on aggregate:
```ruby
  on OrderCreated do |_event|
    @status = :created
  end
```
which will generate standard private handler method:
```ruby
  def apply_order_created(_event)
    @status = :created
  end
```

Full example of usage (include of Events modules, and declaration):
```ruby
class Order
  include AggregateRoot
  include Orders::Events

  def initialize
    @status = :draft
  end

  attr_accessor :status
  private

  on OrderCreated do |_event|
    @status = :created
  end

  def apply_order_expired(_event)
    @status = :expired
  end
end
```

usage of proposed declarative `on ` will be optional and will coexist with standard convention (after all its generating exactly same method like required by standard convention)

I see few pros of declarative approach:
-   I can see direct correlation between callback and event name (with standard approach, conversion is hidden, and method looks like not used. 
- I case of missing Event class I will see error immediately without running specific use case specs
- I can easily navigate to related event by using standard editors/IDE features
- I can easily find usages of Event by using standard editors/IDE features, which will improve the flow in case of refactoring
