### PR TITLE
Publish event can link to multiple streams

### DIFF
--- a/ruby_event_store/lib/ruby_event_store/client.rb
+++ b/ruby_event_store/lib/ruby_event_store/client.rb
@@ -27,7 +27,9 @@ module RubyEventStore
     def append_to_stream(events, stream_name: GLOBAL_STREAM, expected_version: :any)
       events = normalize_to_array(events)
       events.each{|event| enrich_event_metadata(event) }
-      @repository.append_to_stream(events, stream_name, expected_version)
+      first_stream, *other_streams = normalize_to_array(stream_name)
+      @repository.append_to_stream(events, first_stream, expected_version)
+      other_streams.each { |stream| link_to_stream(map_to_event_ids(events), stream_name: stream) }
       :ok
     end
 
@@ -187,6 +189,10 @@ module RubyEventStore
       metadata.merge!(@metadata_proc.call || {}) if @metadata_proc
 
       # event.class.new(event_id: event.event_id, metadata: metadata, data: event.data)
+    end
+
+    def map_to_event_ids(events)
+      normalize_to_array(events).map { |e| e.event_id }
     end
 
     class Page

--- a/ruby_event_store/spec/client_spec.rb
+++ b/ruby_event_store/spec/client_spec.rb
@@ -43,6 +43,16 @@ module RubyEventStore
       expect(client.read_stream_events_forward(GLOBAL_STREAM)).to eq([test_event])
     end
 
+    specify 'publish to multiple streams' do
+      client = RubyEventStore::Client.new(repository: InMemoryRepository.new)
+      test_event = TestEvent.new
+      stream_names = [SecureRandom.uuid, SecureRandom.uuid]
+      expect(client.publish_event(test_event, stream_name: stream_names)).to eq(:ok)
+      stream_names.each do |stream_name|
+        expect(client.read_stream_events_forward(stream_name)).to eq([test_event])
+      end
+    end
+
     specify 'publish first event, expect any stream state' do
       stream = SecureRandom.uuid
       client = RubyEventStore::Client.new(repository: InMemoryRepository.new)


### PR DESCRIPTION
I have a use case where it could be useful to publish an event and link it against multiple streams, before calling the event_broker to notify subscribers. This pull request should not break the current implementation and usage of the client.