### PR TITLE
Gems metadata update

### DIFF
--- a/aggregate_root/aggregate_root.gemspec
+++ b/aggregate_root/aggregate_root.gemspec
@@ -12,7 +12,13 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Event sourced (with Rails Event Store) aggregate root implementation}
   spec.description   = %q{Event sourced (with Rails Event Store) aggregate root implementation}
-  spec.homepage      = ''
+  spec.homepage      = 'http://railseventstore.org'
+  spec.metadata    = {
+    "homepage_uri" => "http://railseventstore.org/",
+    "changelog_uri" => "https://github.com/RailsEventStore/rails_event_store/releases",
+    "source_code_uri" => "https://github.com/RailsEventStore/rails_event_store",
+    "bug_tracker_uri" => "https://github.com/RailsEventStore/rails_event_store/issues",
+  }
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = 'exe'

--- a/aggregate_root/aggregate_root.gemspec
+++ b/aggregate_root/aggregate_root.gemspec
@@ -12,9 +12,9 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Event sourced (with Rails Event Store) aggregate root implementation}
   spec.description   = %q{Event sourced (with Rails Event Store) aggregate root implementation}
-  spec.homepage      = 'http://railseventstore.org'
+  spec.homepage      = 'https://railseventstore.org'
   spec.metadata    = {
-    "homepage_uri" => "http://railseventstore.org/",
+    "homepage_uri" => "https://railseventstore.org/",
     "changelog_uri" => "https://github.com/RailsEventStore/rails_event_store/releases",
     "source_code_uri" => "https://github.com/RailsEventStore/rails_event_store",
     "bug_tracker_uri" => "https://github.com/RailsEventStore/rails_event_store/issues",

--- a/bounded_context/bounded_context.gemspec
+++ b/bounded_context/bounded_context.gemspec
@@ -11,6 +11,13 @@ Gem::Specification.new do |spec|
   spec.email         = ['dev@arkency.com']
 
   spec.summary       = %q{Generate opinionated component structure.}
+  spec.homepage      = 'http://railseventstore.org'
+  spec.metadata    = {
+    "homepage_uri" => "http://railseventstore.org/",
+    "changelog_uri" => "https://github.com/RailsEventStore/rails_event_store/releases",
+    "source_code_uri" => "https://github.com/RailsEventStore/rails_event_store",
+    "bug_tracker_uri" => "https://github.com/RailsEventStore/rails_event_store/issues",
+  }
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})

--- a/bounded_context/bounded_context.gemspec
+++ b/bounded_context/bounded_context.gemspec
@@ -11,9 +11,9 @@ Gem::Specification.new do |spec|
   spec.email         = ['dev@arkency.com']
 
   spec.summary       = %q{Generate opinionated component structure.}
