### PR TITLE
Fluent API, part two.

### DIFF
--- a/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
@@ -37,57 +37,6 @@ module RailsEventStoreActiveRecord
       @repo_reader.last_stream_event(stream)
     end
 
-    def read_events_forward(stream, after_event_id, count)
-      RubyEventStore::Specification.new(self)
-        .stream(stream.name)
-        .from(after_event_id)
-        .limit(count)
-        .each
-        .to_a
-    end
-
-    def read_events_backward(stream, before_event_id, count)
-      RubyEventStore::Specification.new(self)
-        .stream(stream.name)
-        .from(before_event_id)
-        .limit(count)
-        .backward
-        .each
-        .to_a
-    end
-
-    def read_stream_events_forward(stream)
-      RubyEventStore::Specification.new(self)
-        .stream(stream.name)
-        .each
-        .to_a
-    end
-
-    def read_stream_events_backward(stream)
-      RubyEventStore::Specification.new(self)
-        .stream(stream.name)
-        .backward
-        .each
-        .to_a
-    end
-
-    def read_all_streams_forward(after_event_id, count)
-      RubyEventStore::Specification.new(self)
-        .from(after_event_id)
-        .limit(count)
-        .each
-        .to_a
-    end
-
-    def read_all_streams_backward(before_event_id, count)
-      RubyEventStore::Specification.new(self)
-        .from(before_event_id)
-        .limit(count)
-        .backward
-        .each
-        .to_a
-    end
-
     def read_event(event_id)
       @repo_reader.read_event(event_id)
     end

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/legacy_event_repository.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/legacy_event_repository.rb
@@ -54,57 +54,6 @@ instead:
       build_event_entity(LegacyEvent.where(stream: stream.name).last)
     end
 
-    def read_events_forward(stream, start_event_id, count)
-      RubyEventStore::Specification.new(self)
-        .stream(stream.name)
-        .from(start_event_id)
-        .limit(count)
-        .each
-        .to_a
-    end
-
-    def read_events_backward(stream, start_event_id, count)
-      RubyEventStore::Specification.new(self)
-        .stream(stream.name)
-        .from(start_event_id)
-        .limit(count)
-        .backward
-        .each
-        .to_a
-    end
-
-    def read_stream_events_forward(stream)
-      RubyEventStore::Specification.new(self)
-        .stream(stream.name)
-        .each
-        .to_a
-    end
-
-    def read_stream_events_backward(stream)
-      RubyEventStore::Specification.new(self)
-        .stream(stream.name)
-        .backward
-        .each
-        .to_a
-    end
-
-    def read_all_streams_forward(start_event_id, count)
-      RubyEventStore::Specification.new(self)
-        .from(start_event_id)
-        .limit(count)
-        .each
-        .to_a
-    end
-
-    def read_all_streams_backward(start_event_id, count)
-      RubyEventStore::Specification.new(self)
-        .from(start_event_id)
-        .limit(count)
-        .backward
-        .each
-        .to_a
-    end
-
     def read_event(event_id)
       build_event_entity(LegacyEvent.find_by(event_id: event_id)) or raise RubyEventStore::EventNotFound.new(event_id)
     end

--- a/rails_event_store_active_record/spec/event_repository_spec.rb
+++ b/rails_event_store_active_record/spec/event_repository_spec.rb
@@ -32,51 +32,36 @@ module RailsEventStoreActiveRecord
         RubyEventStore::Stream.new(RubyEventStore::GLOBAL_STREAM),
         RubyEventStore::ExpectedVersion.any
       )
-      reserved_stream = RubyEventStore::Stream.new("all")
 
