### PR TITLE
Event#correlate_with

### DIFF
--- a/ruby_event_store/lib/ruby_event_store/event.rb
+++ b/ruby_event_store/lib/ruby_event_store/event.rb
@@ -56,7 +56,7 @@ module RubyEventStore
     end
 
     def causation_id=(val)
-      metadata[:causation_id]=(val)
+      metadata[:causation_id]= val
     end
 
     def correlate_with(other_message)

--- a/ruby_event_store/lib/ruby_event_store/event.rb
+++ b/ruby_event_store/lib/ruby_event_store/event.rb
@@ -6,8 +6,6 @@ module RubyEventStore
       @event_id = event_id.to_s
       @metadata = Metadata.new(metadata.to_h)
       @data     = data.to_h
-      self.correlation_id ||= @event_id
-      self.causation_id   ||= @event_id
     end
     attr_reader :event_id, :metadata, :data
 
@@ -62,7 +60,7 @@ module RubyEventStore
     end
 
     def correlate_with(other_message)
-      self.correlation_id = other_message.correlation_id || event.event_id
+      self.correlation_id = other_message.correlation_id || other_message.event_id
       self.causation_id   = other_message.event_id
     end
 

--- a/ruby_event_store/lib/ruby_event_store/event.rb
+++ b/ruby_event_store/lib/ruby_event_store/event.rb
@@ -6,6 +6,8 @@ module RubyEventStore
       @event_id = event_id.to_s
       @metadata = Metadata.new(metadata.to_h)
       @data     = data.to_h
+      self.correlation_id ||= @event_id
+      self.causation_id   ||= @event_id
     end
     attr_reader :event_id, :metadata, :data
 
@@ -41,6 +43,27 @@ module RubyEventStore
         event_id,
         data
       ].hash ^ BIG_VALUE
+    end
+
+    def correlation_id
+      metadata[:correlation_id]
+    end
+
+    def correlation_id=(val)
+      metadata[:correlation_id] = val
+    end
+
+    def causation_id
+      metadata[:causation_id]
+    end
+
+    def causation_id=(val)
+      metadata[:causation_id]=(val)
+    end
+
+    def correlate_with(other_message)
+      self.correlation_id = other_message.correlation_id || event.event_id
+      self.causation_id   = other_message.event_id
     end
 
     alias_method :eql?, :==

--- a/ruby_event_store/spec/event_spec.rb
+++ b/ruby_event_store/spec/event_spec.rb
@@ -167,29 +167,7 @@ module RubyEventStore
       end.to raise_error(ArgumentError)
     end
 
-    specify "correlation_id && causation_id" do
-      e0 = Event.new(event_id: "doh")
-      expect(e0.event_id).to       eq("doh")
-      expect(e0.correlation_id).to eq(nil)
-      expect(e0.causation_id).to   eq(nil)
-
-      e1 = Event.new(event_id: "yay")
-      e1.correlate_with(e0)
-      expect(e1.event_id).to       eq("yay")
-      expect(e1.correlation_id).to eq("doh")
-      expect(e1.causation_id).to   eq("doh")
-
-      e2 = Event.new(event_id: "jeb")
-      e2.correlate_with(e1)
-      expect(e2.event_id).to       eq("jeb")
-      expect(e2.correlation_id).to eq("doh")
-      expect(e2.causation_id).to   eq("yay")
-
-      event = Event.new(event_id: "mem", metadata: {correlation_id: "cor", causation_id: "cau"})
-      expect(event.event_id).to       eq("mem")
-      expect(event.correlation_id).to eq("cor")
-      expect(event.causation_id).to   eq("cau")
-    end
-
+    it_behaves_like :correlatable, Event
   end
+
 end

--- a/ruby_event_store/spec/event_spec.rb
+++ b/ruby_event_store/spec/event_spec.rb
@@ -170,8 +170,8 @@ module RubyEventStore
     specify "correlation_id && causation_id" do
       e0 = Event.new(event_id: "doh")
       expect(e0.event_id).to       eq("doh")
