### PR TITLE
Add more verbose descriptions

### DIFF
--- a/rails_event_store-rspec/lib/rails_event_store/rspec/be_event.rb
+++ b/rails_event_store-rspec/lib/rails_event_store/rspec/be_event.rb
@@ -115,9 +115,9 @@ module RailsEventStore
       include ::RSpec::Matchers::Composable
 
       def initialize(expected, differ:, formatter:)
+        @expected  = expected
         @differ    = differ
         @formatter = formatter
-        @expected  = expected
       end
 
       def matches?(actual)
@@ -152,7 +152,15 @@ expected: not a kind of #{expected}
       end
 
       def description
-        "be event #{formatter.(expected)}"
+        "be an event #{formatter.(expected)}#{data_and_metadata_expectations_description}"
+      end
+
+      def data_and_metadata_expectations_description
+        predicate = strict? ? "matching" : "including"
+        expectation_list = []
+        expectation_list << "with data #{predicate} #{formatter.(expected_data)}" if expected_data
+        expectation_list << "with metadata #{predicate} #{formatter.(expected_metadata)}" if expected_metadata
+        " (#{expectation_list.join(" and ")})" if expectation_list.any?
       end
 
       private

--- a/rails_event_store-rspec/lib/rails_event_store/rspec/have_applied.rb
+++ b/rails_event_store-rspec/lib/rails_event_store/rspec/have_applied.rb
@@ -1,12 +1,11 @@
 module RailsEventStore
   module RSpec
     class HaveApplied
-      def initialize(mandatory_expected, *optional_expected, differ:, formatter:, lister:)
+      def initialize(mandatory_expected, *optional_expected, differ:, phraser:)
         @expected  = [mandatory_expected, *optional_expected]
         @matcher   = ::RSpec::Matchers::BuiltIn::Include.new(*expected)
         @differ    = differ
-        @formatter = formatter
-        @lister    = lister
+        @phraser    = phraser
       end
 
       def matches?(aggregate_root)
@@ -39,7 +38,7 @@ module RailsEventStore
       end
 
       def description
-        "have applied events that have to (#{lister.(expected).strip})"
+        "have applied events that have to (#{phraser.(expected).strip})"
       end
 
       private
@@ -53,7 +52,7 @@ module RailsEventStore
         end
       end
 
-      attr_reader :formatter, :differ, :lister, :expected, :events, :count, :matcher
+      attr_reader :differ, :phraser, :expected, :events, :count, :matcher
     end
   end
 end

--- a/rails_event_store-rspec/lib/rails_event_store/rspec/have_applied.rb
+++ b/rails_event_store-rspec/lib/rails_event_store/rspec/have_applied.rb
@@ -1,11 +1,12 @@
 module RailsEventStore
   module RSpec
     class HaveApplied
-      def initialize(mandatory_expected, *optional_expected, differ:, formatter:)
+      def initialize(mandatory_expected, *optional_expected, differ:, formatter:, lister:)
         @expected  = [mandatory_expected, *optional_expected]
         @matcher   = ::RSpec::Matchers::BuiltIn::Include.new(*expected)
         @differ    = differ
         @formatter = formatter
+        @lister    = lister
       end
 
       def matches?(aggregate_root)
@@ -38,7 +39,7 @@ module RailsEventStore
       end
 
       def description
-        "have applied [%s]" % expected.map { |e| formatter.(e) }.join(', ')
+        "have applied events that have to (#{lister.(expected).strip})"
       end
 
       private
@@ -52,7 +53,7 @@ module RailsEventStore
         end
       end
 
-      attr_reader :formatter, :differ, :expected, :events, :count, :matcher
+      attr_reader :formatter, :differ, :lister, :expected, :events, :count, :matcher
     end
   end
 end

--- a/rails_event_store-rspec/lib/rails_event_store/rspec/have_published.rb
+++ b/rails_event_store-rspec/lib/rails_event_store/rspec/have_published.rb
@@ -1,12 +1,11 @@
 module RailsEventStore
   module RSpec
     class HavePublished
-      def initialize(mandatory_expected, *optional_expected, differ:, formatter:, lister:)
+      def initialize(mandatory_expected, *optional_expected, differ:, phraser:)
         @expected  = [mandatory_expected, *optional_expected]
         @matcher   = ::RSpec::Matchers::BuiltIn::Include.new(*expected)
         @differ    = differ
-        @formatter = formatter
-        @lister    = lister
+        @phraser   = phraser
       end
 
       def matches?(event_store)
@@ -45,7 +44,7 @@ module RailsEventStore
       end
 
       def description
-        "have published events that have to (#{lister.(expected).strip})"
+        "have published events that have to (#{phraser.(expected).strip})"
       end
 
       private