-      expect{ repository.read_stream_events_forward(reserved_stream) }.to raise_error(RubyEventStore::ReservedInternalName)
-      expect{ repository.read_stream_events_backward(reserved_stream) }.to raise_error(RubyEventStore::ReservedInternalName)
-      expect{ repository.read_events_forward(reserved_stream, :head, 5) }.to raise_error(RubyEventStore::ReservedInternalName)
-      expect{ repository.read_events_backward(reserved_stream, :head, 5) }.to raise_error(RubyEventStore::ReservedInternalName)
-    end
-
-    specify "all considered internal detail" do
-      repository = EventRepository.new
-      repository.append_to_stream(
-        [event = SRecord.new],
-        RubyEventStore::Stream.new(RubyEventStore::GLOBAL_STREAM),
-        RubyEventStore::ExpectedVersion.any
-      )
-      specification = RubyEventStore::Specification.new(repository)
-
-      expect{ repository.read(specification.stream("all").result) }.to raise_error(RubyEventStore::ReservedInternalName)
-      expect{ repository.read(specification.stream("all").backward.result) }.to raise_error(RubyEventStore::ReservedInternalName)
-      expect{ repository.read(specification.stream("all").from(:head).limit(5).result) }.to raise_error(RubyEventStore::ReservedInternalName)
-      expect{ repository.read(specification.stream("all").from(:head).limit(5).backward.result) }.to raise_error(RubyEventStore::ReservedInternalName)
+      expect{ repository.read(RubyEventStore::Specification.new(repository).stream("all").result) }.to raise_error(RubyEventStore::ReservedInternalName)
+      expect{ repository.read(RubyEventStore::Specification.new(repository).stream("all").backward.result) }.to raise_error(RubyEventStore::ReservedInternalName)
+      expect{ repository.read(RubyEventStore::Specification.new(repository).stream("all").from(:head).limit(5).result) }.to raise_error(RubyEventStore::ReservedInternalName)
+      expect{ repository.read(RubyEventStore::Specification.new(repository).stream("all").from(:head).limit(5).backward.result) }.to raise_error(RubyEventStore::ReservedInternalName)
     end
 
     specify "using preload()" do
       repository = EventRepository.new
+      
       repository.append_to_stream([
         event0 = SRecord.new,
         event1 = SRecord.new,
       ], RubyEventStore::Stream.new('stream'), RubyEventStore::ExpectedVersion.auto)
-      c1 = count_queries{ repository.read_all_streams_forward(:head, 2) }
+      c1 = count_queries{ repository.read(RubyEventStore::Specification.new(repository).from(:head).limit(2).result) }
       expect(c1).to eq(2)
 
-      c2 = count_queries{ repository.read_all_streams_backward(:head, 2) }
+      c2 = count_queries{ repository.read(RubyEventStore::Specification.new(repository).from(:head).limit(2).backward.result) }
       expect(c2).to eq(2)
 
-      c3 = count_queries{ repository.read_stream_events_forward(RubyEventStore::Stream.new('stream')) }
+      c3 = count_queries{ repository.read(RubyEventStore::Specification.new(repository).stream("stream").result) }
       expect(c3).to eq(2)
 
-      c4 = count_queries{ repository.read_stream_events_backward(RubyEventStore::Stream.new('stream')) }
+      c4 = count_queries{ repository.read(RubyEventStore::Specification.new(repository).stream("stream").backward.result) }
       expect(c4).to eq(2)
 
-      c5 = count_queries{ repository.read_events_forward(RubyEventStore::Stream.new('stream'), :head, 2) }
+      c5 = count_queries{ repository.read(RubyEventStore::Specification.new(repository).stream("stream").from(:head).limit(2).result) }
       expect(c5).to eq(2)
 
-      c6 = count_queries{ repository.read_events_backward(RubyEventStore::Stream.new('stream'), :head, 2) }
+      c6 = count_queries{ repository.read(RubyEventStore::Specification.new(repository).stream("stream").from(:head).limit(2).backward.result) }
       expect(c6).to eq(2)
     end
 
@@ -119,11 +104,13 @@ module RailsEventStoreActiveRecord
         remove_index :event_store_events_in_streams, [:stream, :position]
       end
       repository = EventRepository.new
-      expect(repository.read_events_forward(RubyEventStore::Stream.new('stream'), :head, 3).map(&:event_id)).to eq([u1,u2,u3])
-      expect(repository.read_stream_events_forward(RubyEventStore::Stream.new('stream')).map(&:event_id)).to eq([u1,u2,u3])
+      
 
