### PR TITLE
Publish rspec matcher

### DIFF
--- a/rails_event_store-rspec/Makefile
+++ b/rails_event_store-rspec/Makefile
@@ -6,7 +6,8 @@ IGNORE      = RailsEventStore::RSpec::Matchers\#differ \
               RailsEventStore::RSpec::Matchers\#have_published \
               RailsEventStore::RSpec::Matchers\#have_applied \
               RailsEventStore::RSpec::Matchers\#publish \
-              RailsEventStore::RSpec::Matchers\#be_an_event
+              RailsEventStore::RSpec::Matchers\#be_an_event \
+              RailsEventStore::RSpec::Publish\#last_event
 SUBJECT     ?= RailsEventStore::RSpec*
 
 install: ## Install gem dependencies

--- a/rails_event_store-rspec/Makefile
+++ b/rails_event_store-rspec/Makefile
@@ -5,6 +5,7 @@ IGNORE      = RailsEventStore::RSpec::Matchers\#differ \
               RailsEventStore::RSpec::Matchers\#formatter \
               RailsEventStore::RSpec::Matchers\#have_published \
               RailsEventStore::RSpec::Matchers\#have_applied \
+              RailsEventStore::RSpec::Matchers\#publish \
               RailsEventStore::RSpec::Matchers\#be_an_event
 SUBJECT     ?= RailsEventStore::RSpec*
 

--- a/rails_event_store-rspec/lib/rails_event_store/rspec.rb
+++ b/rails_event_store-rspec/lib/rails_event_store/rspec.rb
@@ -10,6 +10,7 @@ require "rails_event_store/rspec/version"
 require "rails_event_store/rspec/be_event"
 require "rails_event_store/rspec/have_published"
 require "rails_event_store/rspec/have_applied"
+require "rails_event_store/rspec/publish"
 require "rails_event_store/rspec/matchers"
 
 ::RSpec.configure do |config|

--- a/rails_event_store-rspec/lib/rails_event_store/rspec/matchers.rb
+++ b/rails_event_store-rspec/lib/rails_event_store/rspec/matchers.rb
@@ -38,8 +38,8 @@ module RailsEventStore
         HaveApplied.new(*expected, differ: differ, phraser: phraser)
       end
 
-      def publish(event = nil, &block)
-        Publish.new(event, &block)
+      def publish(*expected)
+        Publish.new(*expected)
       end
 
       private

--- a/rails_event_store-rspec/lib/rails_event_store/rspec/matchers.rb
+++ b/rails_event_store-rspec/lib/rails_event_store/rspec/matchers.rb
@@ -38,6 +38,10 @@ module RailsEventStore
         HaveApplied.new(*expected, differ: differ, phraser: phraser)
       end
 
+      def publish(event = nil, &block)
+        Publish.new(event, &block)
+      end
+
       private
 
       def formatter

--- a/rails_event_store-rspec/lib/rails_event_store/rspec/publish.rb
+++ b/rails_event_store-rspec/lib/rails_event_store/rspec/publish.rb
@@ -1,0 +1,95 @@
+require 'rspec/matchers/built_in/base_matcher'
+
+module RailsEventStore
+  module RSpec
+    class Publish < ::RSpec::Matchers::BuiltIn::BaseMatcher
+      def in(event_store, &block)
+        @event_store = event_store
+        @block = block if block_given?
+        self
+      end
+
+      def in_stream(stream, &block)
+        @stream = stream
+        @block = block if block_given?
+        self
+      end
+
+      def matches?(event_proc)
+        raise_event_store_not_set unless @event_store
+        @event_proc = event_proc
+        return false unless Proc === event_proc
+        spec = @event_store.read
+        spec = spec.stream(@stream) if @stream
+        last_event_before_block = spec.backward.limit(1).each.to_a.first
+        event_proc.call
+        spec = spec.from(last_event_before_block.event_id) if last_event_before_block
+        @published_events = spec.each.to_a
+        if @block
+          @block.call(@published_events)
+        elsif @event
+          ::RSpec::Matchers::BuiltIn::Include.new(*@event).matches?(@published_events)
+        else
+          !@published_events.empty?
+        end
+      end
+
+      def does_not_match?(event_proc)
+        !matches?(event_proc) && Proc === event_proc
+      end
+
+      def failure_message
+        if @event
+          <<-EOS
+  expected block to have published:
+
+  #{@event.inspect}
+
+  #{"in stream #{@stream} " if @stream}but published:
+
+  #{@published_events.inspect}
+          EOS
+        else
+          "expected block to have published any events"
+        end
+      end
+
+      def failure_message_when_negated
+        if @event
+          <<-EOS
+  expected block not to have published:
+
+  #{@event.inspect}
+
+  #{"in stream #{@stream} " if @stream}but published:
+
+  #{@published_events.inspect}
+          EOS
+        else
+          "expected block not to have published any events"
+        end
+      end
+
+      def description
+        "publish events"
+      end
+
+      def supports_block_expectations?
+        true
+      end
+
+      private
+
+      def initialize(event = nil, &block)
+        @event = event
+        @stream = nil
+        @event_store = nil
+        @block = block
+      end
+
+      def raise_event_store_not_set
+        raise SyntaxError, "You have to set the event store instance with `in`, e.g. `expect { ... }.to publish(an_event(MyEvent)).in(event_store)`"
+      end
+    end
+  end
+end

