### PR TITLE
Remove ActiveSupport dependency

### DIFF
--- a/aggregate_root/aggregate_root.gemspec
+++ b/aggregate_root/aggregate_root.gemspec
@@ -30,6 +30,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.6'
   spec.add_development_dependency 'ruby_event_store', '= 0.27.1'
   spec.add_development_dependency 'mutant-rspec', '~> 0.8.14'
-
-  spec.add_dependency 'activesupport', '>= 3.0'
 end

--- a/aggregate_root/lib/aggregate_root.rb
+++ b/aggregate_root/lib/aggregate_root.rb
@@ -1,4 +1,3 @@
-require 'active_support/inflector'
 require 'aggregate_root/version'
 require 'aggregate_root/configuration'
 require 'aggregate_root/default_apply_strategy'

--- a/aggregate_root/lib/aggregate_root/default_apply_strategy.rb
+++ b/aggregate_root/lib/aggregate_root/default_apply_strategy.rb
@@ -19,11 +19,20 @@ module AggregateRoot
     private
 
     def handler_name_by_class(event_class)
-      "apply_#{event_class.name.demodulize.underscore}"
+      "apply_#{to_snake_case(event_class.name)}"
     end
 
     def handler_name(event)
       on_methods.fetch(event.class){ handler_name_by_class(event.class) }
+    end
+
+    def to_snake_case(class_name)
+      class_name
+        .split("::")
+        .last
+        .gsub(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
+        .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+        .downcase
     end
 
     private

--- a/aggregate_root/lib/aggregate_root/default_apply_strategy.rb
+++ b/aggregate_root/lib/aggregate_root/default_apply_strategy.rb
@@ -18,12 +18,12 @@ module AggregateRoot
 
     private
 
-    def handler_name_by_class(event_class)
-      "apply_#{to_snake_case(event_class.name)}"
+    def handler_name(event)
+      on_methods.fetch(event.class) { handler_name_by_class(event.class) }
     end
 
-    def handler_name(event)
-      on_methods.fetch(event.class){ handler_name_by_class(event.class) }
+    def handler_name_by_class(event_class)
+      "apply_#{to_snake_case(event_class.name)}"
     end
 
     def to_snake_case(class_name)

--- a/aggregate_root/spec/aggregate_root_spec.rb
+++ b/aggregate_root/spec/aggregate_root_spec.rb
@@ -32,11 +32,13 @@ RSpec.describe AggregateRoot do
     stream = "any-order-stream"
     order_created = Orders::Events::OrderCreated.new
     order_expired = Orders::Events::OrderExpired.new
+    order_complicated = Orders::Events::OrderA1BcdEFghI2Jz.new
 
     order = Order.new
     order.apply(order_created)
     order.apply(order_expired)
-    expect(event_store).to receive(:publish_events).with([order_created, order_expired], stream_name: stream, expected_version: -1).and_call_original
+    order.apply(order_complicated)
+    expect(event_store).to receive(:publish_events).with([order_created, order_expired, order_complicated], stream_name: stream, expected_version: -1).and_call_original
     order.store(stream, event_store: event_store)
     expect(order.unpublished_events.to_a).to be_empty
   end

--- a/aggregate_root/spec/spec_helper.rb
+++ b/aggregate_root/spec/spec_helper.rb
@@ -15,6 +15,7 @@ module Orders
   module Events
     OrderCreated = Class.new(RubyEventStore::Event)
     OrderExpired = Class.new(RubyEventStore::Event)
+    OrderA1BcdEFghI2Jz = Class.new(RubyEventStore::Event)
     SpanishInquisition = Class.new(RubyEventStore::Event)
   end
 end
@@ -36,6 +37,10 @@ class Order
 
   def apply_order_expired(_event)
     @status = :expired
+  end
+
+  def apply_order_a1_bcd_e_fgh_i2_jz(_event)
+    @status = :all_your_base_are_belong_to_us
   end
 end
 


### PR DESCRIPTION
`to_snake_case` is almost copied from Rails
[underscore](http://api.rubyonrails.org/classes/ActiveSupport/Inflector.html#method-i-underscore)
implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/railseventstore/rails_event_store/288)
<!-- Reviewable:end -->
