### PR TITLE
link_to_stream

### DIFF
--- a/rails_event_store_active_record/Makefile
+++ b/rails_event_store_active_record/Makefile
@@ -15,7 +15,7 @@ mutate: test  ## Run mutation tests
 	@bundle exec mutant --include lib --require ruby_event_store --use rspec "RailsEventStoreActiveRecord*" \
 	  --ignore-subject "RailsEventStoreActiveRecord::EventRepository#normalize_to_array" \
 	  --ignore-subject "RailsEventStoreActiveRecord::LegacyEventRepository#normalize_to_array" \
-	  --ignore-subject "RailsEventStoreActiveRecord::EventRepository#detect_pkey_index_violated"
+	  --ignore-subject "RailsEventStoreActiveRecord::EventRepository#detect_index_violated"
 
 build:
 	@gem build -V rails_event_store_active_record.gemspec

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
@@ -165,6 +165,7 @@ module RailsEventStoreActiveRecord
       e.message.include?("event_store_events_pkey") ||  # Postgresql
       e.message.include?("event_store_events.id")   ||  # Sqlite3
 
+      e.message.include?("Key (stream, event_id)")  ||  # Postgresql
       e.message.include?("event_store_events_in_streams.stream, event_store_events_in_streams.event_id")  ## Sqlite3
     end
 

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
@@ -161,12 +161,14 @@ module RailsEventStoreActiveRecord
     end
 
     def detect_pkey_index_violated(e)
-      e.message.include?("for key 'PRIMARY'")       ||  # MySQL
-      e.message.include?("event_store_events_pkey") ||  # Postgresql
-      e.message.include?("event_store_events.id")   ||  # Sqlite3
+      m = e.message
+      m.include?("for key 'PRIMARY'")       ||  # MySQL
+      m.include?("event_store_events_pkey") ||  # Postgresql
+      m.include?("event_store_events.id")   ||  # Sqlite3
 
-      e.message.include?("Key (stream, event_id)")  ||  # Postgresql
-      e.message.include?("event_store_events_in_streams.stream, event_store_events_in_streams.event_id")  ## Sqlite3
+      m.include?("for key 'index_event_store_events_in_streams_on_stream_and_event_id'")        || # Mysql
+      m.include?("Key (stream, event_id)")                                                      || # Postgresql
+      m.include?("event_store_events_in_streams.stream, event_store_events_in_streams.event_id")   # Sqlite3
     end
 
     def build_event_record(event)

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
@@ -148,7 +148,7 @@ module RailsEventStoreActiveRecord
     end
 
     def raise_error(e)
-      if detect_pkey_index_violated(e)
+      if detect_index_violated(e)
         raise RubyEventStore::EventDuplicatedInStream
       end
       raise RubyEventStore::WrongExpectedEventVersion
@@ -174,15 +174,23 @@ module RailsEventStoreActiveRecord
       end
     end
 
-    def detect_pkey_index_violated(e)
-      m = e.message
-      m.include?("for key 'PRIMARY'")       ||  # MySQL
-      m.include?("event_store_events_pkey") ||  # Postgresql
-      m.include?("event_store_events.id")   ||  # Sqlite3
+    MYSQL_PKEY_ERROR    = "for key 'PRIMARY'"
+    POSTGRES_PKEY_ERROR = "event_store_events_pkey"
+    SQLITE3_PKEY_ERROR  = "event_store_events.id"
 
-      m.include?("for key 'index_event_store_events_in_streams_on_stream_and_event_id'")        || # Mysql
-      m.include?("Key (stream, event_id)")                                                      || # Postgresql
-      m.include?("event_store_events_in_streams.stream, event_store_events_in_streams.event_id")   # Sqlite3
+    MYSQL_INDEX_ERROR    = "for key 'index_event_store_events_in_streams_on_stream_and_event_id'"
+    POSTGRES_INDEX_ERROR = "Key (stream, event_id)"
+    SQLITE3_INDEX_ERROR  = "event_store_events_in_streams.stream, event_store_events_in_streams.event_id"
+
+    def detect_index_violated(e)
+      m = e.message
+      m.include?(MYSQL_PKEY_ERROR)     ||
+      m.include?(POSTGRES_PKEY_ERROR)  ||
+      m.include?(SQLITE3_PKEY_ERROR)   ||
+
+      m.include?(MYSQL_INDEX_ERROR)    ||
+      m.include?(POSTGRES_INDEX_ERROR) ||
+      m.include?(SQLITE3_INDEX_ERROR)
     end
 
     def build_event_record(event)

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
@@ -163,7 +163,9 @@ module RailsEventStoreActiveRecord
     def detect_pkey_index_violated(e)
       e.message.include?("for key 'PRIMARY'")       ||  # MySQL
       e.message.include?("event_store_events_pkey") ||  # Postgresql
