### PR TITLE
Kills some mutants

### DIFF
--- a/rails_event_store/lib/rails_event_store/link_by_metadata.rb
+++ b/rails_event_store/lib/rails_event_store/link_by_metadata.rb
@@ -2,26 +2,26 @@ module RailsEventStore
 
   class LinkByMetadata < RubyEventStore::LinkByMetadata
     def initialize(event_store: Rails.configuration.event_store, key:, prefix: nil)
-      super(event_store: event_store, key: key, prefix: prefix)
+      super
     end
   end
 
   class LinkByCorrelationId < RubyEventStore::LinkByCorrelationId
     def initialize(event_store: Rails.configuration.event_store, prefix: nil)
-      super(event_store: event_store, prefix: prefix)
+      super
     end
   end
 
   class LinkByCausationId < RubyEventStore::LinkByCausationId
     def initialize(event_store: Rails.configuration.event_store, prefix: nil)
-      super(event_store: event_store, prefix: prefix)
+      super
     end
   end
 
   class LinkByEventType < RubyEventStore::LinkByEventType
     def initialize(event_store: Rails.configuration.event_store, prefix: nil)
-      super(event_store: event_store, prefix: prefix)
+      super
     end
   end
-  
+
 end


### PR DESCRIPTION
The way super handles arguments is as follows: When you invoke super with no arguments Ruby sends a message to the parent of the current object, asking it to invoke a method of the same name as the method invoking super. It automatically forwards the arguments that were passed to the method from which it's called.