### PR TITLE
Circle cache gems - RES

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,10 +87,4 @@ workflows:
   version: 2
   test_mutate:
     jobs:
-    - ruby_event_store
     - rails_event_store
-    - rails_event_store_active_record
-    - aggregate_root
-    - rails_event_store-rspec
-    - rails_event_store-browser
-    - bounded_context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,9 +28,11 @@ jobs:
     steps:
       - run: brew install sqlite3
       - checkout
+      - run: "date +'Cache for week: %U of %Y' >> rails_event_store/CacheBust"
       - restore_cache:
           keys:
-          - v1-rails_event_store-{{ checksum "rails_event_store/Gemfile" }}-{{ checksum "rails_event_store/rails_event_store.gemspec" }}
+          - v1-rails_event_store-{{ checksum "rails_event_store/Gemfile" }}-{{ checksum "rails_event_store/rails_event_store.gemspec" }}-{{ checksum "rails_event_store/CacheBust" }}
+          - v1-rails_event_store-{{ checksum "rails_event_store/Gemfile" }}-{{ checksum "rails_event_store/rails_event_store.gemspec" }}-
           - v1-rails_event_store-
       - run:
           name: make install
@@ -42,7 +44,7 @@ jobs:
       - save_cache:
           paths:
             - rails_event_store/vendor/bundle
-          key: v1-rails_event_store-{{ checksum "rails_event_store/Gemfile" }}-{{ checksum "rails_event_store/rails_event_store.gemspec" }}
+          key: v1-rails_event_store-{{ checksum "rails_event_store/Gemfile" }}-{{ checksum "rails_event_store/rails_event_store.gemspec" }}-{{ checksum "rails_event_store/CacheBust" }}
       - run:
           name: make mutate
           working_directory: rails_event_store

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,8 @@ jobs:
           name: make mutate
           working_directory: rails_event_store
           command: make mutate
+          environment:
+            BUNDLE_PATH: vendor/bundle
 
   rails_event_store-rspec:
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,4 +91,10 @@ workflows:
   version: 2
   test_mutate:
     jobs:
+    - ruby_event_store
     - rails_event_store
+    - rails_event_store_active_record
+    - aggregate_root
+    - rails_event_store-rspec
+    - rails_event_store-browser
+    - bounded_context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,14 +24,29 @@ jobs:
   rails_event_store:
     macos:
       xcode: "9.3.0"
+    working_directory: ~/res
     steps:
       - run: brew install sqlite3
       - checkout
+      - restore_cache:
+          keys:
+          - v1-rails_event_store-{{ checksum "rails_event_store/Gemfile" }}-{{ checksum "rails_event_store/rails_event_store.gemspec" }}
+          - v1-rails_event_store-
       - run:
-          name: make install mutate
-          command: cd rails_event_store && make install mutate
+          name: make install
+          working_directory: rails_event_store
+          command: make install
           environment:
             ARCHFLAGS: "-arch x86_64"
+            BUNDLE_PATH: vendor/bundle
+      - save_cache:
+          paths:
+            - rails_event_store/vendor/bundle
+          key: v1-rails_event_store-{{ checksum "rails_event_store/Gemfile" }}-{{ checksum "rails_event_store/rails_event_store.gemspec" }}
+      - run:
+          name: make mutate
+          working_directory: rails_event_store
+          command: make mutate
 
   rails_event_store-rspec:
     macos:


### PR DESCRIPTION
This saves around 90s per build when all gems are already in the cache.

Normal apps use strategy based on `{{ checksum "Gemfile.lock" }}` but we as a library don't commit that file. We run mutation testing on newest versions of Rails etc.

Cache in CircleCI is immutable and stored once.

Let's use new cache key every week to cache newest state of dependencies.

It's not a problem if we restore old cache. Bundler will just take a
little more time to install uncached dependencies. We try 3 potential
keys for restoration.

We also expire cache when Gemfile is changed or gemspec.

More on how this works on CircleCI: https://circleci.com/docs/2.0/caching/

Issue: #286