### PR TITLE
PoC - new and safe dynamic subscriptions API - discussion

### DIFF
--- a/rails_event_store/spec/full_story_spec.rb
+++ b/rails_event_store/spec/full_story_spec.rb
@@ -14,7 +14,7 @@ module RailsEventStore
     specify 'building a read model runtime - pub_sub' do
       client = Client.new
       invoice = InvoiceReadModel.new
-      client.subscribe(invoice, [PriceChanged, ProductAdded])
+      client.subscribe(invoice, to: [PriceChanged, ProductAdded])
       publish_ordering_events(client)
       assert_invoice_structure(invoice)
     end

--- a/ruby_event_store/Makefile
+++ b/ruby_event_store/Makefile
@@ -5,6 +5,7 @@ IGNORE      = RubyEventStore.const_missing \
               RubyEventStore::InMemoryRepository\#append_with_synchronize \
               RubyEventStore::InMemoryRepository\#normalize_to_array \
               RubyEventStore::Client\#normalize_to_array \
+              RubyEventStore::Client::Within\#normalize_to_array \
               RubyEventStore::SerializedRecord \
               RubyEventStore::Projection\#read_events_from_stream \
               RubyEventStore::Projection\#read_events_from_all_streams
@@ -20,7 +21,7 @@ test: ## Run unit tests
 
 mutate: test ## Run mutation tests
 	@echo "Running mutation tests"
-	@bundle exec mutant --include lib \
+	@MUTATING=true bundle exec mutant --include lib \
 		$(addprefix --require ,$(REQUIRE)) \
 		$(addprefix --ignore-subject ,$(IGNORE)) \
 		--use rspec "$(SUBJECT)"

--- a/ruby_event_store/lib/ruby_event_store/client.rb
+++ b/ruby_event_store/lib/ruby_event_store/client.rb
@@ -99,7 +99,7 @@ module RubyEventStore
         @block = block
         @event_broker = event_broker
         @global_subscribers = []
-        @subscribers = Hash.new {|hsh, key| hsh[key] = [] }
+        @subscribers = Hash.new {[]}
       end
 
       def subscribe_to_all_events(*handlers, &handler2)

--- a/ruby_event_store/lib/ruby_event_store/client.rb
+++ b/ruby_event_store/lib/ruby_event_store/client.rb
@@ -97,7 +97,7 @@ module RubyEventStore
         raise SubscriberNotExist unless subscriber || proc
         raise ArgumentError if event_types
         subscriber ||= proc
-        @event_broker.add_global_subscriber(subscriber)
+        @event_broker.add_subscriber(subscriber, event_types)
       else
         if proc
           warn(DEPRECATED_WITHIN)

--- a/ruby_event_store/lib/ruby_event_store/client.rb
+++ b/ruby_event_store/lib/ruby_event_store/client.rb
@@ -189,14 +189,6 @@ module RubyEventStore
       # event.class.new(event_id: event.event_id, metadata: metadata, data: event.data)
     end
 
-    def handle_subscribe(unsub, &proc)
-      begin
-        proc.call
-      ensure
-        unsub.()
-      end if proc
-    end
-
     class Page
       def initialize(repository, start, count)
         if start.instance_of?(Symbol)

--- a/ruby_event_store/lib/ruby_event_store/client.rb
+++ b/ruby_event_store/lib/ruby_event_store/client.rb
@@ -93,9 +93,9 @@ module RubyEventStore
     #  subscribe(to:, &subscriber)
     def subscribe(subscriber = nil, event_types = nil, to: nil, &proc)
       if to
-        raise ArgumentError if subscriber && proc
-        raise SubscriberNotExist unless subscriber || proc
-        raise ArgumentError if event_types
+        raise ArgumentError, "subscriber must be first argument or block, cannot be both" if subscriber && proc
+        raise SubscriberNotExist, "subscriber must be first argument or block" unless subscriber || proc
+        raise ArgumentError, "list of event types must be second argument or named argument to: , it cannot be both" if event_types
         subscriber ||= proc
         @event_broker.add_subscriber(subscriber, to)
       else

