### PR TITLE
AggregatRoot loads events in batches

### DIFF
--- a/aggregate_root/Makefile
+++ b/aggregate_root/Makefile
@@ -1,7 +1,8 @@
 GEM_VERSION = $(shell cat ../RES_VERSION)
 GEM_NAME    = aggregate_root
 REQUIRE     = $(GEM_NAME)
-IGNORE      =
+IGNORE      = AggregateRoot\#events_enumerator
+
 SUBJECT     ?= AggregateRoot*
 
 install: ## Install gem dependencies

--- a/aggregate_root/lib/aggregate_root.rb
+++ b/aggregate_root/lib/aggregate_root.rb
@@ -36,7 +36,7 @@ module AggregateRoot
 
   def load(stream_name, event_store: default_event_store)
     @loaded_from_stream_name = stream_name
-    event_store.read.stream(stream_name).each.with_index do |event, index|
+    events_enumerator(event_store, stream_name).with_index do |event, index|
       apply(event)
       @version = index
     end
@@ -70,6 +70,10 @@ module AggregateRoot
 
   def default_event_store
     AggregateRoot.configuration.default_event_store
+  end
+
+  def events_enumerator(event_store, stream_name)
+    event_store.read.in_batches.stream(stream_name).each
   end
 
   attr_reader :loaded_from_stream_name

--- a/aggregate_root/spec/aggregate_root_spec.rb
+++ b/aggregate_root/spec/aggregate_root_spec.rb
@@ -285,7 +285,6 @@ RSpec.describe AggregateRoot do
         end
       end.to raise_error(ArgumentError, "Anonymous class is missing name")
     end
-
   end
 
   describe '.include' do
@@ -294,5 +293,4 @@ RSpec.describe AggregateRoot do
       Order.include(AggregateRoot)
     end
   end
-
 end


### PR DESCRIPTION
To prevent killing someones app by performing massive query via repository. 

We decided to ignore it since it's very hard to satisfy mutant within current `AggregateRoot` design. To kill the mutation we would need to be sure that *Repository performs certain operation. See df502227d5d5dae26ad0e88420a99473fc5d8206 for reference.