### PR TITLE
Allow to use any background job library to handle async jobs

### DIFF
--- a/rails_event_store/lib/rails_event_store/active_job_dispatcher.rb
+++ b/rails_event_store/lib/rails_event_store/active_job_dispatcher.rb
@@ -4,7 +4,17 @@ module RailsEventStore
 
   class ActiveJobDispatcher < AsyncDispatcher
     def initialize(proxy_strategy: AsyncProxyStrategy::Inline.new)
-      super(proxy_strategy: proxy_strategy)
+      super(proxy_strategy: proxy_strategy, async_call: ActiveJobCall.new)
+    end
+
+    class ActiveJobCall
+      def call(klass, serialized_event)
+        klass.perform_later(serialized_event.to_h)
+      end
+
+      def async_handler?(klass)
+        Class === klass && klass < ActiveJob::Base
+      end
     end
   end
 end

--- a/rails_event_store/lib/rails_event_store/active_job_dispatcher.rb
+++ b/rails_event_store/lib/rails_event_store/active_job_dispatcher.rb
@@ -1,73 +1,10 @@
 require 'active_job'
 
 module RailsEventStore
-  module AsyncProxyStrategy
-    class AfterCommit
-      def call(klass, serialized_event)
-        if ActiveRecord::Base.connection.transaction_open?
-          ActiveRecord::Base.
-            connection.
-            current_transaction.
-            add_record(AsyncRecord.new(klass, serialized_event))
-        else
-          klass.perform_later(serialized_event.to_h)
-        end
-      end
 
-      private
-      class AsyncRecord
-        def initialize(klass, serialized_event)
-          @klass = klass
-          @serialized_event = serialized_event
-        end
-
-        def committed!
-          klass.perform_later(serialized_event.to_h)
-        end
-
-        def rolledback!(*)
-        end
-
-        def before_committed!
-        end
-
-        def add_to_transaction
-          AfterCommit.new.call(klass, serialized_event)
-        end
-
-        attr_reader :serialized_event, :klass
-      end
-    end
-
-    class Inline
-      def call(klass, serialized_event)
-        klass.perform_later(serialized_event.to_h)
-      end
-    end
-  end
-
-  class ActiveJobDispatcher < RubyEventStore::PubSub::Dispatcher
+  class ActiveJobDispatcher < AsyncDispatcher
     def initialize(proxy_strategy: AsyncProxyStrategy::Inline.new)
-      @async_proxy_strategy = proxy_strategy
+      super(proxy_strategy: proxy_strategy)
     end
-
-    def call(subscriber, _, serialized_event)
-      if async_handler?(subscriber)
-        @async_proxy_strategy.call(subscriber, serialized_event)
-      else
-        super
-      end
-    end
-
-    def verify(subscriber)
-      super unless async_handler?(subscriber)
-    end
-
-    private
-
-    def async_handler?(klass)
-      Class === klass && klass < ActiveJob::Base
-    end
-
   end
 end

--- a/rails_event_store/lib/rails_event_store/all.rb
+++ b/rails_event_store/lib/rails_event_store/all.rb
@@ -1,4 +1,5 @@
 require 'ruby_event_store'
+require 'rails_event_store/async_dispatcher'
 require 'rails_event_store/active_job_dispatcher'
 require 'rails_event_store/async_handler_helpers'
 require 'rails_event_store/client'

--- a/rails_event_store/lib/rails_event_store/async_dispatcher.rb
+++ b/rails_event_store/lib/rails_event_store/async_dispatcher.rb
@@ -1,28 +1,27 @@
-require 'active_job'
-
 module RailsEventStore
   module AsyncProxyStrategy
     class AfterCommit
-      def call(klass, serialized_event)
+      def call(klass, serialized_event, async_call)
         if ActiveRecord::Base.connection.transaction_open?
           ActiveRecord::Base.
             connection.
             current_transaction.
-            add_record(AsyncRecord.new(klass, serialized_event))
+            add_record(AsyncRecord.new(klass, serialized_event, async_call))
         else
-          klass.perform_later(serialized_event.to_h)
+          async_call.call(klass, serialized_event)
         end
       end
 
       private
       class AsyncRecord