@@ -59,7 +58,7 @@ module RailsEventStore
         end
       end
 
-      attr_reader :formatter, :differ, :lister, :stream_name, :expected, :count, :events
+      attr_reader :differ, :phraser, :stream_name, :expected, :count, :events
     end
   end
 end

--- a/rails_event_store-rspec/lib/rails_event_store/rspec/have_published.rb
+++ b/rails_event_store-rspec/lib/rails_event_store/rspec/have_published.rb
@@ -1,11 +1,12 @@
 module RailsEventStore
   module RSpec
     class HavePublished
-      def initialize(mandatory_expected, *optional_expected, differ:, formatter:)
+      def initialize(mandatory_expected, *optional_expected, differ:, formatter:, lister:)
         @expected  = [mandatory_expected, *optional_expected]
         @matcher   = ::RSpec::Matchers::BuiltIn::Include.new(*expected)
         @differ    = differ
         @formatter = formatter
+        @lister    = lister
       end
 
       def matches?(event_store)
@@ -44,9 +45,7 @@ module RailsEventStore
       end
 
       def description
-        "have published [%s]" % expected
-          .map { |e| formatter.(e) }
-          .join(', ')
+        "have published events that have to (#{lister.(expected).strip})"
       end
 
       private
@@ -60,7 +59,7 @@ module RailsEventStore
         end
       end
 
-      attr_reader :formatter, :differ, :stream_name, :expected, :count, :events
+      attr_reader :formatter, :differ, :lister, :stream_name, :expected, :count, :events
     end
   end
 end

--- a/rails_event_store-rspec/lib/rails_event_store/rspec/matchers.rb
+++ b/rails_event_store-rspec/lib/rails_event_store/rspec/matchers.rb
@@ -9,25 +9,25 @@ module RailsEventStore
       alias :event    :be_an_event
 
       def have_published(*expected)
-        HavePublished.new(*expected, differ: differ, formatter: formatter, lister: lister)
+        HavePublished.new(*expected, differ: differ, phraser: phraser)
       end
 
       def have_applied(*expected)
-        HaveApplied.new(*expected, differ: differ, formatter: formatter, lister: lister)
+        HaveApplied.new(*expected, differ: differ, phraser: phraser)
       end
 
       private
 
       def formatter
-        ::RSpec::Support::ObjectFormatter.method(:format)
+        ::RSpec::Support::ObjectFormatter.public_method(:format)
       end
 
       def differ
         ::RSpec::Support::Differ.new(color: ::RSpec::Matchers.configuration.color?)
       end
 
-      def lister
-        ::RSpec::Matchers::EnglishPhrasing.method(:list)
+      def phraser
+        ::RSpec::Matchers::EnglishPhrasing.public_method(:list)
       end
     end
   end

--- a/rails_event_store-rspec/lib/rails_event_store/rspec/matchers.rb
+++ b/rails_event_store-rspec/lib/rails_event_store/rspec/matchers.rb
@@ -9,11 +9,11 @@ module RailsEventStore
       alias :event    :be_an_event
 
       def have_published(*expected)
-        HavePublished.new(*expected, differ: differ, formatter: formatter)
+        HavePublished.new(*expected, differ: differ, formatter: formatter, lister: lister)
       end
 
       def have_applied(*expected)
-        HaveApplied.new(*expected, differ: differ, formatter: formatter)
+        HaveApplied.new(*expected, differ: differ, formatter: formatter, lister: lister)
       end
 
       private
@@ -24,6 +24,10 @@ module RailsEventStore
 
       def differ
         ::RSpec::Support::Differ.new(color: ::RSpec::Matchers.configuration.color?)
+      end
+
+      def lister
+        ::RSpec::Matchers::EnglishPhrasing.method(:list)
       end
     end
   end

--- a/rails_event_store-rspec/spec/rails_event_store/rspec/be_event_spec.rb
+++ b/rails_event_store-rspec/spec/rails_event_store/rspec/be_event_spec.rb
@@ -173,9 +173,39 @@ Data diff:
             .and(matcher(FooEvent).with_metadata(foo: "bar")))
       end
 
-      specify { expect(matcher(FooEvent).description).to eq("be event FooEvent") }
+      specify { expect(matcher(FooEvent).description).to eq("be an event FooEvent") }
 