-      expect(e0.correlation_id).to eq("doh")
-      expect(e0.causation_id).to   eq("doh")
+      expect(e0.correlation_id).to eq(nil)
+      expect(e0.causation_id).to   eq(nil)
 
       e1 = Event.new(event_id: "yay")
       e1.correlate_with(e0)

--- a/ruby_event_store/spec/event_spec.rb
+++ b/ruby_event_store/spec/event_spec.rb
@@ -167,5 +167,29 @@ module RubyEventStore
       end.to raise_error(ArgumentError)
     end
 
+    specify "correlation_id && causation_id" do
+      e0 = Event.new(event_id: "doh")
+      expect(e0.event_id).to       eq("doh")
+      expect(e0.correlation_id).to eq("doh")
+      expect(e0.causation_id).to   eq("doh")
+
+      e1 = Event.new(event_id: "yay")
+      e1.correlate_with(e0)
+      expect(e1.event_id).to       eq("yay")
+      expect(e1.correlation_id).to eq("doh")
+      expect(e1.causation_id).to   eq("doh")
+
+      e2 = Event.new(event_id: "jeb")
+      e2.correlate_with(e1)
+      expect(e2.event_id).to       eq("jeb")
+      expect(e2.correlation_id).to eq("doh")
+      expect(e2.causation_id).to   eq("yay")
+
+      event = Event.new(event_id: "mem", metadata: {correlation_id: "cor", causation_id: "cau"})
+      expect(event.event_id).to       eq("mem")
+      expect(event.correlation_id).to eq("cor")
+      expect(event.causation_id).to   eq("cau")
+    end
+
   end
 end

--- a/ruby_event_store/spec/mappers/protobuf_spec.rb
+++ b/ruby_event_store/spec/mappers/protobuf_spec.rb
@@ -162,6 +162,8 @@ module RubyEventStore
         event.metadata['doh']
       end.to raise_error(ArgumentError)
     end
+
+    it_behaves_like :correlatable, Proto
   end
 
   module Mappers

--- a/ruby_event_store/spec/spec_helper.rb
+++ b/ruby_event_store/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'ruby_event_store'
 require 'support/rspec_defaults'
 require 'support/mutant_timeout'
+require 'support/correlatable'
 require_relative 'mappers/events_pb.rb'
 
 OrderCreated = Class.new(RubyEventStore::Event)

--- a/ruby_event_store/spec/support/correlatable.rb
+++ b/ruby_event_store/spec/support/correlatable.rb
@@ -1,0 +1,31 @@
+RSpec.shared_examples :correlatable do |klass|
+  specify "correlation_id && causation_id" do
+    e0 = klass.new(event_id: "doh", data: nil)
+    expect(e0.event_id).to       eq("doh")
+    expect(e0.correlation_id).to eq(nil)
+    expect(e0.causation_id).to   eq(nil)
+
+    e1 = klass.new(event_id: "yay", data: nil)
+    e1.correlate_with(e0)
+    expect(e1.event_id).to       eq("yay")
+    expect(e1.correlation_id).to eq("doh")
+    expect(e1.causation_id).to   eq("doh")
+
+    e2 = klass.new(event_id: "jeb", data: nil)
+    e2.correlate_with(e1)
+    expect(e2.event_id).to       eq("jeb")
+    expect(e2.correlation_id).to eq("doh")
+    expect(e2.causation_id).to   eq("yay")
+
+    event = klass.new(
+      event_id: "mem",
+      data: nil,
+      metadata: {
+        correlation_id: "cor",
+        causation_id: "cau"
+    })
+    expect(event.event_id).to       eq("mem")
+    expect(event.correlation_id).to eq("cor")
+    expect(event.causation_id).to   eq("cau")
+  end
+end


### PR DESCRIPTION
https://blog.arkency.com/correlation-id-and-causation-id-in-evented-systems/

> Let’s say every message has 3 ids. 1 is its id. Another is correlation the last
> it causation. If you are responding to a message, you copy its correlation id
> as your correlation id, its message id is your causation id. This allows you to
> see an entire conversation (correlation id) or to see what causes what (causation id).

Issue: #346