### PR TITLE
use the current version of rails for the migration generation

### DIFF
--- a/rails_event_store_active_record/lib/rails_event_store_active_record/generators/migration_generator.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/generators/migration_generator.rb
@@ -10,13 +10,13 @@ module RailsEventStoreActiveRecord
 
     private
 
-    def rails_version
-      Rails::VERSION::STRING
+    def active_record_version
+      Gem::Version.new(ActiveRecord::VERSION::STRING)
     end
 
     def migration_version
-      return nil if Gem::Version.new(rails_version) < Gem::Version.new("5.0.0")
-      "[4.2]"
+      return nil if active_record_version < Gem::Version.new("5.0.0")
+      "[#{active_record_version.to_s.sub(/\A(\d+\.\d+)\.\d+\z/, '\1')}]"
     end
 
     def timestamp

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/generators/v1_v2_migration_generator.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/generators/v1_v2_migration_generator.rb
@@ -10,13 +10,13 @@ module RailsEventStoreActiveRecord
 
     private
 
-    def rails_version
-      Rails::VERSION::STRING
+    def active_record_version
+      Gem::Version.new(ActiveRecord::VERSION::STRING)
     end
 
     def migration_version
-      return nil if Gem::Version.new(rails_version) < Gem::Version.new("5.0.0")
-      "[4.2]"
+      return nil if active_record_version < Gem::Version.new("5.0.0")
+      "[#{active_record_version.to_s.sub(/\A(\d+\.\d+)\.\d+\z/, '\1')}]"
     end
 
     def timestamp

--- a/rails_event_store_active_record/spec/migration_generator_spec.rb
+++ b/rails_event_store_active_record/spec/migration_generator_spec.rb
@@ -14,7 +14,7 @@ module RailsEventStoreActiveRecord
     specify do
       FakeFS.with_fresh do
         FakeFS::FileSystem.clone(File.expand_path('../../', __FILE__))
-        stub_const("Rails::VERSION::STRING", "4.2.8")
+        stub_const("ActiveRecord::VERSION::STRING", "4.2.8")
 
         generator = MigrationGenerator.new
         allow(Time).to receive(:now).and_return(Time.new(2016,8,9,22,22,22))
@@ -27,13 +27,13 @@ module RailsEventStoreActiveRecord
     specify do
       FakeFS.with_fresh do
         FakeFS::FileSystem.clone(File.expand_path('../../', __FILE__))
-        stub_const("Rails::VERSION::STRING", "5.0.0")
+        stub_const("ActiveRecord::VERSION::STRING", "5.0.0")
 
         generator = MigrationGenerator.new
         allow(Time).to receive(:now).and_return(Time.new(2016,8,9,22,22,22))
         generator.create_migration
 
-        expect(File.read("db/migrate/20160809222222_create_event_store_events.rb")).to match(/ActiveRecord::Migration\[4\.2\]$/)
+        expect(File.read("db/migrate/20160809222222_create_event_store_events.rb")).to match(/ActiveRecord::Migration\[\d+\.\d+\]$/)
       end
     end
   end

--- a/rails_event_store_active_record/spec/spec_helper.rb
+++ b/rails_event_store_active_record/spec/spec_helper.rb
@@ -6,7 +6,8 @@ ENV['DATABASE_URL']  ||= 'sqlite3:db.sqlite3'
 ENV['RAILS_VERSION'] ||= Rails::VERSION::STRING
 
 MigrationCode = File.read(File.expand_path('../../lib/rails_event_store_active_record/generators/templates/migration_template.rb', __FILE__) )
-migration_version = Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new("5.0.0") ? "" : "[4.2]"
+active_record_version = Gem::Version.new(ActiveRecord::VERSION::STRING)
+migration_version = active_record_version < Gem::Version.new("5.0.0") ? "" : "[#{active_record_version.to_s.sub(/\A(\d+\.\d+)\.\d+\z/, '\1')}]"
 MigrationCode.gsub!("<%= migration_version %>", migration_version)
 MigrationCode.gsub!("force: false", "force: true")
 