-      expect(repository.read_events_backward(RubyEventStore::Stream.new('stream'), :head, 3).map(&:event_id)).to eq([u3,u2,u1])
-      expect(repository.read_stream_events_backward(RubyEventStore::Stream.new('stream')).map(&:event_id)).to eq([u3,u2,u1])
+      expect(repository.read(RubyEventStore::Specification.new(repository).stream("stream").from(:head).limit(3).result).map(&:event_id)).to eq([u1,u2,u3])
+      expect(repository.read(RubyEventStore::Specification.new(repository).stream("stream").result).map(&:event_id)).to eq([u1,u2,u3])
+
+      expect(repository.read(RubyEventStore::Specification.new(repository).stream("stream").backward.from(:head).limit(3).result).map(&:event_id)).to eq([u3,u2,u1])
+      expect(repository.read(RubyEventStore::Specification.new(repository).stream("stream").backward.result).map(&:event_id)).to eq([u3,u2,u1])
     end
 
     specify "explicit sorting by id rather than accidental for all events" do
@@ -162,21 +149,21 @@ module RailsEventStoreActiveRecord
       )
       repository = EventRepository.new
 
-      expect(repository.read_all_streams_forward(:head, 3).map(&:event_id)).to eq([u1,u2,u3])
-      expect(repository.read_all_streams_backward(:head, 3).map(&:event_id)).to eq([u3,u2,u1])
+      expect(repository.read(RubyEventStore::Specification.new(repository).from(:head).limit(3).result).map(&:event_id)).to eq([u1,u2,u3])
+      expect(repository.read(RubyEventStore::Specification.new(repository).from(:head).limit(3).backward.result).map(&:event_id)).to eq([u3,u2,u1])
     end
 
     specify do
       expect_query(/SELECT.*FROM.*event_store_events_in_streams.*WHERE.*event_store_events_in_streams.*stream.*=.*ORDER BY .*event_store_events_in_streams.*id.* ASC LIMIT.*/) do
         repository = EventRepository.new
-        repository.read_all_streams_forward(:head, 3)
+        repository.read(RubyEventStore::Specification.new(repository).from(:head).limit(3).result)
       end
     end
 
     specify do
       expect_query(/SELECT.*FROM.*event_store_events_in_streams.*WHERE.*event_store_events_in_streams.*stream.*=.*ORDER BY .*event_store_events_in_streams.*id.* DESC LIMIT.*/) do
         repository = EventRepository.new
-        repository.read_all_streams_backward(:head, 3)
+        repository.read(RubyEventStore::Specification.new(repository).from(:head).limit(3).backward.result)
       end
     end
 
@@ -204,10 +191,10 @@ module RailsEventStoreActiveRecord
           ], RubyEventStore::Stream.new('stream'), RubyEventStore::ExpectedVersion.none)
         end.to raise_error(RubyEventStore::WrongExpectedEventVersion)
         expect(repository.has_event?('9bedf448-e4d0-41a3-a8cd-f94aec7aa763')).to be_falsey
-        expect(repository.read_all_streams_forward(:head, 2)).to eq([event])
+        expect(repository.read(RubyEventStore::Specification.new(repository).from(:head).limit(2).result).to_a).to eq([event])
       end
       expect(repository.has_event?('9bedf448-e4d0-41a3-a8cd-f94aec7aa763')).to be_falsey
-      expect(repository.read_all_streams_forward(:head, 2)).to eq([event])
+      expect(repository.read(RubyEventStore::Specification.new(repository).from(:head).limit(2).result).to_a).to eq([event])
     end
 
     specify "limited query when looking for unexisting events during linking" do

--- a/rails_event_store_active_record/spec/v1_v2_schema_migration_spec.rb
+++ b/rails_event_store_active_record/spec/v1_v2_schema_migration_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "v1_v2_migration" do
   end
 
   def verify_all_events_stream