-      e.message.include?("event_store_events.id")       # Sqlite3
+      e.message.include?("event_store_events.id")   ||  # Sqlite3
+
+      e.message.include?("event_store_events_in_streams.stream, event_store_events_in_streams.event_id")  ## Sqlite3
     end
 
     def build_event_record(event)

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
@@ -19,7 +19,7 @@ module RailsEventStoreActiveRecord
     end
 
     def link_to_stream(event_ids, stream_name, expected_version)
-      add_to_stream(event_ids, stream_name, expected_version, false) do |event_id|
+      add_to_stream(event_ids, stream_name, expected_version, nil) do |event_id|
         event_id
       end
     end

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
@@ -19,6 +19,9 @@ module RailsEventStoreActiveRecord
     end
 
     def link_to_stream(event_ids, stream_name, expected_version)
+      (normalize_to_array(event_ids) - Event.where(id: event_ids).pluck(:id)).each do |id|
+        raise RubyEventStore::EventNotFound.new(id)
+      end
       add_to_stream(event_ids, stream_name, expected_version, nil) do |event_id|
         event_id
       end
@@ -101,7 +104,7 @@ module RailsEventStoreActiveRecord
       )
       mapper.serialized_record_to_event(serialized_record)
     rescue ActiveRecord::RecordNotFound
-      raise RubyEventStore::EventNotFound
+      raise RubyEventStore::EventNotFound.new(event_id)
     end
 
     def get_all_streams

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/legacy_event_repository.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/legacy_event_repository.rb
@@ -117,7 +117,7 @@ instead:
     end
 
     def read_event(event_id)
-      build_event_entity(LegacyEvent.find_by(event_id: event_id)) or raise RubyEventStore::EventNotFound
+      build_event_entity(LegacyEvent.find_by(event_id: event_id)) or raise RubyEventStore::EventNotFound.new(event_id)
     end
 
     def get_all_streams

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/legacy_event_repository.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/legacy_event_repository.rb
@@ -46,6 +46,10 @@ instead:
       raise RubyEventStore::EventDuplicatedInStream
     end
 
+    def link_to_stream(_event_ids, _stream_name, _expected_version)
+      raise RubyEventStore::NotSupported
+    end
+
     def delete_stream(stream_name)
       LegacyEvent.where({stream: stream_name}).update_all(stream: RubyEventStore::GLOBAL_STREAM)
     end

--- a/rails_event_store_active_record/spec/event_repository_spec.rb
+++ b/rails_event_store_active_record/spec/event_repository_spec.rb
@@ -20,6 +20,7 @@ module RailsEventStoreActiveRecord
     let(:test_race_conditions_auto)  { !ENV['DATABASE_URL'].include?("sqlite") }
     let(:test_race_conditions_any)   { !ENV['DATABASE_URL'].include?("sqlite") }
     let(:test_expected_version_auto) { true }
+    let(:test_link_events_to_stream) { true }
 
     it_behaves_like :event_repository, EventRepository
 

--- a/rails_event_store_active_record/spec/event_repository_spec.rb
+++ b/rails_event_store_active_record/spec/event_repository_spec.rb
@@ -160,6 +160,15 @@ module RailsEventStoreActiveRecord
       expect(repository.read_all_streams_forward(:head, 2)).to eq([event])
     end
 