--- a/ruby_event_store/lib/ruby_event_store/client.rb
+++ b/ruby_event_store/lib/ruby_event_store/client.rb
@@ -97,7 +97,7 @@ module RubyEventStore
         raise SubscriberNotExist unless subscriber || proc
         raise ArgumentError if event_types
         subscriber ||= proc
-        @event_broker.add_subscriber(subscriber, event_types)
+        @event_broker.add_subscriber(subscriber, to)
       else
         if proc
           warn(DEPRECATED_WITHIN)

--- a/ruby_event_store/lib/ruby_event_store/client.rb
+++ b/ruby_event_store/lib/ruby_event_store/client.rb
@@ -88,9 +88,24 @@ module RubyEventStore
       end
     end
 
-    def subscribe_to_all_events(subscriber, &proc)
-      @event_broker.add_global_subscriber(subscriber).tap do |unsub|
-        handle_subscribe(unsub, &proc)
+    DEPRECATED_ALL_WITHIN = "subscribe_to_all_events(subscriber, &task) has been deprecated. Use within(&task).subscribe_to_all_events(subscriber).call instead."
+    # OLD:
+    #  subscribe_to_all_events(subscriber, &within)
+    #  subscribe_to_all_events(subscriber)
+    # NEW:
+    #  subscribe_to_all_events(subscriber)
+    #  subscribe_to_all_events(&subscriber)
+    def subscribe_to_all_events(subscriber = nil, &proc)
+      if subscriber
+        if proc
+          warn(DEPRECATED_ALL_WITHIN)
+          within(&proc).subscribe_to_all_events(subscriber).call
+          -> {}
+        else
+          @event_broker.add_global_subscriber(subscriber)
+        end
+      else
+        @event_broker.add_global_subscriber(proc)
       end
     end
 

--- a/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
+++ b/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
@@ -73,21 +73,20 @@ module RubyEventStore
     def add_to_stream(events, expected_version, stream_name, include_global)
       raise InvalidExpectedVersion if !expected_version.equal?(:any) && stream_name.eql?(GLOBAL_STREAM)
       events = normalize_to_array(events)
-      stream = read_stream_events_forward(stream_name)
       expected_version = case expected_version
         when :none
           -1
-        when :auto, :any
-          stream.size - 1
-        when Integer
+        when :auto
+          read_stream_events_forward(stream_name).size - 1
+        when Integer, :any
           expected_version
         else
          raise InvalidExpectedVersion
       end
-      append_with_synchronize(events, expected_version, stream, stream_name, include_global)
+      append_with_synchronize(events, expected_version, stream_name, include_global)
     end
 
-    def append_with_synchronize(events, expected_version, stream, stream_name, include_global)
+    def append_with_synchronize(events, expected_version, stream_name, include_global)
       # expected_version :auto assumes external lock is used
       # which makes reading stream before writing safe.
       #
@@ -97,11 +96,15 @@ module RubyEventStore
       # not for the whole read+write algorithm.
       Thread.pass
       @mutex.synchronize do
-        append(events, expected_version, stream, stream_name, include_global)
+        if expected_version == :any
+          expected_version = read_stream_events_forward(stream_name).size - 1
+        end
+        append(events, expected_version, stream_name, include_global)
       end
     end
 
-    def append(events, expected_version, stream, stream_name, include_global)
+    def append(events, expected_version, stream_name, include_global)
+      stream = read_stream_events_forward(stream_name)
       raise WrongExpectedEventVersion unless (stream.size - 1).equal?(expected_version)
       events.each do |event|
         raise EventDuplicatedInStream if stream.any?{|ev| ev.event_id.eql?(event.event_id) }

--- a/ruby_event_store/lib/ruby_event_store/pub_sub/broker.rb
+++ b/ruby_event_store/lib/ruby_event_store/pub_sub/broker.rb
@@ -17,14 +17,6 @@ module RubyEventStore
         @dispatcher = dispatcher
       end
 
-      def dup
-        self.class.new(dispatcher: @dispatcher).tap do |broker|
-          hash = @subscribers.dup
-          broker.instance_variable_set(:@subscribers, hash.update(hash){|k,v| v.dup })
-          broker.instance_variable_set(:@global_subscribers, @global_subscribers.dup)
-        end
-      end
-
       def add_subscriber(subscriber, event_types)
         verify_subscriber(subscriber)
         subscribe(subscriber, event_types)