-      specify { expect(matcher(kind_of(FooEvent)).description).to eq("be event kind of FooEvent") }
+      specify { expect(matcher(kind_of(FooEvent)).description).to eq("be an event kind of FooEvent") }
+
+      specify do
+        expect(matcher(FooEvent).with_data(foo: "bar").description)
+          .to eq("be an event FooEvent (with data including {:foo=>\"bar\"})")
+      end
+
+      specify do
+        expect(matcher(FooEvent).with_data(foo: "bar").strict.description)
+          .to eq("be an event FooEvent (with data matching {:foo=>\"bar\"})")
+      end
+
+      specify do
+        expect(matcher(FooEvent).with_metadata(foo: "bar").description)
+          .to eq("be an event FooEvent (with metadata including {:foo=>\"bar\"})")
+      end
+
+      specify do
+        expect(matcher(FooEvent).with_metadata(foo: "bar").strict.description)
+          .to eq("be an event FooEvent (with metadata matching {:foo=>\"bar\"})")
+      end
+
+      specify do
+        expect(matcher(FooEvent).with_metadata(foo: "bar").with_data(bar: "foo").description)
+          .to eq("be an event FooEvent (with data including {:bar=>\"foo\"} and with metadata including {:foo=>\"bar\"})")
+      end
+
+      specify do
+        expect(matcher(FooEvent).with_data(bar: "foo").with_metadata(foo: "baz").strict.description)
+            .to eq("be an event FooEvent (with data matching {:bar=>\"foo\"} and with metadata matching {:foo=>\"baz\"})")
+      end
     end
   end
 end

--- a/rails_event_store-rspec/spec/rails_event_store/rspec/be_event_spec.rb
+++ b/rails_event_store-rspec/spec/rails_event_store/rspec/be_event_spec.rb
@@ -178,6 +178,11 @@ Data diff:
       specify { expect(matcher(kind_of(FooEvent)).description).to eq("be an event kind of FooEvent") }
 
       specify do
+        expect(matcher(FooEvent).with_data(foo: kind_of(String)).description)
+            .to eq("be an event FooEvent (with data including {:foo=>kind of String})")
+      end
+
+      specify do
         expect(matcher(FooEvent).with_data(foo: "bar").description)
           .to eq("be an event FooEvent (with data including {:foo=>\"bar\"})")
       end
@@ -185,6 +190,11 @@ Data diff:
       specify do
         expect(matcher(FooEvent).with_data(foo: "bar").strict.description)
           .to eq("be an event FooEvent (with data matching {:foo=>\"bar\"})")
+      end
+
+      specify do
+        expect(matcher(FooEvent).with_metadata(foo: kind_of(String)).description)
+            .to eq("be an event FooEvent (with metadata including {:foo=>kind of String})")
       end
 
       specify do

--- a/rails_event_store-rspec/spec/rails_event_store/rspec/have_applied_spec.rb
+++ b/rails_event_store-rspec/spec/rails_event_store/rspec/have_applied_spec.rb
@@ -7,7 +7,7 @@ module RailsEventStore
       let(:aggregate_root) { TestAggregate.new }
 
       def matcher(*expected)
-        HaveApplied.new(*expected, differ: colorless_differ, formatter: formatter, lister: lister)
+        HaveApplied.new(*expected, differ: colorless_differ, phraser: phraser)
       end
 
       def colorless_differ
@@ -18,7 +18,7 @@ module RailsEventStore
         ::RSpec::Support::ObjectFormatter.method(:format)
       end
 
-      def lister
+      def phraser
         ::RSpec::Matchers::EnglishPhrasing.method(:list)
       end
 
@@ -154,7 +154,6 @@ module RailsEventStore
           matchers.an_event(FooEvent).with_metadata({ baz: "foo" }).with_data({ baz: "foo" }),
           matchers.an_event(BazEvent).with_metadata({ baz: "foo" }).with_data({ baz: "foo" })
         )
-        puts _matcher.description
         expect(_matcher.description)
           .to eq("have applied events that have to (be an event FooEvent (with data including {:baz=>\"foo\"} and with metadata including {:baz=>\"foo\"}) and be an event BazEvent (with data including {:baz=>\"foo\"} and with metadata including {:baz=>\"foo\"}))")
       end
@@ -162,8 +161,7 @@ module RailsEventStore
       specify do
         _matcher = matcher(
           FooEvent,
-          BazEvent
-        )
+          BazEvent)
         expect(_matcher.description)
           .to eq("have applied events that have to (FooEvent and BazEvent)")
       end

--- a/rails_event_store-rspec/spec/rails_event_store/rspec/have_applied_spec.rb
+++ b/rails_event_store-rspec/spec/rails_event_store/rspec/have_applied_spec.rb
@@ -7,7 +7,7 @@ module RailsEventStore
       let(:aggregate_root) { TestAggregate.new }
 
       def matcher(*expected)
-        HaveApplied.new(*expected, differ: colorless_differ, formatter: formatter)
+        HaveApplied.new(*expected, differ: colorless_differ, formatter: formatter, lister: lister)
       end
 
       def colorless_differ