+    specify "limited query when looking for unexisting events during linking" do
+      repository = EventRepository.new
+      expect_query(/SELECT.*event_store_events.*id.*FROM.*event_store_events.*WHERE.*event_store_events.*id.*=.*/) do
+        expect do
+          repository.link_to_stream('72922e65-1b32-4e97-8023-03ae81dd3a27', "flow", -1)
+        end.to raise_error(RubyEventStore::EventNotFound)
+      end
+    end
+
     def cleanup_concurrency_test
       ActiveRecord::Base.connection_pool.disconnect!
     end

--- a/rails_event_store_active_record/spec/legacy_event_repository_spec.rb
+++ b/rails_event_store_active_record/spec/legacy_event_repository_spec.rb
@@ -25,6 +25,7 @@ module RailsEventStoreActiveRecord
 
     let(:test_race_conditions_any)   { !ENV['DATABASE_URL'].include?("sqlite") }
     let(:test_expected_version_auto) { false }
+    let(:test_link_events_to_stream) { false }
 
     it_behaves_like :event_repository, LegacyEventRepository
 
@@ -74,6 +75,13 @@ module RailsEventStoreActiveRecord
         repository.append_to_stream(TestDomainEvent.new(event_id: SecureRandom.uuid), 'stream_1', :none)
         repository.append_to_stream(TestDomainEvent.new(event_id: SecureRandom.uuid), 'stream_2', :none)
       }.to_not raise_error
+    end
+
+    specify do
+      repository = LegacyEventRepository.new
+      expect{
+        repository.link_to_stream(SecureRandom.uuid, 'stream_2', :none)
+      }.to raise_error(RubyEventStore::NotSupported)
     end
 
     private

--- a/ruby_event_store/lib/ruby_event_store/client.rb
+++ b/ruby_event_store/lib/ruby_event_store/client.rb
@@ -119,7 +119,7 @@ module RubyEventStore
         else
           start = start.to_s
           raise InvalidPageStart if start.empty?
-          raise EventNotFound unless repository.has_event?(start)
+          raise EventNotFound.new(start) unless repository.has_event?(start)
         end
         raise InvalidPageSize unless count > 0
         @start = start

--- a/ruby_event_store/lib/ruby_event_store/client.rb
+++ b/ruby_event_store/lib/ruby_event_store/client.rb
@@ -31,6 +31,11 @@ module RubyEventStore
       :ok
     end
 
+    def link_to_stream(event_ids, stream_name:, expected_version: :any)
+      repository.link_to_stream(event_ids, stream_name, expected_version)
+      self
+    end
+
     def delete_stream(stream_name)
       raise IncorrectStreamData if stream_name.nil? || stream_name.empty?
       repository.delete_stream(stream_name)

--- a/ruby_event_store/lib/ruby_event_store/errors.rb
+++ b/ruby_event_store/lib/ruby_event_store/errors.rb
@@ -7,6 +7,7 @@ module RubyEventStore
   InvalidPageStart           = Class.new(ArgumentError)
   InvalidPageSize            = Class.new(ArgumentError)
   EventDuplicatedInStream    = Class.new(StandardError)
+  NotSupported               = Class.new(StandardError)
 
   class InvalidHandler < StandardError
     def initialize(object)

--- a/ruby_event_store/lib/ruby_event_store/errors.rb
+++ b/ruby_event_store/lib/ruby_event_store/errors.rb
@@ -2,12 +2,19 @@ module RubyEventStore
   WrongExpectedEventVersion  = Class.new(StandardError)
   InvalidExpectedVersion     = Class.new(StandardError)
   IncorrectStreamData        = Class.new(StandardError)
-  EventNotFound              = Class.new(StandardError)
   SubscriberNotExist         = Class.new(StandardError)
   InvalidPageStart           = Class.new(ArgumentError)
   InvalidPageSize            = Class.new(ArgumentError)
   EventDuplicatedInStream    = Class.new(StandardError)
   NotSupported               = Class.new(StandardError)
+
+  class EventNotFound < StandardError
+    attr_reader :event_id
+    def initialize(event_id)
+      super("Event not found: #{event_id}")
+      @event_id = event_id
+    end
+  end
 
   class InvalidHandler < StandardError
     def initialize(object)

--- a/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
+++ b/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
@@ -66,7 +66,7 @@ module RubyEventStore
     end
 
     def read_event(event_id)
