### PR TITLE
Unstable order of read events from GLOBAL_STREAM.

### DIFF
--- a/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository_reader.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository_reader.rb
@@ -33,7 +33,8 @@ module RailsEventStoreActiveRecord
         stream = stream.where('id < ?', before_event)
       end
 
-      stream.preload(:event).order('position DESC, id DESC').limit(count)
+      stream = stream.order('position DESC') unless stream_name.eql?(RubyEventStore::GLOBAL_STREAM)
+      stream.preload(:event).order('id DESC').limit(count)
         .map(&method(:build_event_instance))
     end
 
@@ -45,8 +46,10 @@ module RailsEventStoreActiveRecord
     end
 
     def read_stream_events_backward(stream_name)
-      EventInStream.preload(:event).where(stream: stream_name).order('position DESC, id DESC')
-        .map(&method(:build_event_instance))
+      stream = EventInStream.preload(:event).where(stream: stream_name)
+      stream = stream.order('position DESC') unless stream_name.eql?(RubyEventStore::GLOBAL_STREAM)
+      stream = stream.order('id DESC')
+      stream.map(&method(:build_event_instance))
     end
 
     def read_all_streams_forward(after_event_id, count)

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository_reader.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository_reader.rb
@@ -21,7 +21,8 @@ module RailsEventStoreActiveRecord
         stream = stream.where('id > ?', after_event)
       end
 
-      stream.preload(:event).order('position ASC, id ASC').limit(count)
+      stream = stream.order('position ASC') unless stream_name.eql?(RubyEventStore::GLOBAL_STREAM)
+      stream.preload(:event).order('id ASC').limit(count)
         .map(&method(:build_event_instance))
     end
 
@@ -37,8 +38,10 @@ module RailsEventStoreActiveRecord
     end
 
     def read_stream_events_forward(stream_name)
-      EventInStream.preload(:event).where(stream: stream_name).order('position ASC, id ASC')
-        .map(&method(:build_event_instance))
+      stream = EventInStream.preload(:event).where(stream: stream_name)
+      stream = stream.order('position ASC') unless stream_name.eql?(RubyEventStore::GLOBAL_STREAM)
+      stream = stream.order('id ASC')
+      stream.map(&method(:build_event_instance))
     end
 
     def read_stream_events_backward(stream_name)

--- a/rails_event_store_active_record/spec/event_repository_spec.rb
+++ b/rails_event_store_active_record/spec/event_repository_spec.rb
@@ -128,9 +128,14 @@ module RailsEventStoreActiveRecord
         event_id: e3.id,
       )
       repository = EventRepository.new
+
       expect(repository.read_all_streams_forward(:head, 3).map(&:event_id)).to eq([u1,u2,u3])
       expect(repository.read_events_forward("all", :head, 3).map(&:event_id)).to eq([u1,u2,u3])
       expect(repository.read_stream_events_forward("all").map(&:event_id)).to eq([u1,u2,u3])
+
+      expect(repository.read_all_streams_backward(:head, 3).map(&:event_id)).to eq([u3,u2,u1])
+      expect(repository.read_events_backward("all", :head, 3).map(&:event_id)).to eq([u3,u2,u1])
+      expect(repository.read_stream_events_backward("all").map(&:event_id)).to eq([u3,u2,u1])
     end
 
     specify "explicit ORDER BY position" do

--- a/rails_event_store_active_record/spec/event_repository_spec.rb
+++ b/rails_event_store_active_record/spec/event_repository_spec.rb
@@ -138,6 +138,27 @@ module RailsEventStoreActiveRecord
       expect(repository.read_stream_events_backward("all").map(&:event_id)).to eq([u3,u2,u1])
     end
 
+    specify do
+      expect_query(/SELECT.*FROM.*event_store_events_in_streams.*WHERE.*event_store_events_in_streams.*stream.*=.*ORDER BY id ASC LIMIT.*/) do
+        repository = EventRepository.new
+        repository.read_all_streams_forward(:head, 3)
+      end
+    end
+
+    specify do
+      expect_query(/SELECT.*FROM.*event_store_events_in_streams.*WHERE.*event_store_events_in_streams.*stream.*=.*ORDER BY id ASC LIMIT.*/) do
+        repository = EventRepository.new
+        repository.read_events_forward("all", :head, 3)
+      end
+    end
+
+    specify do
+      expect_query(/SELECT.*FROM.*event_store_events_in_streams.*WHERE.*event_store_events_in_streams.*stream.*=.*ORDER BY id ASC.*/) do
+        repository = EventRepository.new
+        repository.read_stream_events_forward("all")
+      end
+    end
+
     specify "explicit ORDER BY position" do
       expect_query(/SELECT.*FROM.*event_store_events_in_streams.*WHERE.*event_store_events_in_streams.*stream.*=.*ORDER BY position DESC LIMIT.*/) do
         repository = EventRepository.new

--- a/rails_event_store_active_record/spec/event_repository_spec.rb
+++ b/rails_event_store_active_record/spec/event_repository_spec.rb
@@ -129,6 +129,8 @@ module RailsEventStoreActiveRecord
       )
       repository = EventRepository.new
       expect(repository.read_all_streams_forward(:head, 3).map(&:event_id)).to eq([u1,u2,u3])
+      expect(repository.read_events_forward("all", :head, 3).map(&:event_id)).to eq([u1,u2,u3])
+      expect(repository.read_stream_events_forward("all").map(&:event_id)).to eq([u1,u2,u3])
     end
 
     specify "explicit ORDER BY position" do

--- a/rails_event_store_active_record/spec/event_repository_spec.rb
+++ b/rails_event_store_active_record/spec/event_repository_spec.rb
@@ -91,6 +91,9 @@ module RailsEventStoreActiveRecord
       repository = EventRepository.new
       expect(repository.read_events_forward('stream', :head, 3).map(&:event_id)).to eq([u1,u2,u3])
       expect(repository.read_stream_events_forward('stream').map(&:event_id)).to eq([u1,u2,u3])
+
+      expect(repository.read_events_backward('stream', :head, 3).map(&:event_id)).to eq([u3,u2,u1])
+      expect(repository.read_stream_events_backward('stream').map(&:event_id)).to eq([u3,u2,u1])
     end
 
     specify "explicit sorting by position rather than accidental for all events" do


### PR DESCRIPTION
When reading via dedicated reader for traversing all streams we sort
event records by "id" only.

For traversing particular stream we primarily sort by "position", in
addition to "id".

We allow explicitly passing "all" stream to traverse this particular
stream and this is where discrepancy in resulting order appears.

Not sure if RDBMS beyond sqlite are affected.