--- a/rails_event_store_active_record/spec/v1_v2_migration_generator_spec.rb
+++ b/rails_event_store_active_record/spec/v1_v2_migration_generator_spec.rb
@@ -14,7 +14,7 @@ module RailsEventStoreActiveRecord
     specify do
       FakeFS.with_fresh do
         FakeFS::FileSystem.clone(File.expand_path('../../', __FILE__))
-        stub_const("Rails::VERSION::STRING", "4.2.8")
+        stub_const("ActiveRecord::VERSION::STRING", "4.2.8")
 
         generator = V1V2MigrationGenerator.new
         allow(Time).to receive(:now).and_return(Time.new(2016,8,9,22,22,22))
@@ -27,13 +27,13 @@ module RailsEventStoreActiveRecord
     specify do
       FakeFS.with_fresh do
         FakeFS::FileSystem.clone(File.expand_path('../../', __FILE__))
-        stub_const("Rails::VERSION::STRING", "5.0.0")
+        stub_const("ActiveRecord::VERSION::STRING", "5.0.0")
 
         generator = V1V2MigrationGenerator.new
         allow(Time).to receive(:now).and_return(Time.new(2016,8,9,22,22,22))
         generator.create_migration
 
-        expect(File.read("db/migrate/20160809222222_migrate_res_schema_v1_to_v2.rb")).to match(/ActiveRecord::Migration\[4\.2\]$/)
+        expect(File.read("db/migrate/20160809222222_migrate_res_schema_v1_to_v2.rb")).to match(/ActiveRecord::Migration\[\d+\.\d+\]$/)
       end
     end
   end

--- a/rails_event_store_active_record/spec/v1_v2_schema_migration_spec.rb
+++ b/rails_event_store_active_record/spec/v1_v2_schema_migration_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe "v1_v2_migration" do
   include SchemaHelper
 
   MigrationRubyCode = File.read(File.expand_path('../../lib/rails_event_store_active_record/generators/templates/v1_v2_migration_template.rb', __FILE__) )
-  migration_version = Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new("5.0.0") ? "" : "[4.2]"
+  active_record_version = Gem::Version.new(ActiveRecord::VERSION::STRING)
+  migration_version = active_record_version < Gem::Version.new("5.0.0") ? "" : "[#{active_record_version.to_s.sub(/\A(\d+\.\d+)\.\d+\z/, '\1')}]"
   MigrationRubyCode.gsub!("<%= migration_version %>", migration_version)
 
   specify do


### PR DESCRIPTION
Hi guys,  
Don't you think this is kinda weird?
```ruby
def migration_version
  return nil if Gem::Version.new(rails_version) < Gem::Version.new("5.0.0")
  "[4.2]"
end
```
(If rails 5 then select rails 4 migration class)  
It is also leave some database options on schema dump.  
```ruby
  create_table "event_store_events", id: :string, limit: 36, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
    t.string "event_type", null: false
    t.text "metadata"
    t.text "data", null: false
    t.datetime "created_at", null: false
    t.index ["created_at"], name: "index_event_store_events_on_created_at"
  end

  create_table "event_store_events_in_streams", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
    t.string "stream", null: false
    t.integer "position"
    t.string "event_id", null: false
    t.datetime "created_at", null: false
    t.index ["created_at"], name: "index_event_store_events_in_streams_on_created_at"
    t.index ["stream", "event_id"], name: "index_event_store_events_in_streams_on_stream_and_event_id", unique: true
    t.index ["stream", "position"], name: "index_event_store_events_in_streams_on_stream_and_position", unique: true
  end
```
  
Can we match the migration version?  
P.S. I don't mind nitpicking comment if you guys don't satisfied with this PR in anyway I will change it for you.