--- a/rails_event_store-rspec/spec/rails_event_store/rspec/matchers_spec.rb
+++ b/rails_event_store-rspec/spec/rails_event_store/rspec/matchers_spec.rb
@@ -34,6 +34,14 @@ module RailsEventStore
         expect(event_store).to matchers.have_published(matchers.an_event(FooEvent), matchers.an_event(BarEvent))
       end
 
+      specify do
+        event_store = RailsEventStore::Client.new(repository: RailsEventStore::InMemoryRepository.new)
+        event_store.publish_event(FooEvent.new)
+        expect {
+          event_store.publish_event(BarEvent.new)
+        }.to publish(matchers.an_event(BarEvent)).in(event_store)
+      end
+
       specify { expect(matchers.have_applied(matchers.an_event(FooEvent))).to be_an(HaveApplied) }
 
       specify do

--- a/rails_event_store-rspec/spec/rails_event_store/rspec/matchers_spec.rb
+++ b/rails_event_store-rspec/spec/rails_event_store/rspec/matchers_spec.rb
@@ -68,6 +68,10 @@ module RailsEventStore
         aggregate_root.bar
         expect(aggregate_root).to matchers.have_applied(matchers.an_event(FooEvent), matchers.an_event(BarEvent))
       end
+
+      specify do
+        expect(matchers.publish).to be_a(Publish)
+      end
     end
 
     module Matchers

--- a/rails_event_store-rspec/spec/rails_event_store/rspec/publish_spec.rb
+++ b/rails_event_store-rspec/spec/rails_event_store/rspec/publish_spec.rb
@@ -11,58 +11,64 @@ module RailsEventStore
         )
       end
 
-      def matcher(*events, &block)
-        Publish.new(events, &block)
+      def matcher(*expected)
+        Publish.new(*expected)
       end
 
       specify do
         expect {
           expect {
             true
-          }.to Publish.new()
+          }.to matcher
         }.to raise_error(SyntaxError, "You have to set the event store instance with `in`, e.g. `expect { ... }.to publish(an_event(MyEvent)).in(event_store)`")
       end
 
       specify do
         expect {
           true
-        }.not_to Publish.new.in(event_store)
+        }.not_to matcher.in(event_store)
       end
 
       specify do
         expect {
           event_store.publish_event(FooEvent.new)
-        }.to Publish.new.in(event_store)
+        }.to matcher.in(event_store)
       end
 
       specify do
         expect {
-          true
-        }.to Publish.new{ |events|
-          expect(events).to eq []
-        }.in(event_store)
+          event_store.publish_event(FooEvent.new, stream_name: 'Foo$1')
+        }.to matcher.in(event_store).in_stream('Foo$1')
       end
 
       specify do
-        foo_event = FooEvent.new
-        bar_event = BarEvent.new
         expect {
-          event_store.publish_event(foo_event)
-          event_store.publish_event(bar_event)
-        }.to Publish.new.in(event_store){ |events|
-          expect(events).to eq [foo_event, bar_event]
-        }
+          event_store.publish_event(FooEvent.new, stream_name: 'Foo$1')
+        }.not_to matcher.in(event_store).in_stream('Bar$1')
       end
 
       specify do