-    events = repository.read_all_streams_forward(:head, 100)
+    events = repository.read(RubyEventStore::Specification.new(repository).from(:head).limit(100).result)
     expect(events.size).to eq(9)
     expect(events.map(&:event_id)).to eq(%w(
       94b297a3-5a29-4942-9038-3efeceb4d905
@@ -99,7 +99,8 @@ RSpec.describe "v1_v2_migration" do
   end
 
   def verify_event_sourced_stream
-    events = repository.read_stream_events_forward(RubyEventStore::Stream.new("Order-1"))
+    events = repository.read(RubyEventStore::Specification.new(repository).stream("Order-1").result)
+
     expect(events.map(&:event_id)).to eq(%w(
       d39cb65f-bc3c-4fbb-9470-52bf5e322bba
       f2cecc51-adb1-4d83-b3ca-483d26311f03
@@ -124,7 +125,7 @@ RSpec.describe "v1_v2_migration" do
   end
 
   def verify_technical_stream
-    events = repository.read_stream_events_forward(RubyEventStore::Stream.new("WroclawBuyers"))
+    events = repository.read(RubyEventStore::Specification.new(repository).stream("WroclawBuyers").result)
     expect(events.map(&:event_id)).to eq(%w(
       9009df88-6044-4a62-b7ae-098c42a9c5e1
       cefdd213-0c92-46f6-bbdf-3ea9542d969a

--- a/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
+++ b/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
@@ -28,58 +28,7 @@ module RubyEventStore
     end
 
     def last_stream_event(stream)
-      read_stream_events_forward(stream).last
-    end
-
-    def read_events_forward(stream, start_event_id, count)
-      Specification.new(self)
-        .stream(stream.name)
-        .from(start_event_id)
-        .limit(count)
-        .each
-        .to_a
-    end
-
-    def read_events_backward(stream, start_event_id, count)
-      Specification.new(self)
-        .stream(stream.name)
-        .from(start_event_id)
-        .limit(count)
-        .backward
-        .each
-        .to_a
-    end
-
-    def read_stream_events_forward(stream)
-      Specification.new(self)
-        .stream(stream.name)
-        .each
-        .to_a
-    end
-
-    def read_stream_events_backward(stream)
-      Specification.new(self)
-        .stream(stream.name)
-        .backward
-        .each
-        .to_a
-    end
-
-    def read_all_streams_forward(start_event_id, count)
-      Specification.new(self)
-        .from(start_event_id)
-        .limit(count)
-        .each
-        .to_a
-    end
-
-    def read_all_streams_backward(start_event_id, count)
-      Specification.new(self)
-        .from(start_event_id)
-        .limit(count)
-        .backward
-        .each
-        .to_a
+      stream_of(stream.name).last
     end
 
     def read_event(event_id)
@@ -109,7 +58,7 @@ module RubyEventStore
     end
 
     def last_stream_version(stream)
-      read_stream_events_forward(stream).size - 1
+      stream_of(stream.name).size - 1
     end
 
     def append_with_synchronize(events, expected_version, stream, include_global)

--- a/ruby_event_store_rom_sql/lib/ruby_event_store/rom/event_repository.rb
+++ b/ruby_event_store_rom_sql/lib/ruby_event_store/rom/event_repository.rb
@@ -57,57 +57,6 @@ module RubyEventStore
           .first
       end
 
-      def read_events_forward(stream, after_event_id, count)
-        RubyEventStore::Specification.new(self)
-          .stream(stream.name)
-          .from(after_event_id)
-          .limit(count)
-          .each
-          .to_a
-      end
-
-      def read_events_backward(stream, before_event_id, count)
-        RubyEventStore::Specification.new(self)
-          .stream(stream.name)
-          .from(before_event_id)
-          .limit(count)
-          .backward
-          .each
-          .to_a
-      end
-
-      def read_stream_events_forward(stream)
-        RubyEventStore::Specification.new(self)
-          .stream(stream.name)
-          .each
-          .to_a
-      end
-
-      def read_stream_events_backward(stream)
-        RubyEventStore::Specification.new(self)
-          .stream(stream.name)
-          .backward
-          .each
-          .to_a
-      end
-
-      def read_all_streams_forward(after_event_id, count)
-        RubyEventStore::Specification.new(self)
-          .from(after_event_id)
-          .limit(count)
-          .each
-          .to_a
-      end
-
-      def read_all_streams_backward(before_event_id, count)
-        RubyEventStore::Specification.new(self)
-          .from(before_event_id)
-          .limit(count)
-          .backward
-          .each
-          .to_a
-      end
-
       def read_event(event_id)
         @events.by_id(event_id)
       rescue => ex

--- a/ruby_event_store_rom_sql/spec/rom/event_repository_spec.rb
+++ b/ruby_event_store_rom_sql/spec/rom/event_repository_spec.rb
@@ -36,25 +36,10 @@ module RubyEventStore::ROM
       )
       reserved_stream = RubyEventStore::Stream.new("all")
 
-      expect{ repository.read_stream_events_forward(reserved_stream) }.to raise_error(RubyEventStore::ReservedInternalName)
-      expect{ repository.read_stream_events_backward(reserved_stream) }.to raise_error(RubyEventStore::ReservedInternalName)
-      expect{ repository.read_events_forward(reserved_stream, :head, 5) }.to raise_error(RubyEventStore::ReservedInternalName)
-      expect{ repository.read_events_backward(reserved_stream, :head, 5) }.to raise_error(RubyEventStore::ReservedInternalName)
-    end
-
-    specify "all considered internal detail" do
-      repository = EventRepository.new
-      repository.append_to_stream(
-        [event = SRecord.new],
-        RubyEventStore::Stream.new(RubyEventStore::GLOBAL_STREAM),
-        RubyEventStore::ExpectedVersion.any
-      )
-      specification = RubyEventStore::Specification.new(repository)
-
-      expect{ repository.read(specification.stream("all").result) }.to raise_error(RubyEventStore::ReservedInternalName)
-      expect{ repository.read(specification.stream("all").backward.result) }.to raise_error(RubyEventStore::ReservedInternalName)
-      expect{ repository.read(specification.stream("all").from(:head).limit(5).result) }.to raise_error(RubyEventStore::ReservedInternalName)
-      expect{ repository.read(specification.stream("all").from(:head).limit(5).backward.result) }.to raise_error(RubyEventStore::ReservedInternalName)
+      expect{ repository.read(RubyEventStore::Specification.new(repository).stream("all").result) }.to raise_error(RubyEventStore::ReservedInternalName)
+      expect{ repository.read(RubyEventStore::Specification.new(repository).stream("all").backward.result) }.to raise_error(RubyEventStore::ReservedInternalName)
+      expect{ repository.read(RubyEventStore::Specification.new(repository).stream("all").from(:head).limit(5).result) }.to raise_error(RubyEventStore::ReservedInternalName)
+      expect{ repository.read(RubyEventStore::Specification.new(repository).stream("all").from(:head).limit(5).backward.result) }.to raise_error(RubyEventStore::ReservedInternalName)
     end
 
     # TODO: Port from AR to ROM
@@ -64,22 +49,22 @@ module RubyEventStore::ROM
         SRecord.new,
         SRecord.new,
       ], default_stream, RubyEventStore::ExpectedVersion.auto)
-      c1 = count_queries{ repository.read_all_streams_forward(:head, 2) }
+      c1 = count_queries{ repository.read(RubyEventStore::Specification.new(repository).from(:head).limit(2).result) }
       expect(c1).to eq(2)
 
-      c2 = count_queries{ repository.read_all_streams_backward(:head, 2) }
+      c2 = count_queries{ repository.read(RubyEventStore::Specification.new(repository).from(:head).limit(2).backward.result) }
       expect(c2).to eq(2)
 
-      c3 = count_queries{ repository.read_stream_events_forward(default_stream) }
+      c3 = count_queries{ repository.read(RubyEventStore::Specification.new(repository).stream("stream").result) }
       expect(c3).to eq(2)
 
-      c4 = count_queries{ repository.read_stream_events_backward(default_stream) }
+      c4 = count_queries{ repository.read(RubyEventStore::Specification.new(repository).stream("stream").backward.result) }
       expect(c4).to eq(2)
 
-      c5 = count_queries{ repository.read_events_forward(default_stream, :head, 2) }
+      c5 = count_queries{ repository.read(RubyEventStore::Specification.new(repository).stream("stream").from(:head).limit(2).result) }
       expect(c5).to eq(2)
 
-      c6 = count_queries{ repository.read_events_backward(default_stream, :head, 2) }
+      c6 = count_queries{ repository.read(RubyEventStore::Specification.new(repository).stream("stream").from(:head).limit(2).backward.result) }
       expect(c6).to eq(2)
     end
 
@@ -125,11 +110,11 @@ module RubyEventStore::ROM
       # end
       repository = EventRepository.new(rom: rom)
 
-      expect(repository.read_events_forward(default_stream, :head, 3).map(&:event_id)).to eq([u1,u2,u3])
-      expect(repository.read_stream_events_forward(default_stream).map(&:event_id)).to eq([u1,u2,u3])
+      expect(repository.read(RubyEventStore::Specification.new(repository).stream("stream").from(:head).limit(3).result).map(&:event_id)).to eq([u1,u2,u3])
+      expect(repository.read(RubyEventStore::Specification.new(repository).stream("stream").result).map(&:event_id)).to eq([u1,u2,u3])
 
-      expect(repository.read_events_backward(default_stream, :head, 3).map(&:event_id)).to eq([u3,u2,u1])
-      expect(repository.read_stream_events_backward(default_stream).map(&:event_id)).to eq([u3,u2,u1])
+      expect(repository.read(RubyEventStore::Specification.new(repository).stream("stream").backward.from(:head).limit(3).result).map(&:event_id)).to eq([u3,u2,u1])
+      expect(repository.read(RubyEventStore::Specification.new(repository).stream("stream").backward.result).map(&:event_id)).to eq([u3,u2,u1])
     end
 
     specify "explicit sorting by id rather than accidental for all events" do
@@ -170,15 +155,15 @@ module RubyEventStore::ROM
       
       repository = EventRepository.new(rom: rom)
 
-      expect(repository.read_all_streams_forward(:head, 3).map(&:event_id)).to eq([u1,u2,u3])
-      expect(repository.read_all_streams_backward(:head, 3).map(&:event_id)).to eq([u3,u2,u1])
+      expect(repository.read(RubyEventStore::Specification.new(repository).from(:head).limit(3).result).map(&:event_id)).to eq([u1,u2,u3])
+      expect(repository.read(RubyEventStore::Specification.new(repository).from(:head).limit(3).backward.result).map(&:event_id)).to eq([u3,u2,u1])
     end
 
     # TODO: Port from AR to ROM
     xspecify do
       expect_query(/SELECT.*FROM.*event_store_events_in_streams.*WHERE.*event_store_events_in_streams.*stream.*=.*ORDER BY id ASC LIMIT.*/) do
         repository = EventRepository.new
-        repository.read_all_streams_forward(:head, 3)
+        repository.read(RubyEventStore::Specification.new(repository).from(:head).limit(3).result)
       end
     end
 
@@ -186,7 +171,7 @@ module RubyEventStore::ROM
     xspecify do
       expect_query(/SELECT.*FROM.*event_store_events_in_streams.*WHERE.*event_store_events_in_streams.*stream.*=.*ORDER BY id DESC LIMIT.*/) do
         repository = EventRepository.new
-        repository.read_all_streams_backward(:head, 3)
+        repository.read(RubyEventStore::Specification.new(repository).from(:head).limit(3).backward.result)
       end
     end
 
@@ -215,10 +200,10 @@ module RubyEventStore::ROM
           ], default_stream, RubyEventStore::ExpectedVersion.none)
         end.to raise_error(RubyEventStore::WrongExpectedEventVersion)
         expect(repository.has_event?('9bedf448-e4d0-41a3-a8cd-f94aec7aa763')).to be_falsey
-        expect(repository.read_all_streams_forward(:head, 2)).to eq([event])
+        expect(repository.read(RubyEventStore::Specification.new(repository).from(:head).limit(2).result).to_a).to eq([event])
       end
       expect(repository.has_event?('9bedf448-e4d0-41a3-a8cd-f94aec7aa763')).to be_falsey
-      expect(repository.read_all_streams_forward(:head, 2)).to eq([event])
+      expect(repository.read(RubyEventStore::Specification.new(repository).from(:head).limit(2).result).to_a).to eq([event])
     end
 
     # TODO: Port from AR to ROM


### PR DESCRIPTION
## Internal

- [ ] Rewrite old repository API usage in specs

## External

- [ ] Can `Client#read_event` be implemented with fluent as well? Or is it more like `find`?
- [ ] Make `Client#read` public, releasing fluent API to RES consumers
- [ ] Deprecate old read methods on client -- don't remove in nearest release
- [ ] Document migration strategy from old to current reader API