### PR TITLE
Revert rspec as runtime dependency

### DIFF
--- a/rails_event_store-rspec/rails_event_store-rspec.gemspec
+++ b/rails_event_store-rspec/rails_event_store-rspec.gemspec
@@ -25,4 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'mutant-rspec', '~> 0.8.14'
   spec.add_development_dependency 'rails', '~> 5.1'
   spec.add_development_dependency 'rails_event_store', '= 0.25.2'
+
+  spec.add_runtime_dependency 'rspec', '~> 3.0'
 end


### PR DESCRIPTION
Without rspec gem tests are failing with LoadError:

    cannot load such file -- rspec

Regression fix #115

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/railseventstore/rails_event_store/203)
<!-- Reviewable:end -->