@@ -16,6 +16,10 @@ module RailsEventStore
 
       def formatter
         ::RSpec::Support::ObjectFormatter.method(:format)
+      end
+
+      def lister
+        ::RSpec::Matchers::EnglishPhrasing.method(:list)
       end
 
       specify do
@@ -147,11 +151,12 @@ module RailsEventStore
 
       specify do
         _matcher = matcher(
-          matchers.an_event(FooEvent),
-          matchers.an_event(BazEvent)
+          matchers.an_event(FooEvent).with_metadata({ baz: "foo" }).with_data({ baz: "foo" }),
+          matchers.an_event(BazEvent).with_metadata({ baz: "foo" }).with_data({ baz: "foo" })
         )
+        puts _matcher.description
         expect(_matcher.description)
-          .to eq("have applied [be event FooEvent, be event BazEvent]")
+          .to eq("have applied events that have to (be an event FooEvent (with data including {:baz=>\"foo\"} and with metadata including {:baz=>\"foo\"}) and be an event BazEvent (with data including {:baz=>\"foo\"} and with metadata including {:baz=>\"foo\"}))")
       end
 
       specify do
@@ -160,7 +165,7 @@ module RailsEventStore
           BazEvent
         )
         expect(_matcher.description)
-          .to eq("have applied [FooEvent, BazEvent]")
+          .to eq("have applied events that have to (FooEvent and BazEvent)")
       end
     end
   end

--- a/rails_event_store-rspec/spec/rails_event_store/rspec/have_published_spec.rb
+++ b/rails_event_store-rspec/spec/rails_event_store/rspec/have_published_spec.rb
@@ -12,7 +12,7 @@ module RailsEventStore
       end
 
       def matcher(*expected)
-        HavePublished.new(*expected, differ: colorless_differ, formatter: formatter)
+        HavePublished.new(*expected, differ: colorless_differ, formatter: formatter, lister: lister)
       end
 
       def colorless_differ
@@ -21,6 +21,10 @@ module RailsEventStore
 
       def formatter
         ::RSpec::Support::ObjectFormatter.method(:format)
+      end
+
+      def lister
+        ::RSpec::Matchers::EnglishPhrasing.method(:list)
       end
 
       specify do
@@ -172,7 +176,7 @@ module RailsEventStore
           matchers.an_event(BazEvent)
         )
         expect(_matcher.description)
-          .to eq("have published [be event FooEvent, be event BazEvent]")
+          .to eq("have published events that have to (be an event FooEvent and be an event BazEvent)")
       end
 
       specify do
@@ -181,7 +185,7 @@ module RailsEventStore
           BazEvent
         )
         expect(_matcher.description)
-          .to eq("have published [FooEvent, BazEvent]")
+          .to eq("have published events that have to (FooEvent and BazEvent)")
       end
    end
   end

--- a/rails_event_store-rspec/spec/rails_event_store/rspec/have_published_spec.rb
+++ b/rails_event_store-rspec/spec/rails_event_store/rspec/have_published_spec.rb
@@ -12,7 +12,7 @@ module RailsEventStore
       end
 
       def matcher(*expected)
-        HavePublished.new(*expected, differ: colorless_differ, formatter: formatter, lister: lister)
+        HavePublished.new(*expected, differ: colorless_differ, phraser: phraser)
       end
 
       def colorless_differ
@@ -23,7 +23,7 @@ module RailsEventStore
         ::RSpec::Support::ObjectFormatter.method(:format)
       end
 
-      def lister
+      def phraser
         ::RSpec::Matchers::EnglishPhrasing.method(:list)
       end
 

--- a/rails_event_store-rspec/spec/rails_event_store/rspec/matchers_spec.rb
+++ b/rails_event_store-rspec/spec/rails_event_store/rspec/matchers_spec.rb
@@ -36,6 +36,8 @@ module RailsEventStore
 
       specify { expect(matchers.have_applied(matchers.an_event(FooEvent))).to be_an(HaveApplied) }
 
+      specify { expect(matchers.have_applied(matchers.an_event(FooEvent)).description).to eq("have applied events that have to (be an event FooEvent)") }
+
       specify do
         expect(matchers.have_applied(
           matchers.an_event(FooEvent),


### PR DESCRIPTION
This pull request improves verbosity of RES matchers descriptions in rspec --format doc

Matcher like
```
expect(FooEvent.new(data: { foo: "bar" }, metadata: { timestamp: Time.now }))
          .to(matcher(FooEvent).with_data(foo: "bar")
            .and(matcher(FooEvent).with_metadata(timestamp: kind_of(Time))))
```
Will be much more verbose now:

```
should be an event FooEvent (with data including {:foo=>"bar"}) and be an event FooEvent (with metadata including {:timestamp=>kind of Time})
```