--- a/ruby_event_store/lib/ruby_event_store/pub_sub/broker.rb
+++ b/ruby_event_store/lib/ruby_event_store/pub_sub/broker.rb
@@ -9,6 +9,14 @@ module RubyEventStore
         @dispatcher = dispatcher
       end
 
+      def dup
+        self.class.new(dispatcher: @dispatcher).tap do |broker|
+          hash = @subscribers.dup
+          broker.instance_variable_set(:@subscribers, hash.update(hash){|k,v| v.dup })
+          broker.instance_variable_set(:@global_subscribers, @global_subscribers.dup)
+        end
+      end
+
       def add_subscriber(subscriber, event_types)
         verify_subscriber(subscriber)
         subscribe(subscriber, event_types)

--- a/ruby_event_store/lib/ruby_event_store/pub_sub/broker.rb
+++ b/ruby_event_store/lib/ruby_event_store/pub_sub/broker.rb
@@ -1,3 +1,5 @@
+require 'concurrent'
+
 module RubyEventStore
   module PubSub
     class Broker
@@ -6,6 +8,12 @@ module RubyEventStore
       def initialize(dispatcher: DEFAULT_DISPATCHER)
         @subscribers = Hash.new {|hsh, key| hsh[key] = [] }
         @global_subscribers = []
+
+        @thread_global_subscribers = Concurrent::ThreadLocalVar.new([])
+        @thread_subscribers = Concurrent::ThreadLocalVar.new do
+          Hash.new {|hsh, key| hsh[key] = [] }
+        end
+
         @dispatcher = dispatcher
       end
 
@@ -29,6 +37,19 @@ module RubyEventStore
         ->() { @global_subscribers.delete(subscriber) }
       end
 
+      def add_thread_global_subscriber(subscriber)
+        verify_subscriber(subscriber)
+        @thread_global_subscribers.value += [subscriber]
+
+        ->() { @thread_global_subscribers.value -= [subscriber] }
+      end
+
+      def add_thread_subscriber(subscriber, event_types)
+        verify_subscriber(subscriber)
+        event_types.each{ |type| @thread_subscribers.value[type.name] << subscriber }
+        ->() {event_types.each{ |type| @thread_subscribers.value.fetch(type.name).delete(subscriber) } }
+      end
+
       def notify_subscribers(event)
         all_subscribers_for(event.class).each do |subscriber|
           @dispatcher.call(subscriber, event)
@@ -48,7 +69,10 @@ module RubyEventStore
       end
 
       def all_subscribers_for(event_type)
-        @subscribers[event_type.name] + @global_subscribers
+        @subscribers[event_type.name] +
+        @global_subscribers +
+        @thread_global_subscribers.value +
+        @thread_subscribers.value[event_type.name]
       end
     end
   end

--- a/ruby_event_store/lib/ruby_event_store/spec/event_broker_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/event_broker_lint.rb
@@ -122,6 +122,7 @@ RSpec.shared_examples :event_broker do |broker_class|
     expect(dispatcher.dispatched).to eq([{subscriber: handler, event: event1}])
   end
 
+
   private
   class HandlerClass
     @@received = nil

--- a/ruby_event_store/ruby_event_store.gemspec
+++ b/ruby_event_store/ruby_event_store.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |spec|
 
 
   spec.add_dependency 'activesupport'
+  spec.add_dependency 'concurrent-ruby', '~> 1.0'
+  spec.add_dependency 'immutable-ruby', '~> 0.0.2'
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.6'

--- a/ruby_event_store/ruby_event_store.gemspec
+++ b/ruby_event_store/ruby_event_store.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport'
   spec.add_dependency 'concurrent-ruby', '~> 1.0'
-  spec.add_dependency 'immutable-ruby', '~> 0.0.2'
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.6'

--- a/ruby_event_store/spec/client_spec.rb
+++ b/ruby_event_store/spec/client_spec.rb
@@ -160,7 +160,7 @@ module RubyEventStore
 
     specify 'throws exception if subscriber is not defined' do
       client = RubyEventStore::Client.new(repository: InMemoryRepository.new)