-      all.find { |e| event_id.equal?(e.event_id) } or raise EventNotFound
+      all.find { |e| event_id.eql?(e.event_id) } or raise EventNotFound
     end
 
     def get_all_streams

--- a/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
+++ b/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
@@ -97,8 +97,9 @@ module RubyEventStore
     def append(events, expected_version, stream, stream_name)
       raise WrongExpectedEventVersion unless (stream.size - 1).equal?(expected_version)
       events.each do |event|
-        all.push(event)
         raise EventDuplicatedInStream if stream.any?{|ev| ev.event_id.eql?(event.event_id) }
+        raise EventDuplicatedInStream if all.any?{|ev| ev.event_id.eql?(event.event_id) }
+        all.push(event)
         stream.push(event)
       end
       streams[stream_name] = stream

--- a/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
+++ b/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
@@ -57,7 +57,7 @@ module RubyEventStore
     end
 
     def read_event(event_id)
-      all.find { |e| event_id.eql?(e.event_id) } or raise EventNotFound
+      all.find { |e| event_id.eql?(e.event_id) } or raise EventNotFound.new(event_id)
     end
 
     def get_all_streams

--- a/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
+++ b/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
@@ -10,21 +10,12 @@ module RubyEventStore
     end
 
     def append_to_stream(events, stream_name, expected_version)
-      raise InvalidExpectedVersion if !expected_version.equal?(:any) && stream_name.eql?(GLOBAL_STREAM)
-      events = normalize_to_array(events)
-      stream = read_stream_events_forward(stream_name)
-      expected_version = case expected_version
-        when :none
-          -1
-        when :auto, :any
-          stream.size - 1
-        when Integer
-          expected_version
-        else
-          raise InvalidExpectedVersion
-      end
-      append_with_synchronize(events, expected_version, stream, stream_name)
-      self
+      add_to_stream(events, expected_version, stream_name, true)
+    end
+
+    def link_to_stream(event_ids, stream_name, expected_version)
+      events = normalize_to_array(event_ids).map{|eid| read_event(eid) }
+      add_to_stream(events, expected_version, stream_name, nil)
     end
 
     def delete_stream(stream_name)
@@ -80,7 +71,24 @@ module RubyEventStore
       return *events
     end
 
-    def append_with_synchronize(events, expected_version, stream, stream_name)
+    def add_to_stream(events, expected_version, stream_name, include_global)
+      raise InvalidExpectedVersion if !expected_version.equal?(:any) && stream_name.eql?(GLOBAL_STREAM)
+      events = normalize_to_array(events)
+      stream = read_stream_events_forward(stream_name)
+      expected_version = case expected_version
+        when :none
+          -1
+        when :auto, :any
+          stream.size - 1
+        when Integer
+          expected_version
+        else
+         raise InvalidExpectedVersion
+      end
+      append_with_synchronize(events, expected_version, stream, stream_name, include_global)
+    end
+
+    def append_with_synchronize(events, expected_version, stream, stream_name, include_global)
       # expected_version :auto assumes external lock is used
       # which makes reading stream before writing safe.
       #
@@ -90,19 +98,22 @@ module RubyEventStore
       # not for the whole read+write algorithm.
       Thread.pass
       @mutex.synchronize do
-        append(events, expected_version, stream, stream_name)
+        append(events, expected_version, stream, stream_name, include_global)
       end
     end
 
-    def append(events, expected_version, stream, stream_name)
+    def append(events, expected_version, stream, stream_name, include_global)
       raise WrongExpectedEventVersion unless (stream.size - 1).equal?(expected_version)
       events.each do |event|
         raise EventDuplicatedInStream if stream.any?{|ev| ev.event_id.eql?(event.event_id) }
-        raise EventDuplicatedInStream if all.any?{|ev| ev.event_id.eql?(event.event_id) }
-        all.push(event)
+        if include_global
+          raise EventDuplicatedInStream if all.any?{|ev| ev.event_id.eql?(event.event_id) }
+          all.push(event)
+        end
         stream.push(event)
       end
       streams[stream_name] = stream
+      self
     end
 
     def read_batch(source, start_event_id, count)

