### PR TITLE
Remove ActiveSupport dependency from `ruby_event_store` gem

### DIFF
--- a/ruby_event_store/lib/ruby_event_store/mappers/default.rb
+++ b/ruby_event_store/lib/ruby_event_store/mappers/default.rb
@@ -1,5 +1,4 @@
 require 'yaml'
-require 'active_support'
 
 module RubyEventStore
   module Mappers
@@ -20,7 +19,7 @@ module RubyEventStore
 
       def serialized_record_to_event(record)
         event_type = @events_class_remapping.fetch(record.event_type) { record.event_type }
-        ActiveSupport::Inflector.constantize(event_type).new(
+        Object.const_get(event_type).new(
           event_id: record.event_id,
           metadata: @serializer.load(record.metadata),
           data:     @serializer.load(record.data)

--- a/ruby_event_store/lib/ruby_event_store/mappers/protobuf.rb
+++ b/ruby_event_store/lib/ruby_event_store/mappers/protobuf.rb
@@ -17,7 +17,7 @@ module RubyEventStore
 
       def serialized_record_to_event(record)
         event_type = events_class_remapping.fetch(record.event_type) { record.event_type }
-        ActiveSupport::Inflector.constantize(event_type).decode(record.data)
+        Object.const_get(event_type).decode(record.data)
       end
 
       def add_metadata(event, key, value)

--- a/ruby_event_store/ruby_event_store.gemspec
+++ b/ruby_event_store/ruby_event_store.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
 
-  spec.add_dependency 'activesupport'
   spec.add_dependency 'concurrent-ruby', '~> 1.0'
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Removing ActiveSupport dependency to avoid monkey patching and all the other fun stuff when not using Rails/ActiveRecord with RES