### PR TITLE
Allow explicit read from GLOBAL_STREAM in InMemoryRepository

### DIFF
--- a/rails_event_store_active_record/spec/event_repository_spec.rb
+++ b/rails_event_store_active_record/spec/event_repository_spec.rb
@@ -22,6 +22,7 @@ module RailsEventStoreActiveRecord
     let(:test_race_conditions_any)   { !ENV['DATABASE_URL'].include?("sqlite") }
     let(:test_expected_version_auto) { true }
     let(:test_link_events_to_stream) { true }
+    let(:test_non_legacy_all_stream) { true }
 
     it_behaves_like :event_repository, EventRepository
 

--- a/rails_event_store_active_record/spec/legacy_event_repository_spec.rb
+++ b/rails_event_store_active_record/spec/legacy_event_repository_spec.rb
@@ -26,6 +26,7 @@ module RailsEventStoreActiveRecord
     let(:test_race_conditions_any)   { !ENV['DATABASE_URL'].include?("sqlite") }
     let(:test_expected_version_auto) { false }
     let(:test_link_events_to_stream) { false }
+    let(:test_non_legacy_all_stream) { false }
 
     it_behaves_like :event_repository, LegacyEventRepository
 

--- a/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
+++ b/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
@@ -42,10 +42,12 @@ module RubyEventStore
     end
 
     def read_stream_events_forward(stream_name)
+      return @all if stream_name.eql?(GLOBAL_STREAM)
       @streams[stream_name] || Array.new
     end
 
     def read_stream_events_backward(stream_name)
+      return @all if stream_name.eql?(GLOBAL_STREAM)
       read_stream_events_forward(stream_name).reverse
     end
 
@@ -113,7 +115,7 @@ module RubyEventStore
           raise EventDuplicatedInStream if @all.any?{|ev| ev.event_id.eql?(event.event_id) }
           @all.push(event)
         end
-        stream.push(event)
+        stream.push(event) unless stream_name.eql?(GLOBAL_STREAM)
       end
       @streams[stream_name] = stream
       self

--- a/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
+++ b/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
@@ -5,9 +5,9 @@ module RubyEventStore
   class InMemoryRepository
 
     def initialize
-      @all = Array.new
       @streams = Hash.new
       @mutex = Mutex.new
+      @streams[GLOBAL_STREAM] = Array.new
     end
 
     def append_to_stream(events, stream_name, expected_version)
@@ -24,7 +24,7 @@ module RubyEventStore
     end
 
     def has_event?(event_id)
-      @all.any?{ |item| item.event_id.eql?(event_id) }
+      @streams.fetch(GLOBAL_STREAM).any? { |item| item.event_id.eql?(event_id) }
     end
 
     def last_stream_event(stream_name)
@@ -42,29 +42,27 @@ module RubyEventStore
     end
 
     def read_stream_events_forward(stream_name)
-      return @all if stream_name.eql?(GLOBAL_STREAM)
-      @streams[stream_name] || Array.new
+      @streams.fetch(stream_name, Array.new)
     end
 
     def read_stream_events_backward(stream_name)
-      return @all if stream_name.eql?(GLOBAL_STREAM)
       read_stream_events_forward(stream_name).reverse
     end
 
     def read_all_streams_forward(start_event_id, count)
-      read_batch(@all, start_event_id, count)
+      read_events_forward(GLOBAL_STREAM, start_event_id, count)
     end
 
     def read_all_streams_backward(start_event_id, count)
-      read_batch(@all.reverse, start_event_id, count)
+      read_events_backward(GLOBAL_STREAM, start_event_id, count)
     end
 
     def read_event(event_id)
-      @all.find { |e| event_id.eql?(e.event_id) } or raise EventNotFound.new(event_id)
+      @streams.fetch(GLOBAL_STREAM).find { |e| event_id.eql?(e.event_id) } or raise EventNotFound.new(event_id)
     end
 
     def get_all_streams
-      [Stream.new("all")] + @streams.keys.map { |name| Stream.new(name) }
+      @streams.keys.map { |name| Stream.new(name) }
     end
 
     private
@@ -112,8 +110,9 @@ module RubyEventStore
       events.each do |event|
         raise EventDuplicatedInStream if stream.any?{|ev| ev.event_id.eql?(event.event_id) }
         if include_global
-          raise EventDuplicatedInStream if @all.any?{|ev| ev.event_id.eql?(event.event_id) }
-          @all.push(event)
+          global_stream = read_stream_events_forward(GLOBAL_STREAM)
+          raise EventDuplicatedInStream if global_stream.any? { |ev| ev.event_id.eql?(event.event_id) }
+          global_stream.push(event)
         end
         stream.push(event) unless stream_name.eql?(GLOBAL_STREAM)
       end

--- a/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
@@ -837,6 +837,14 @@ RSpec.shared_examples :event_repository do |repository_class|
     expect(repository.read_all_streams_forward(:head, 10)).to eq([event])
   end
 
+  it 'allows reading from GLOBAL_STREAM explicitly' do
+    skip unless test_non_legacy_all_stream
+    event = SRecord.new(event_id: "df8b2ba3-4e2c-4888-8d14-4364855fa80e")
+    repository.append_to_stream(event, "any", :any)
+
+    expect(repository.read_events_forward("all", :head, 10)).to eq([event])
+  end
+
   specify 'GLOBAL_STREAM is unordered, one cannot expect specific version number to work' do
     expect {
       event = SRecord.new(event_id: "df8b2ba3-4e2c-4888-8d14-4364855fa80e")

--- a/ruby_event_store/spec/in_memory_repository_spec.rb
+++ b/ruby_event_store/spec/in_memory_repository_spec.rb
@@ -8,6 +8,7 @@ module RubyEventStore
     let(:test_race_conditions_auto)  { true }
     let(:test_expected_version_auto) { true }
     let(:test_link_events_to_stream) { true }
+    let(:test_non_legacy_all_stream) { true }
 
     it_behaves_like :event_repository, InMemoryRepository
 


### PR DESCRIPTION
We allow reading from "all" stream like it is any other stream. Due to
implementation detail InMemoryRepository does not allow that.