### PR TITLE
Move common methods to `Repository` module

### DIFF
--- a/rails_event_store/lib/rails_event_store/all.rb
+++ b/rails_event_store/lib/rails_event_store/all.rb
@@ -7,6 +7,7 @@ require 'rails_event_store/deprecations'
 
 module RailsEventStore
   Event                     = RubyEventStore::Event
+  Repository                = RubyEventStore::Repository
   InMemoryRepository        = RubyEventStore::InMemoryRepository
   EventBroker               = RubyEventStore::PubSub::Broker
   Projection                = RubyEventStore::Projection

--- a/ruby_event_store/lib/ruby_event_store.rb
+++ b/ruby_event_store/lib/ruby_event_store.rb
@@ -1,5 +1,6 @@
 require 'ruby_event_store/pub_sub/dispatcher'
 require 'ruby_event_store/pub_sub/broker'
+require 'ruby_event_store/repository'
 require 'ruby_event_store/in_memory_repository'
 require 'ruby_event_store/projection'
 require 'ruby_event_store/errors'

--- a/ruby_event_store/lib/ruby_event_store/repository.rb
+++ b/ruby_event_store/lib/ruby_event_store/repository.rb
@@ -1,0 +1,69 @@
+require 'ostruct'
+require 'thread'
+
+module RubyEventStore
+  module Repository
+    POSITION_SHIFT = 1
+    POSITION_DEFAULT = -1
+
+    def append_to_stream(events, stream_name, expected_version)
+      add_to_stream(events, stream_name, expected_version, true)
+    end
+
+    def link_to_stream(events, stream_name, expected_version)
+      add_to_stream(events, stream_name, expected_version, nil)
+    end
+  
+  private
+
+    def add_to_stream(events, stream_name, expected_version, include_global, &block)
+      assert_valid_version_for_stream!(stream_name, expected_version)
+
+      events = normalize_to_array(events)
+      expected_version = normalize_expected_version(expected_version, stream_name)
+
+      append(events, stream_name, expected_version, include_global, &block)
+      
+      self
+    end
+
+    def append(events, stream_name, expected_version, include_global, &block)
+      raise "Not implemented: #{self.class.name}#append"
+    end
+
+    def assert_valid_version_for_stream!(stream_name, expected_version)
+      raise InvalidExpectedVersion if !expected_version.equal?(:any) && stream_name.eql?(GLOBAL_STREAM)
+    end
+
+    def compute_position(expected_version, offset = 0)
+      puts "expected_version: #{expected_version.inspect}"
+      puts "offset: #{offset.inspect}"
+      puts "POSITION_SHIFT: #{POSITION_SHIFT.inspect}"
+      unless expected_version.equal?(:any)
+        expected_version + offset + POSITION_SHIFT
+      end
+    end
+
+    def normalize_expected_version(expected_version, stream_name)
+      case expected_version
+        when Integer, :any
+          expected_version
+        when :none
+          -1
+        when :auto
+          last_position_for(stream_name) || POSITION_DEFAULT
+        else
+          raise InvalidExpectedVersion
+      end
+    end
+
+    def last_position_for(stream_name)
+      raise "Not implemented: #{self.class.name}#last_position_for"
+    end
+
+    def normalize_to_array(events)
+      return events if events.is_a?(Enumerable)
+      [events]
+    end
+  end
+end


### PR DESCRIPTION
Hi @paneq, would you accept some updates to share logic across `EventRepository` implementations?

I'm working on the ROM-based repository adapter ([feature/rom_adapter](https://github.com/joelvh/rails_event_store/tree/feature/rom_adapter)) and was looking to find ways to share code a bit more. I think that there can be more sharing between AR and ROM as well.

Let me know your thoughts on this.

Thanks.

~Joel