-        foo_event = FooEvent.new
-        bar_event = BarEvent.new
-        event_store.publish_event(foo_event)
         expect {
-          event_store.publish_event(bar_event)
-        }.to Publish.new.in(event_store){ |events|
-          expect(events).to eq [bar_event]
-        }
+          event_store.publish_event(FooEvent.new)
+        }.not_to matcher(matchers.an_event(BarEvent)).in(event_store)
+      end
+
+      specify do
+        expect {
+          event_store.publish_event(FooEvent.new)
+        }.to matcher(matchers.an_event(FooEvent)).in(event_store)
+      end
+
+      specify do
+        expect {
+          event_store.publish_event(FooEvent.new, stream_name: "Foo$1")
+        }.to matcher(matchers.an_event(FooEvent)).in(event_store).in_stream("Foo$1")
+      end
+
+      specify do
+        expect {
+          event_store.publish_event(FooEvent.new)
+        }.not_to matcher(matchers.an_event(FooEvent)).in(event_store).in_stream("Foo$1")
       end
 
       specify do
@@ -71,39 +77,108 @@ module RailsEventStore
         expect {
           event_store.publish_event(foo_event, stream_name: "Foo$1")
           event_store.publish_event(bar_event, stream_name: "Bar$1")
-        }.to Publish.new.in(event_store).in_stream("Foo$1"){ |events|
-          expect(events).to eq [foo_event]
-        }
+        }.to matcher(matchers.an_event(FooEvent), matchers.an_event(BarEvent)).in(event_store)
+      end
+
+      specify do
+        foo_event = FooEvent.new
+        bar_event = BarEvent.new
+
+        event_store.publish_event(foo_event)
+        expect {
+          event_store.publish_event(bar_event)
+        }.not_to matcher(matchers.an_event(FooEvent)).in(event_store)
       end
 
       specify do
         expect {
-          event_store.publish_event(FooEvent.new, stream_name: 'Foo$1')
-        }.to Publish.new.in(event_store).in_stream('Foo$1')
+          true
+        }.not_to matcher.in(event_store)
       end
 
       specify do
-        expect {
-          event_store.publish_event(FooEvent.new, stream_name: 'Foo$1')
-        }.not_to Publish.new.in(event_store).in_stream('Bar$1')
+        _matcher = matcher.in(event_store)
+        _matcher.matches?(Proc.new { })
+
+        expect(_matcher.failure_message_when_negated.to_s).to eq(<<~EOS.strip)
+          expected block not to have published any events
+        EOS
       end
 
       specify do
-        expect {
-          event_store.publish_event(FooEvent.new)
-        }.to Publish.new(matchers.an_event(FooEvent)).in(event_store)
+        _matcher = matcher.in(event_store)
+        _matcher.matches?(Proc.new { })
+
+        expect(_matcher.failure_message.to_s).to eq(<<~EOS.strip)
+          expected block to have published any events
+        EOS
       end
 
       specify do
-        expect {
-          event_store.publish_event(FooEvent.new, stream_name: "Foo$1")
-        }.to Publish.new(matchers.an_event(FooEvent)).in(event_store).in_stream("Foo$1")
+        _matcher = matcher(actual = matchers.an_event(FooEvent)).in(event_store)
+        _matcher.matches?(Proc.new { })
+
+        expect(_matcher.failure_message.to_s).to eq(<<~EOS)
+          expected block to have published:
+
+          #{[actual].inspect}
+
+          but published:
+
+          []
+        EOS
       end
 
       specify do
-        expect {
-          event_store.publish_event(FooEvent.new)
-        }.not_to Publish.new(matchers.an_event(FooEvent)).in(event_store).in_stream("Foo$1")
+        _matcher = matcher(actual = matchers.an_event(FooEvent)).in_stream('foo').in(event_store)
+        _matcher.matches?(Proc.new { })
+
+        expect(_matcher.failure_message.to_s).to eq(<<~EOS)
+          expected block to have published:
+
+          #{[actual].inspect}
+
+          in stream foo but published:
+
+          []
+        EOS
+      end
+
+      specify do
+        foo_event = FooEvent.new
+        _matcher = matcher(actual = matchers.an_event(FooEvent)).in(event_store)
+        _matcher.matches?(Proc.new { event_store.publish_event(foo_event) })
+
+        expect(_matcher.failure_message_when_negated.to_s).to eq(<<~EOS)
+          expected block not to have published:
+
+          #{[actual].inspect}
+
+          but published:
+
+          #{[foo_event].inspect}
+        EOS
+      end
+
+      specify do
+        foo_event = FooEvent.new
+        _matcher = matcher(actual = matchers.an_event(FooEvent)).in_stream('foo').in(event_store)
+        _matcher.matches?(Proc.new { event_store.publish_event(foo_event, stream_name: 'foo') })
+
+        expect(_matcher.failure_message_when_negated.to_s).to eq(<<~EOS)
+          expected block not to have published:
+
+          #{[actual].inspect}
+
+          in stream foo but published:
+
+          #{[foo_event].inspect}
+        EOS
+      end
+
+      specify do
+        _matcher = matcher
+        expect(_matcher.description).to eq("publish events")
       end
     end
   end