-      expect { client.subscribe(nil, [])}.to raise_error(SubscriberNotExist)
+      expect { client.subscribe(nil, to: [])}.to raise_error(SubscriberNotExist)
       expect { client.subscribe_to_all_events(nil)}.to raise_error(SubscriberNotExist)
     end
 

--- a/ruby_event_store/spec/in_memory_repository_spec.rb
+++ b/ruby_event_store/spec/in_memory_repository_spec.rb
@@ -3,8 +3,6 @@ require 'ruby_event_store/spec/event_repository_lint'
 
 module RubyEventStore
   RSpec.describe InMemoryRepository do
-    # There is no way to use in-memory adapter in a
-    # lock-free, unlimited concurrency way
     let(:test_race_conditions_any)   { true }
     let(:test_race_conditions_auto)  { true }
     let(:test_expected_version_auto) { true }

--- a/ruby_event_store/spec/in_memory_repository_spec.rb
+++ b/ruby_event_store/spec/in_memory_repository_spec.rb
@@ -5,7 +5,7 @@ module RubyEventStore
   RSpec.describe InMemoryRepository do
     # There is no way to use in-memory adapter in a
     # lock-free, unlimited concurrency way
-    let(:test_race_conditions_any)   { false }
+    let(:test_race_conditions_any)   { true }
     let(:test_race_conditions_auto)  { true }
     let(:test_expected_version_auto) { true }
     let(:test_link_events_to_stream) { true }

--- a/ruby_event_store/spec/projection_spec.rb
+++ b/ruby_event_store/spec/projection_spec.rb
@@ -122,7 +122,7 @@ module RubyEventStore
         from_stream(stream_name).
         init( -> { { total: 0 } }).
         when(MoneyDeposited, ->(state, event) { state[:total] += event.data[:amount] })
-      event_store.subscribe(deposits, deposits.handled_events)
+      event_store.subscribe(deposits, to: deposits.handled_events)
       event_store.publish_event(MoneyDeposited.new(data: { amount: 10 }), stream_name: stream_name)
       event_store.publish_event(MoneyDeposited.new(data: { amount: 5 }), stream_name: stream_name)
       expect(deposits.current_state).to eq(total: 15)

--- a/ruby_event_store/spec/subscription_spec.rb
+++ b/ruby_event_store/spec/subscription_spec.rb
@@ -284,5 +284,56 @@ module RubyEventStore
         event_2, :subscriber1, event_2, :subscriber2,
       ]
     end
+
+    context "dynamic subscribe v2" do
+      specify 'dynamic global subscription via proxy' do
+        event_1 = OrderCreated.new
+        event_2 = ProductAdded.new
+        dispatcher = CustomDispatcher.new
+        broker = PubSub::Broker.new(dispatcher: dispatcher)
+        client = RubyEventStore::Client.new(repository: repository, event_broker: broker)
+
+        result = client.within do
+          client.publish_event(event_1)
+        end.subscribe_to_all_events(Subscribers::ValidHandler).call
+
+        client.publish_event(event_2)
+
+        expect(dispatcher.dispatched_events).to eq [{to: Subscribers::ValidHandler, event: event_1}]
+        expect(client.read_all_streams_forward).to eq([event_1, event_2])
+      end
+
+      # specify 'dynamic subscription' do
+      #   event_1 = OrderCreated.new
+      #   event_2 = ProductAdded.new
+      #   event_3 = ProductAdded.new
+      #   types = [OrderCreated, ProductAdded]
+      #   result = client.subscribe(h = Subscribers::ValidHandler.new, types) do
+      #     client.publish_event(event_1)
+      #     client.publish_event(event_2)
+      #   end
+      #   client.publish_event(event_3)
+      #   expect(h.handled_events).to eq([event_1, event_2])
+      #   expect(result).to respond_to(:call)
+      #   expect(client.read_all_streams_forward).to eq([event_1, event_2, event_3])
+      # end
+      #
+      # specify 'dynamic subscription with exception' do
+      #   event_1 = OrderCreated.new
+      #   event_2 = OrderCreated.new
+      #   exception = Class.new(StandardError)
+      #   begin
+      #     client.subscribe(h = Subscribers::ValidHandler.new, [OrderCreated]) do
+      #       client.publish_event(event_1)
+      #       raise exception
+      #     end
+      #   rescue exception
+      #   end
+      #   client.publish_event(event_2)
+      #   expect(h.handled_events).to eq([event_1])
+      #   expect(client.read_all_streams_forward).to eq([event_1, event_2])
+      # end
+
+    end
   end
 end