-        def initialize(klass, serialized_event)
+        def initialize(klass, serialized_event, async_call)
           @klass = klass
           @serialized_event = serialized_event
+          @async_call = async_call
         end
 
         def committed!
-          klass.perform_later(serialized_event.to_h)
+          async_call.call(klass, serialized_event)
         end
 
         def rolledback!(*)
@@ -32,42 +31,36 @@ module RailsEventStore
         end
 
         def add_to_transaction
-          AfterCommit.new.call(klass, serialized_event)
+          AfterCommit.new.call(klass, serialized_event, async_call)
         end
 
-        attr_reader :serialized_event, :klass
+        attr_reader :serialized_event, :klass, :async_call
       end
     end
 
     class Inline
-      def call(klass, serialized_event)
-        klass.perform_later(serialized_event.to_h)
+      def call(klass, serialized_event, async_call)
+        async_call.call(klass, serialized_event)
       end
     end
   end
 
   class AsyncDispatcher < RubyEventStore::PubSub::Dispatcher
-    def initialize(proxy_strategy: AsyncProxyStrategy::Inline.new)
+    def initialize(proxy_strategy: AsyncProxyStrategy::Inline.new, async_call:)
       @async_proxy_strategy = proxy_strategy
+      @async_call = async_call
     end
 
     def call(subscriber, _, serialized_event)
-      if async_handler?(subscriber)
-        @async_proxy_strategy.call(subscriber, serialized_event)
+      if @async_call.async_handler?(subscriber)
+        @async_proxy_strategy.call(subscriber, serialized_event, @async_call)
       else
         super
       end
     end
 
     def verify(subscriber)
-      super unless async_handler?(subscriber)
+      super unless @async_call.async_handler?(subscriber)
     end
-
-    private
-
-    def async_handler?(klass)
-      Class === klass && klass < ActiveJob::Base
-    end
-
   end
 end

--- a/rails_event_store/lib/rails_event_store/async_dispatcher.rb
+++ b/rails_event_store/lib/rails_event_store/async_dispatcher.rb
@@ -1,0 +1,73 @@
+require 'active_job'
+
+module RailsEventStore
+  module AsyncProxyStrategy
+    class AfterCommit
+      def call(klass, serialized_event)
+        if ActiveRecord::Base.connection.transaction_open?
+          ActiveRecord::Base.
+            connection.
+            current_transaction.
+            add_record(AsyncRecord.new(klass, serialized_event))
+        else
+          klass.perform_later(serialized_event.to_h)
+        end
+      end
+
+      private
+      class AsyncRecord
+        def initialize(klass, serialized_event)
+          @klass = klass
+          @serialized_event = serialized_event
+        end
+
+        def committed!
+          klass.perform_later(serialized_event.to_h)
+        end
+
+        def rolledback!(*)
+        end
+
+        def before_committed!
+        end
+
+        def add_to_transaction
+          AfterCommit.new.call(klass, serialized_event)
+        end
+
+        attr_reader :serialized_event, :klass
+      end
+    end
+
+    class Inline
+      def call(klass, serialized_event)
+        klass.perform_later(serialized_event.to_h)
+      end
+    end
+  end
+
+  class AsyncDispatcher < RubyEventStore::PubSub::Dispatcher
+    def initialize(proxy_strategy: AsyncProxyStrategy::Inline.new)
+      @async_proxy_strategy = proxy_strategy
+    end
+
+    def call(subscriber, _, serialized_event)
+      if async_handler?(subscriber)
+        @async_proxy_strategy.call(subscriber, serialized_event)
+      else
+        super
+      end
+    end
+
+    def verify(subscriber)
+      super unless async_handler?(subscriber)
+    end
+
+    private
+
+    def async_handler?(klass)
+      Class === klass && klass < ActiveJob::Base
+    end
+
+  end
+end