--- a/rails_event_store-rspec/spec/rails_event_store/rspec/publish_spec.rb
+++ b/rails_event_store-rspec/spec/rails_event_store/rspec/publish_spec.rb
@@ -1,0 +1,110 @@
+require "spec_helper"
+
+module RailsEventStore
+  module RSpec
+    ::RSpec.describe Publish do
+      let(:matchers) { Object.new.tap { |o| o.extend(Matchers) } }
+      let(:event_store) do
+        RailsEventStore::Client.new(
+          repository: RailsEventStore::InMemoryRepository.new,
+          mapper: RubyEventStore::Mappers::NullMapper.new
+        )
+      end
+
+      def matcher(*events, &block)
+        Publish.new(events, &block)
+      end
+
+      specify do
+        expect {
+          expect {
+            true
+          }.to Publish.new()
+        }.to raise_error(SyntaxError, "You have to set the event store instance with `in`, e.g. `expect { ... }.to publish(an_event(MyEvent)).in(event_store)`")
+      end
+
+      specify do
+        expect {
+          true
+        }.not_to Publish.new.in(event_store)
+      end
+
+      specify do
+        expect {
+          event_store.publish_event(FooEvent.new)
+        }.to Publish.new.in(event_store)
+      end
+
+      specify do
+        expect {
+          true
+        }.to Publish.new{ |events|
+          expect(events).to eq []
+        }.in(event_store)
+      end
+
+      specify do
+        foo_event = FooEvent.new
+        bar_event = BarEvent.new
+        expect {
+          event_store.publish_event(foo_event)
+          event_store.publish_event(bar_event)
+        }.to Publish.new.in(event_store){ |events|
+          expect(events).to eq [foo_event, bar_event]
+        }
+      end
+
+      specify do
+        foo_event = FooEvent.new
+        bar_event = BarEvent.new
+        event_store.publish_event(foo_event)
+        expect {
+          event_store.publish_event(bar_event)
+        }.to Publish.new.in(event_store){ |events|
+          expect(events).to eq [bar_event]
+        }
+      end
+
+      specify do
+        foo_event = FooEvent.new
+        bar_event = BarEvent.new
+        expect {
+          event_store.publish_event(foo_event, stream_name: "Foo$1")
+          event_store.publish_event(bar_event, stream_name: "Bar$1")
+        }.to Publish.new.in(event_store).in_stream("Foo$1"){ |events|
+          expect(events).to eq [foo_event]
+        }
+      end
+
+      specify do
+        expect {
+          event_store.publish_event(FooEvent.new, stream_name: 'Foo$1')
+        }.to Publish.new.in(event_store).in_stream('Foo$1')
+      end
+
+      specify do
+        expect {
+          event_store.publish_event(FooEvent.new, stream_name: 'Foo$1')
+        }.not_to Publish.new.in(event_store).in_stream('Bar$1')
+      end
+
+      specify do
+        expect {
+          event_store.publish_event(FooEvent.new)
+        }.to Publish.new(matchers.an_event(FooEvent)).in(event_store)
+      end
+
+      specify do
+        expect {
+          event_store.publish_event(FooEvent.new, stream_name: "Foo$1")
+        }.to Publish.new(matchers.an_event(FooEvent)).in(event_store).in_stream("Foo$1")
+      end
+
+      specify do
+        expect {
+          event_store.publish_event(FooEvent.new)
+        }.not_to Publish.new(matchers.an_event(FooEvent)).in(event_store).in_stream("Foo$1")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allow to wrap a block with publish matcher to verify if block have published
a given event. Works also with passing a block that yields all events published
within a block, e.g.

```
expect {
  event_store.publish_event(FooEvent.new)
}.to publish.in(event_store) do |events|
  expect(events).to include(an_event(FooEvent))
}
```

or

```
expect {
  MyService.new.call
}.to publish(an_event(FooEvent)).in_stream("Foo$1234").in(event_store)
```