--- a/ruby_event_store/lib/ruby_event_store/mappers/default.rb
+++ b/ruby_event_store/lib/ruby_event_store/mappers/default.rb
@@ -18,6 +18,10 @@ module RubyEventStore
         )
       end
 
+      def fetch
+
+      end
+
       def serialized_record_to_event(record)
         event_type = events_class_remapping.fetch(record.event_type) { record.event_type }
         ActiveSupport::Inflector.constantize(event_type).new(

--- a/ruby_event_store/lib/ruby_event_store/mappers/default.rb
+++ b/ruby_event_store/lib/ruby_event_store/mappers/default.rb
@@ -18,10 +18,6 @@ module RubyEventStore
         )
       end
 
-      def fetch
-
-      end
-
       def serialized_record_to_event(record)
         event_type = events_class_remapping.fetch(record.event_type) { record.event_type }
         ActiveSupport::Inflector.constantize(event_type).new(

--- a/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
@@ -131,7 +131,7 @@ RSpec.shared_examples :event_repository do |repository_class|
     repository.append_to_stream([
       event2 = TestDomainEvent.new(event_id: SecureRandom.uuid),
       event3 = TestDomainEvent.new(event_id: SecureRandom.uuid),
-    ], 'other', 0)
+    ], 'other', -1)
     expect do
       repository.link_to_stream([
         event2.event_id,

--- a/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
@@ -788,6 +788,21 @@ RSpec.shared_examples :event_repository do |repository_class|
     end.to raise_error(RubyEventStore::EventDuplicatedInStream)
   end
 
+  it 'does not allow same event twice' do
+    repository.append_to_stream(
+      TestDomainEvent.new(event_id: "a1b49edb-7636-416f-874a-88f94b859bef"),
+      'stream',
+      -1
+    )
+    expect do
+      repository.append_to_stream(
+        TestDomainEvent.new(event_id: "a1b49edb-7636-416f-874a-88f94b859bef"),
+        'another',
+        -1
+      )
+    end.to raise_error(RubyEventStore::EventDuplicatedInStream)
+  end
+
   it 'does not allow linking same event twice in a stream' do
     skip unless test_link_events_to_stream
     repository.append_to_stream([

--- a/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
@@ -904,6 +904,24 @@ RSpec.shared_examples :event_repository do |repository_class|
   end
 
   specify 'reading non-existent event' do
-    expect{repository.read_event('72922e65-1b32-4e97-8023-03ae81dd3a27')}.to raise_error(RubyEventStore::EventNotFound)
+    expect do
+      repository.read_event('72922e65-1b32-4e97-8023-03ae81dd3a27')
+    end.to raise_error do |err|
+      expect(err).to be_a(RubyEventStore::EventNotFound)
+      expect(err.event_id).to eq('72922e65-1b32-4e97-8023-03ae81dd3a27')
+      expect(err.message).to eq('Event not found: 72922e65-1b32-4e97-8023-03ae81dd3a27')
+    end
   end
+
+  specify 'linking non-existent event' do
+    skip unless test_link_events_to_stream
+    expect do
+      repository.link_to_stream('72922e65-1b32-4e97-8023-03ae81dd3a27', "flow", -1)
+    end.to raise_error do |err|
+      expect(err).to be_a(RubyEventStore::EventNotFound)
+      expect(err.event_id).to eq('72922e65-1b32-4e97-8023-03ae81dd3a27')
+      expect(err.message).to eq('Event not found: 72922e65-1b32-4e97-8023-03ae81dd3a27')
+    end
+  end
+
 end

--- a/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
@@ -895,11 +895,12 @@ RSpec.shared_examples :event_repository do |repository_class|
   end
 
   specify 'reading particular event' do
-    test_event = TestDomainEvent.new
-    repository.append_to_stream(TestDomainEvent.new, "test", -1)
-    repository.append_to_stream(test_event, "test", 0)
+    test_event = TestDomainEvent.new(event_id: "941cd8f5-b3f9-47af-b4e4-07f8cea37467")
+    repository.
+      append_to_stream(TestDomainEvent.new, "test", -1).
+      append_to_stream(test_event, "test", 0)
 
-    expect(repository.read_event(test_event.event_id)).to eq(test_event)
+    expect(repository.read_event("941cd8f5-b3f9-47af-b4e4-07f8cea37467")).to eq(test_event)
   end
 
   specify 'reading non-existent event' do

--- a/ruby_event_store/spec/actions/read_events_batch_spec.rb
+++ b/ruby_event_store/spec/actions/read_events_batch_spec.rb
@@ -18,8 +18,8 @@ module RubyEventStore
 
     specify 'raise exception if event_id does not exist' do
       client = RubyEventStore::Client.new(repository: InMemoryRepository.new)
-      expect { client.read_events_forward(stream_name, start: 0) }.to raise_error(EventNotFound)
-      expect { client.read_events_backward(stream_name, start: 0) }.to raise_error(EventNotFound)
+      expect { client.read_events_forward(stream_name, start: 0) }.to raise_error(EventNotFound, /Event not found: 0/)
+      expect { client.read_events_backward(stream_name, start: 0) }.to raise_error(EventNotFound, /0/)
     end
 
     specify 'raise exception if event_id is not given or invalid' do

--- a/ruby_event_store/spec/client_spec.rb
+++ b/ruby_event_store/spec/client_spec.rb
@@ -199,6 +199,7 @@ module RubyEventStore
       client = RubyEventStore::Client.new(repository: InMemoryRepository.new)
       first_event   = TestEvent.new
       second_event  = TestEvent.new
+      client.subscribe_to_all_events(subscriber = Subscribers::ValidHandler.new)
       client.append_to_stream([first_event, second_event], stream_name: 'stream')
       client.link_to_stream(
         [first_event.event_id, second_event.event_id],
@@ -210,6 +211,7 @@ module RubyEventStore
       )
       expect(client.read_stream_events_forward('flow')).to eq([first_event, second_event])
       expect(client.read_stream_events_forward('cars')).to eq([first_event])
+      expect(subscriber.handled_events).to be_empty
     end
 
   end

--- a/ruby_event_store/spec/in_memory_repository_spec.rb
+++ b/ruby_event_store/spec/in_memory_repository_spec.rb
@@ -8,6 +8,7 @@ module RubyEventStore
     let(:test_race_conditions_any)   { false }
     let(:test_race_conditions_auto)  { true }
     let(:test_expected_version_auto) { true }
+    let(:test_link_events_to_stream) { false }
 
     it_behaves_like :event_repository, InMemoryRepository
 

--- a/ruby_event_store/spec/in_memory_repository_spec.rb
+++ b/ruby_event_store/spec/in_memory_repository_spec.rb
@@ -12,6 +12,28 @@ module RubyEventStore
 
     it_behaves_like :event_repository, InMemoryRepository
 
+    it 'does not allow same event twice in a stream - checks stream events before checking all events' do
+      repository = InMemoryRepository.new
+      repository.append_to_stream(
+        TestDomainEvent.new(event_id: eid = "fbce0b3d-40e3-4d1d-90a1-901f1ded5a4a"),
+        'other',
+        -1
+      )
+      repository.append_to_stream(
+        TestDomainEvent.new(event_id: "a1b49edb-7636-416f-874a-88f94b859bef"),
+        'stream',
+        -1
+      )
+      expect(eid).not_to receive(:eql?)
+      expect do
+        repository.append_to_stream(
+          TestDomainEvent.new(event_id: "a1b49edb-7636-416f-874a-88f94b859bef"),
+          'stream',
+          0
+        )
+      end.to raise_error(RubyEventStore::EventDuplicatedInStream)
+    end
+
     def verify_conncurency_assumptions
     end
 

--- a/ruby_event_store/spec/in_memory_repository_spec.rb
+++ b/ruby_event_store/spec/in_memory_repository_spec.rb
@@ -8,7 +8,7 @@ module RubyEventStore
     let(:test_race_conditions_any)   { false }
     let(:test_race_conditions_auto)  { true }
     let(:test_expected_version_auto) { true }
-    let(:test_link_events_to_stream) { false }
+    let(:test_link_events_to_stream) { true }
 
     it_behaves_like :event_repository, InMemoryRepository
 


### PR DESCRIPTION
Implements API for linking events to streams #134 

* does not trigger handlers
* verifies uniqueness of linked event in a stream
* verifies existence of linked event