--- a/rails_event_store/spec/async_dispatcher_spec.rb
+++ b/rails_event_store/spec/async_dispatcher_spec.rb
@@ -1,0 +1,201 @@
+require 'spec_helper'
+require 'ruby_event_store'
+require 'ruby_event_store/spec/dispatcher_lint'
+
+module RailsEventStore
+  RSpec.describe AsyncDispatcher do
+    class CustomAsyncCall
+      def call(klass, serialized_event)
+        klass.new.perform_async(serialized_event)
+      end
+
+      def async_handler?(klass)
+        not_async_class = [CallableHandler, NotCallableHandler, HandlerClass].include?(klass)
+        !(not_async_class || klass.is_a?(HandlerClass))
+      end
+    end
+
+    it_behaves_like :dispatcher, AsyncDispatcher.new(async_call: CustomAsyncCall.new)
+
+    before(:each) do
+      CallableHandler.reset
+      MyAsyncHandler.reset
+    end
+
+    let!(:event) { RailsEventStore::Event.new(event_id: "83c3187f-84f6-4da7-8206-73af5aca7cc8") }
+    let!(:serialized_event)  { RubyEventStore::Mappers::Default.new.event_to_serialized_record(event) }
+
+    it "verification" do
+      expect do
+        AsyncDispatcher.new(async_call: CustomAsyncCall.new).verify(NotCallableHandler)
+      end.to raise_error(RubyEventStore::InvalidHandler)
+      expect do
+        AsyncDispatcher.new(async_call: CustomAsyncCall.new).verify(MyAsyncHandler)
+      end.not_to raise_error
+      expect do
+        AsyncDispatcher.new(async_call: CustomAsyncCall.new).verify(Object.new)
+      end.not_to raise_error
+    end
+
+    it "builds async proxy for Async::Base ancestors" do
+      expect_to_have_enqueued_job(MyAsyncHandler) do
+        AsyncDispatcher.new(async_call: CustomAsyncCall.new).call(MyAsyncHandler, event, serialized_event)
+      end
+      expect(MyAsyncHandler.received).to be_nil
+      MyAsyncHandler.perform_enqueued_jobs
+      expect(MyAsyncHandler.received).to eq(serialized_event)
+    end
+
+    it "async proxy for defined adapter enqueue job immediately when no transaction is open" do
+      dispatcher = AsyncDispatcher.new(proxy_strategy: AsyncProxyStrategy::AfterCommit.new, async_call: CustomAsyncCall.new)
+      expect_to_have_enqueued_job(MyAsyncHandler) do
+        dispatcher.call(MyAsyncHandler, event, serialized_event)
+      end
+      expect(MyAsyncHandler.received).to be_nil
+      MyAsyncHandler.perform_enqueued_jobs
+      expect(MyAsyncHandler.received).to eq(serialized_event)
+    end
+
+    it "async proxy for defined adapter enqueue job only after transaction commit" do
+      dispatcher = AsyncDispatcher.new(proxy_strategy: AsyncProxyStrategy::AfterCommit.new, async_call: CustomAsyncCall.new)
+      expect_to_have_enqueued_job(MyAsyncHandler) do
+        ActiveRecord::Base.transaction do
+          expect_no_enqueued_job(MyAsyncHandler) do
+            dispatcher.call(MyAsyncHandler, event, serialized_event)
+          end
+        end
+      end
+      expect(MyAsyncHandler.received).to be_nil
+      MyAsyncHandler.perform_enqueued_jobs
+      expect(MyAsyncHandler.received).to eq(serialized_event)
+    end
+
+    it "async proxy for defined adapter do not enqueue job after transaction rollback" do
+      dispatcher = AsyncDispatcher.new(proxy_strategy: AsyncProxyStrategy::AfterCommit.new, async_call: CustomAsyncCall.new)
+      expect_no_enqueued_job(MyAsyncHandler) do
+        ActiveRecord::Base.transaction do
+          dispatcher.call(MyAsyncHandler, event, serialized_event)
+          raise ActiveRecord::Rollback
+        end
+      end
+      MyAsyncHandler.perform_enqueued_jobs
+      expect(MyAsyncHandler.received).to be_nil
+    end
+
+    it "async proxy for defined adapter does not enqueue job after transaction rollback (with raises)" do
+      was = ActiveRecord::Base.raise_in_transactional_callbacks
+      begin
+        ActiveRecord::Base.raise_in_transactional_callbacks = true
+
+        dispatcher = AsyncDispatcher.new(proxy_strategy: AsyncProxyStrategy::AfterCommit.new, async_call: CustomAsyncCall.new)
+        expect_no_enqueued_job(MyAsyncHandler) do
+          ActiveRecord::Base.transaction do
+            dispatcher.call(MyAsyncHandler, event, serialized_event)
+            raise ActiveRecord::Rollback
+          end
+        end
+        MyAsyncHandler.perform_enqueued_jobs
+        expect(MyAsyncHandler.received).to be_nil
+      ensure
+        ActiveRecord::Base.raise_in_transactional_callbacks = was
+      end
+    end if ActiveRecord::Base.respond_to?(:raise_in_transactional_callbacks)
+
+    it "async proxy for defined adapter enqueue job only after top-level transaction (nested is not new) commit" do
+      dispatcher = AsyncDispatcher.new(proxy_strategy: AsyncProxyStrategy::AfterCommit.new, async_call: CustomAsyncCall.new)
+      expect_to_have_enqueued_job(MyAsyncHandler) do
+        ActiveRecord::Base.transaction do
+          expect_no_enqueued_job(MyAsyncHandler) do
+            ActiveRecord::Base.transaction(requires_new: false) do
+              dispatcher.call(MyAsyncHandler, event, serialized_event)
+            end
+          end
+        end
+      end
+      expect(MyAsyncHandler.received).to be_nil
+      MyAsyncHandler.perform_enqueued_jobs
+      expect(MyAsyncHandler.received).to eq(serialized_event)
+    end
+
+    it "async proxy for defined adapter enqueue job only after top-level transaction commit" do
+      dispatcher = AsyncDispatcher.new(proxy_strategy: AsyncProxyStrategy::AfterCommit.new, async_call: CustomAsyncCall.new)
+      expect_to_have_enqueued_job(MyAsyncHandler) do
+        ActiveRecord::Base.transaction do
+          expect_no_enqueued_job(MyAsyncHandler) do
+            ActiveRecord::Base.transaction(requires_new: true) do
+              dispatcher.call(MyAsyncHandler, event, serialized_event)
+            end
+          end
+        end
+      end
+      expect(MyAsyncHandler.received).to be_nil
+      MyAsyncHandler.perform_enqueued_jobs
+      expect(MyAsyncHandler.received).to eq(serialized_event)
+    end
+
+    it "async proxy for defined adapter do not enqueue job after nested transaction rollback" do
+      dispatcher = AsyncDispatcher.new(proxy_strategy: AsyncProxyStrategy::AfterCommit.new, async_call: CustomAsyncCall.new)
+      expect_no_enqueued_job(MyAsyncHandler) do
+        ActiveRecord::Base.transaction do
+          expect_no_enqueued_job(MyAsyncHandler) do
+            ActiveRecord::Base.transaction(requires_new: true) do
+              dispatcher.call(MyAsyncHandler, event, serialized_event)
+              raise ActiveRecord::Rollback
+            end
+          end
+        end
+      end
+      MyAsyncHandler.perform_enqueued_jobs
+      expect(MyAsyncHandler.received).to be_nil
+    end
+
+    def expect_no_enqueued_job(job, &proc)
+      raise unless block_given?
+      yield
+      expect(job.queued).to be_nil
+    end
+
+    def expect_to_have_enqueued_job(job, &proc)
+      raise unless block_given?
+      yield
+      expect(job.queued).not_to be_nil
+    end
+
+    private
+    class CallableHandler
+      @@received = nil
+      def self.reset
+        @@received = nil
+      end
+      def self.received
+        @@received
+      end
+      def call(event)
+        @@received = event
+      end
+    end
+    class NotCallableHandler
+    end
+
+    class MyAsyncHandler
+      @@received = nil
+      @@queued = nil
+      def self.reset
+        @@received = nil
+        @@queued = nil
+      end
+      def self.queued
+        @@queued
+      end
+      def self.received
+        @@received
+      end
+      def self.perform_enqueued_jobs
+        @@received = @@queued
+      end
+      def perform_async(event)
+        @@queued  = event
+      end
+    end
+  end
+end


### PR DESCRIPTION
Breaking change: signature of dispatcher's proxy strategy is changed