-  spec.homepage      = 'http://railseventstore.org'
+  spec.homepage      = 'https://railseventstore.org'
   spec.metadata    = {
-    "homepage_uri" => "http://railseventstore.org/",
+    "homepage_uri" => "https://railseventstore.org/",
     "changelog_uri" => "https://github.com/RailsEventStore/rails_event_store/releases",
     "source_code_uri" => "https://github.com/RailsEventStore/rails_event_store",
     "bug_tracker_uri" => "https://github.com/RailsEventStore/rails_event_store/issues",

--- a/rails_event_store-browser/elm/src/Main.elm
+++ b/rails_event_store-browser/elm/src/Main.elm
@@ -208,8 +208,8 @@ browserFooter model =
     footer [ class "footer" ]
         [ div [ class "footer__links" ]
             [ text ("RailsEventStore v" ++ model.flags.resVersion)
-            , a [ href "http://railseventstore.org/docs/install/", class "footer__link" ] [ text "Documentation" ]
-            , a [ href "http://railseventstore.org/support/", class "footer__link" ] [ text "Support" ]
+            , a [ href "https://railseventstore.org/docs/install/", class "footer__link" ] [ text "Documentation" ]
+            , a [ href "https://railseventstore.org/support/", class "footer__link" ] [ text "Support" ]
             ]
         ]
 

--- a/rails_event_store-browser/rails_event_store-browser.gemspec
+++ b/rails_event_store-browser/rails_event_store-browser.gemspec
@@ -4,14 +4,14 @@ $:.push File.expand_path('../lib', __FILE__)
 require 'rails_event_store/browser/version'
 
 # Describe your gem and declare its dependencies:
-Gem::Specification.new do |s|
-  s.name        = 'rails_event_store-browser'
-  s.version     = RailsEventStore::Browser::VERSION
-  s.authors     = ['Arkency']
-  s.email       = ['dev@arkency.com']
-  s.summary     = 'Web interface for RailsEventStore'
-  s.license     = 'MIT'
-  spec.homepage      = 'https://railseventstore.org'
+Gem::Specification.new do |spec|
+  spec.name        = 'rails_event_store-browser'
+  spec.version     = RailsEventStore::Browser::VERSION
+  spec.authors     = ['Arkency']
+  spec.email       = ['dev@arkency.com']
+  spec.summary     = 'Web interface for RailsEventStore'
+  spec.license     = 'MIT'
+  spec.homepage    = 'https://railseventstore.org'
   spec.metadata    = {
     "homepage_uri" => "https://railseventstore.org/",
     "changelog_uri" => "https://github.com/RailsEventStore/rails_event_store/releases",
@@ -19,15 +19,15 @@ Gem::Specification.new do |s|
     "bug_tracker_uri" => "https://github.com/RailsEventStore/rails_event_store/issues",
   }
 
-  s.files = Dir['{app,config,db,lib,public}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
+  spec.files = Dir['{app,config,db,lib,public}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  s.add_dependency 'rails', '>= 4.2'
-  s.add_dependency 'rails_event_store', '= 0.27.1'
+  spec.add_dependency 'rails', '>= 4.2'
+  spec.add_dependency 'rails_event_store', '= 0.27.1'
 
-  s.add_development_dependency 'sqlite3'
-  s.add_development_dependency 'rspec-rails', '~> 3.6'
-  s.add_development_dependency 'mutant-rspec', '~> 0.8.14'
-  s.add_development_dependency 'capybara'
-  s.add_development_dependency 'selenium-webdriver'
-  s.add_development_dependency 'json-schema'
+  spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'rspec-rails', '~> 3.6'
+  spec.add_development_dependency 'mutant-rspec', '~> 0.8.14'
+  spec.add_development_dependency 'capybara'
+  spec.add_development_dependency 'selenium-webdriver'
+  spec.add_development_dependency 'json-schema'
 end

--- a/rails_event_store-browser/rails_event_store-browser.gemspec
+++ b/rails_event_store-browser/rails_event_store-browser.gemspec
@@ -11,9 +11,9 @@ Gem::Specification.new do |s|
   s.email       = ['dev@arkency.com']
   s.summary     = 'Web interface for RailsEventStore'
   s.license     = 'MIT'
-  spec.homepage      = 'http://railseventstore.org'
+  spec.homepage      = 'https://railseventstore.org'
   spec.metadata    = {
-    "homepage_uri" => "http://railseventstore.org/",
+    "homepage_uri" => "https://railseventstore.org/",
     "changelog_uri" => "https://github.com/RailsEventStore/rails_event_store/releases",
     "source_code_uri" => "https://github.com/RailsEventStore/rails_event_store",
     "bug_tracker_uri" => "https://github.com/RailsEventStore/rails_event_store/issues",

--- a/rails_event_store-browser/rails_event_store-browser.gemspec
+++ b/rails_event_store-browser/rails_event_store-browser.gemspec
@@ -11,6 +11,13 @@ Gem::Specification.new do |s|
   s.email       = ['dev@arkency.com']
   s.summary     = 'Web interface for RailsEventStore'
   s.license     = 'MIT'
+  spec.homepage      = 'http://railseventstore.org'
+  spec.metadata    = {
+    "homepage_uri" => "http://railseventstore.org/",
+    "changelog_uri" => "https://github.com/RailsEventStore/rails_event_store/releases",
+    "source_code_uri" => "https://github.com/RailsEventStore/rails_event_store",
+    "bug_tracker_uri" => "https://github.com/RailsEventStore/rails_event_store/issues",
+  }
 
   s.files = Dir['{app,config,db,lib,public}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 

--- a/rails_event_store-rspec/rails_event_store-rspec.gemspec
+++ b/rails_event_store-rspec/rails_event_store-rspec.gemspec
@@ -11,9 +11,9 @@ Gem::Specification.new do |spec|
   spec.email         = ['dev@arkency.com']
 
   spec.summary       = %q{RSpec matchers for RailsEventStore}
-  spec.homepage      = 'http://railseventstore.org'
+  spec.homepage      = 'https://railseventstore.org'
   spec.metadata    = {
-    "homepage_uri" => "http://railseventstore.org/",
+    "homepage_uri" => "https://railseventstore.org/",
     "changelog_uri" => "https://github.com/RailsEventStore/rails_event_store/releases",
     "source_code_uri" => "https://github.com/RailsEventStore/rails_event_store",
     "bug_tracker_uri" => "https://github.com/RailsEventStore/rails_event_store/issues",

--- a/rails_event_store-rspec/rails_event_store-rspec.gemspec
+++ b/rails_event_store-rspec/rails_event_store-rspec.gemspec
@@ -11,6 +11,13 @@ Gem::Specification.new do |spec|
   spec.email         = ['dev@arkency.com']
 
   spec.summary       = %q{RSpec matchers for RailsEventStore}
+  spec.homepage      = 'http://railseventstore.org'
+  spec.metadata    = {
+    "homepage_uri" => "http://railseventstore.org/",
+    "changelog_uri" => "https://github.com/RailsEventStore/rails_event_store/releases",
+    "source_code_uri" => "https://github.com/RailsEventStore/rails_event_store",
+    "bug_tracker_uri" => "https://github.com/RailsEventStore/rails_event_store/issues",
+  }
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})

--- a/rails_event_store/rails_event_store.gemspec
+++ b/rails_event_store/rails_event_store.gemspec
@@ -12,9 +12,9 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Event Store in Ruby}
   spec.description   = %q{Implementation of Event Store in Ruby}
-  spec.homepage      = 'http://railseventstore.org'
+  spec.homepage      = 'https://railseventstore.org'
   spec.metadata    = {
-    "homepage_uri" => "http://railseventstore.org/",
+    "homepage_uri" => "https://railseventstore.org/",
     "changelog_uri" => "https://github.com/RailsEventStore/rails_event_store/releases",
     "source_code_uri" => "https://github.com/RailsEventStore/rails_event_store",
     "bug_tracker_uri" => "https://github.com/RailsEventStore/rails_event_store/issues",

--- a/rails_event_store/rails_event_store.gemspec
+++ b/rails_event_store/rails_event_store.gemspec
@@ -12,7 +12,13 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Event Store in Ruby}
   spec.description   = %q{Implementation of Event Store in Ruby}
-  spec.homepage      = 'https://github.com/RailsEventStore/rails_event_store'
+  spec.homepage      = 'http://railseventstore.org'
+  spec.metadata    = {
+    "homepage_uri" => "http://railseventstore.org/",
+    "changelog_uri" => "https://github.com/RailsEventStore/rails_event_store/releases",
+    "source_code_uri" => "https://github.com/RailsEventStore/rails_event_store",
+    "bug_tracker_uri" => "https://github.com/RailsEventStore/rails_event_store/issues",
+  }
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = 'exe'

--- a/rails_event_store_active_record/rails_event_store_active_record.gemspec
+++ b/rails_event_store_active_record/rails_event_store_active_record.gemspec
@@ -12,7 +12,13 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Active Record events repository for Rails Event Store}
   spec.description   = %q{Implementation of events repository based on Rails Active Record for Rails Event Store'}
-  spec.homepage      = 'https://github.com/RailsEventStore/rails_event_store_active_record'
+  spec.homepage      = 'http://railseventstore.org'
+  spec.metadata    = {
+    "homepage_uri" => "http://railseventstore.org/",
+    "changelog_uri" => "https://github.com/RailsEventStore/rails_event_store/releases",
+    "source_code_uri" => "https://github.com/RailsEventStore/rails_event_store",
+    "bug_tracker_uri" => "https://github.com/RailsEventStore/rails_event_store/issues",
+  }
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = 'exe'

--- a/rails_event_store_active_record/rails_event_store_active_record.gemspec
+++ b/rails_event_store_active_record/rails_event_store_active_record.gemspec
@@ -12,9 +12,9 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Active Record events repository for Rails Event Store}
   spec.description   = %q{Implementation of events repository based on Rails Active Record for Rails Event Store'}
-  spec.homepage      = 'http://railseventstore.org'
+  spec.homepage      = 'https://railseventstore.org'
   spec.metadata    = {
-    "homepage_uri" => "http://railseventstore.org/",
+    "homepage_uri" => "https://railseventstore.org/",
     "changelog_uri" => "https://github.com/RailsEventStore/rails_event_store/releases",
     "source_code_uri" => "https://github.com/RailsEventStore/rails_event_store",
     "bug_tracker_uri" => "https://github.com/RailsEventStore/rails_event_store/issues",

--- a/railseventstore.org/README.md
+++ b/railseventstore.org/README.md
@@ -1,6 +1,6 @@
 # railseventstore.org
 
-Source files for the documentation and website of [Rails Event Store](http://railseventstore.org).
+Source files for the documentation and website of [Rails Event Store](https://railseventstore.org).
 
 [![Build Status](https://travis-ci.org/RailsEventStore/railseventstore.org.svg?branch=master)](https://travis-ci.org/RailsEventStore/railseventstore.org)
 

--- a/railseventstore.org/source/docs/browser.html.md
+++ b/railseventstore.org/source/docs/browser.html.md
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
 end
 ```
 
-It is assumed that you have _Rails Event Store_ configured at `Rails.configuration.event_store` (like we recommend in [docs](http://railseventstore.org/docs/install/)).
+It is assumed that you have _Rails Event Store_ configured at `Rails.configuration.event_store` (like we recommend in [docs](https://railseventstore.org/docs/install/)).
 
 ## Usage in production
 

--- a/ruby_event_store/ruby_event_store.gemspec
+++ b/ruby_event_store/ruby_event_store.gemspec
@@ -12,9 +12,9 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Event Store in Ruby}
   spec.description   = %q{Implementation of Event Store in Ruby}
-  spec.homepage      = 'http://railseventstore.org'
+  spec.homepage      = 'https://railseventstore.org'
   spec.metadata    = {
-    "homepage_uri" => "http://railseventstore.org/",
+    "homepage_uri" => "https://railseventstore.org/",
     "changelog_uri" => "https://github.com/RailsEventStore/rails_event_store/releases",
     "source_code_uri" => "https://github.com/RailsEventStore/rails_event_store",
     "bug_tracker_uri" => "https://github.com/RailsEventStore/rails_event_store/issues",

--- a/ruby_event_store/ruby_event_store.gemspec
+++ b/ruby_event_store/ruby_event_store.gemspec
@@ -12,7 +12,13 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Event Store in Ruby}
   spec.description   = %q{Implementation of Event Store in Ruby}
-  spec.homepage      = 'https://github.com/RailsEventStore/ruby_event_store'
+  spec.homepage      = 'http://railseventstore.org'
+  spec.metadata    = {
+    "homepage_uri" => "http://railseventstore.org/",
+    "changelog_uri" => "https://github.com/RailsEventStore/rails_event_store/releases",
+    "source_code_uri" => "https://github.com/RailsEventStore/rails_event_store",
+    "bug_tracker_uri" => "https://github.com/RailsEventStore/rails_event_store/issues",
+  }
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = 'exe'


### PR DESCRIPTION
Change alll gems home page to https://railseventstore.org
Add metadata based on
https://olivierlacan.com/posts/changelogs-on-rubygems-org to have
changelog, source code & issue tracker links in RubyGems.org