--- a/ruby_event_store/spec/subscription_spec.rb
+++ b/ruby_event_store/spec/subscription_spec.rb
@@ -236,10 +236,11 @@ module RubyEventStore
       client = RubyEventStore::Client.new(repository: repository, event_broker: broker)
       result = client.within do
         client.publish_event(event_1)
+        :elo
       end.subscribe_to_all_events(Subscribers::ValidHandler).call
       client.publish_event(event_2)
       expect(dispatcher.dispatched_events).to eq [{to: Subscribers::ValidHandler, event: event_1}]
-      expect(result).to respond_to(:call)
+      expect(result).to eq(:elo)
       expect(client.read_all_streams_forward).to eq([event_1, event_2])
     end
 

--- a/ruby_event_store/spec/subscription_spec.rb
+++ b/ruby_event_store/spec/subscription_spec.rb
@@ -193,8 +193,8 @@ module RubyEventStore
       end.to output("#{Client::DEPRECATED_WITHIN}\n").to_stderr
       client.publish_event(event_2)
       expect(subscriber.handled_events).to eq [event_1]
-      expect(result).to respond_to(:call)
       expect(client.read_all_streams_forward).to eq([event_1, event_2])
+      result.()
     end
 
     specify 'dynamic subscription' do
@@ -353,6 +353,20 @@ module RubyEventStore
         event_1, :subscriber1, event_1, :subscriber2,
         event_2, :subscriber1, event_2, :subscriber2,
       ]
+    end
+
+    specify "subscribe unallowed calls" do
+      expect do
+        client.subscribe(subscriber = ->(){}, to: [], ){}
+      end.to raise_error(ArgumentError, "subscriber must be first argument or block, cannot be both")
+
+      expect do
+        client.subscribe(to: [])
+      end.to raise_error(RubyEventStore::SubscriberNotExist, "subscriber must be first argument or block")
+
+      expect do
+        client.subscribe(-> (){}, [], to: [])
+      end.to raise_error(ArgumentError, "list of event types must be second argument or named argument to: , it cannot be both")
     end
 
     context "dynamic subscribe v2" do

--- a/ruby_event_store/spec/subscription_spec.rb
+++ b/ruby_event_store/spec/subscription_spec.rb
@@ -391,7 +391,7 @@ module RubyEventStore
 
         expect(h4.handled_events.count).to eq(big_number)
         expect(h4.handled_events.map(&:class).uniq).to eq([ProductAdded])
-      end
+      end unless ENV['MUTATING'] == 'true'
 
     end
   end

--- a/ruby_event_store/spec/within_spec.rb
+++ b/ruby_event_store/spec/within_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+module RubyEventStore
+  RSpec.describe Client do
+    subject(:within) { Client::Within.new(nil, nil) }
+
+    specify "subscribe with handler as object and block" do
+      expect do
+        within.subscribe(:handler, to: []) do
+        end
+      end.to raise_error(ArgumentError)
+    end
+
+    specify "within without block" do
+      client = Client.new(repository: :something)
+      expect do
+        client.within()
+      end.to raise_error(ArgumentError)
+    end
+
+  end
+end


### PR DESCRIPTION
New dynamic subscriptions API

* [x] Discuss API #155 
* [x] Fix `RubyEventStore::PubSub::Broker` mutations (only runs ruby_event_store/spec/event_broker_spec.rb)
* [x] test nested within
* [x] Thread-safe temporary subscribers #196 
  * [x] new syntax
  * [x] old syntax
    * [x] `subscribe_to_all_events`
    * [x] `subscribe`
* [x] Test fixing #188 
* [x] recongize new syntax 
  * [x] `subscribe_to_all_events`
    * [x] deprecate old api
    * [x] keep new and old api workig 
  * [x] `subscribe` based on `to:`
    * [x] deprecate old api
    * [x] keep new and old api workig
* [ ] document new api
* [ ] blogpost about new API