### PR TITLE
Timeout only if mutating

### DIFF
--- a/aggregate_root/Makefile
+++ b/aggregate_root/Makefile
@@ -21,7 +21,7 @@ test: ## Run unit tests
 
 mutate: test ## Run mutation tests
 	@echo "Running mutation tests"
-	@bundle exec mutant --include lib \
+	@MUTATING=true bundle exec mutant --include lib \
 		$(addprefix --require ,$(REQUIRE)) \
 		$(addprefix --ignore-subject ,$(IGNORE)) \
 		--use rspec "$(SUBJECT)"

--- a/aggregate_root/spec/support/mutant_timeout.rb
+++ b/aggregate_root/spec/support/mutant_timeout.rb
@@ -2,6 +2,10 @@ require 'timeout'
 
 RSpec.configure do |config|
   config.around(:each) do |example|
-    Timeout.timeout(10, &example)
+    if ENV["MUTATING"]
+      Timeout.timeout(10, &example)
+    else
+      example.call
+    end
   end
 end

--- a/bounded_context/Makefile
+++ b/bounded_context/Makefile
@@ -20,7 +20,7 @@ test: ## Run unit tests
 
 mutate: test ## Run mutation tests
 	@echo "Running mutation tests"
-	@bundle exec mutant --include lib \
+	@MUTATING=true bundle exec mutant --include lib \
 		$(addprefix --require ,$(REQUIRE)) \
 		$(addprefix --ignore-subject ,$(IGNORE)) \
 		--use rspec "$(SUBJECT)"

--- a/bounded_context/spec/support/mutant_timeout.rb
+++ b/bounded_context/spec/support/mutant_timeout.rb
@@ -2,6 +2,10 @@ require 'timeout'
 
 RSpec.configure do |config|
   config.around(:each) do |example|
-    Timeout.timeout(10, &example)
+    if ENV["MUTATING"]
+      Timeout.timeout(10, &example)
+    else
+      example.call
+    end
   end
 end

--- a/rails_event_store-browser/Makefile
+++ b/rails_event_store-browser/Makefile
@@ -24,7 +24,7 @@ test: $(JS_BUNDLE) ## Run unit tests
 
 mutate: test ## Run mutation tests
 	@echo "Running mutation tests"
-	@DATABASE_URL=$(DATABASE_URL) bundle exec mutant --include lib \
+	@MUTATING=true DATABASE_URL=$(DATABASE_URL) bundle exec mutant --include lib \
 		$(addprefix --require ,$(REQUIRE)) \
 		$(addprefix --ignore-subject ,$(IGNORE)) \
 		--use rspec "$(SUBJECT)"

--- a/rails_event_store-browser/spec/support/mutant_timeout.rb
+++ b/rails_event_store-browser/spec/support/mutant_timeout.rb
@@ -2,6 +2,10 @@ require 'timeout'
 
 RSpec.configure do |config|
   config.around(:each) do |example|
-    Timeout.timeout(10, &example)
+    if ENV["MUTATING"]
+      Timeout.timeout(10, &example)
+    else
+      example.call
+    end
   end
 end

--- a/rails_event_store-rspec/Makefile
+++ b/rails_event_store-rspec/Makefile
@@ -26,7 +26,7 @@ test: ## Run unit tests
 
 mutate: test ## Run mutation tests
 	@echo "Running mutation tests"
-	@bundle exec mutant --include lib \
+	@MUTATING=true bundle exec mutant --include lib \
 		$(addprefix --require ,$(REQUIRE)) \
 		$(addprefix --ignore-subject ,$(IGNORE)) \
 		--use rspec "$(SUBJECT)"

--- a/rails_event_store-rspec/spec/support/mutant_timeout.rb
+++ b/rails_event_store-rspec/spec/support/mutant_timeout.rb
@@ -2,6 +2,10 @@ require 'timeout'
 
 RSpec.configure do |config|
   config.around(:each) do |example|
-    Timeout.timeout(10, &example)
+    if ENV["MUTATING"]
+      Timeout.timeout(10, &example)
+    else
+      example.call
+    end
   end
 end

--- a/rails_event_store/Makefile
+++ b/rails_event_store/Makefile
@@ -23,7 +23,7 @@ test: ## Run unit tests
 
 mutate: test ## Run mutation tests
 	@echo "Running mutation tests"
-	@bundle exec mutant --include lib \
+	@MUTATING=true bundle exec mutant --include lib \
 		$(addprefix --require ,$(REQUIRE)) \
 		$(addprefix --ignore-subject ,$(IGNORE)) \
 		--use rspec "$(SUBJECT)"

--- a/rails_event_store/spec/support/mutant_timeout.rb
+++ b/rails_event_store/spec/support/mutant_timeout.rb
@@ -2,6 +2,10 @@ require 'timeout'
 
 RSpec.configure do |config|
   config.around(:each) do |example|
-    Timeout.timeout(10, &example)
+    if ENV["MUTATING"]
+      Timeout.timeout(10, &example)
+    else
+      example.call
+    end
   end
 end

--- a/rails_event_store_active_record-legacy/Makefile
+++ b/rails_event_store_active_record-legacy/Makefile
@@ -26,14 +26,14 @@ test: ## Run unit tests
 
 mutate: test ## Run mutation tests
 	@echo "Running mutation tests"
-	@BUNDLE_GEMFILE=Gemfile DATABASE_URL=$(DATABASE_URL) bundle exec mutant --include lib \
+	@MUTATING=true BUNDLE_GEMFILE=Gemfile DATABASE_URL=$(DATABASE_URL) bundle exec mutant --include lib \
 		$(addprefix --require ,$(REQUIRE)) \
 		$(addprefix --ignore-subject ,$(IGNORE)) \
 		--use rspec "$(SUBJECT)"
 
 mutate-fast: ## Run mutation tests with --fail-fast
 	@echo "Running mutation tests with --fail-fast"
-	@BUNDLE_GEMFILE=Gemfile DATABASE_URL=$(DATABASE_URL) bundle exec mutant --include lib \
+	@MUTATING=true BUNDLE_GEMFILE=Gemfile DATABASE_URL=$(DATABASE_URL) bundle exec mutant --include lib \
 		$(addprefix --require ,$(REQUIRE)) \
 		$(addprefix --ignore-subject ,$(IGNORE)) \
 		--fail-fast \

--- a/rails_event_store_active_record-legacy/spec/support/mutant_timeout.rb
+++ b/rails_event_store_active_record-legacy/spec/support/mutant_timeout.rb
@@ -2,6 +2,10 @@ require 'timeout'
 
 RSpec.configure do |config|
   config.around(:each) do |example|
-    Timeout.timeout(10, &example)
+    if ENV["MUTATING"]
+      Timeout.timeout(10, &example)
+    else
+      example.call
+    end
   end
 end

--- a/rails_event_store_active_record/Makefile
+++ b/rails_event_store_active_record/Makefile
@@ -26,14 +26,14 @@ test: ## Run unit tests
 
 mutate: test ## Run mutation tests
 	@echo "Running mutation tests"
-	@BUNDLE_GEMFILE=Gemfile DATABASE_URL=$(DATABASE_URL) bundle exec mutant --include lib \
+	@MUTATING=true BUNDLE_GEMFILE=Gemfile DATABASE_URL=$(DATABASE_URL) bundle exec mutant --include lib \
 		$(addprefix --require ,$(REQUIRE)) \
 		$(addprefix --ignore-subject ,$(IGNORE)) \
 		--use rspec "$(SUBJECT)"
 
 mutate-fast: ## Run mutation tests with --fail-fast
 	@echo "Running mutation tests with --fail-fast"
-	@BUNDLE_GEMFILE=Gemfile DATABASE_URL=$(DATABASE_URL) bundle exec mutant --include lib \
+	@MUTATING=true BUNDLE_GEMFILE=Gemfile DATABASE_URL=$(DATABASE_URL) bundle exec mutant --include lib \
 		$(addprefix --require ,$(REQUIRE)) \
 		$(addprefix --ignore-subject ,$(IGNORE)) \
 		--fail-fast \

--- a/rails_event_store_active_record/spec/support/mutant_timeout.rb
+++ b/rails_event_store_active_record/spec/support/mutant_timeout.rb
@@ -2,6 +2,10 @@ require 'timeout'
 
 RSpec.configure do |config|
   config.around(:each) do |example|
-    Timeout.timeout(10, &example)
+    if ENV["MUTATING"]
+      Timeout.timeout(10, &example)
+    else
+      example.call
+    end
   end
 end

--- a/ruby_event_store-browser/Makefile
+++ b/ruby_event_store-browser/Makefile
@@ -25,7 +25,7 @@ test: $(JS_BUNDLE) ## Run unit tests
 
 mutate: test ## Run mutation tests
 	@echo "Running mutation tests"
-	@DATABASE_URL=$(DATABASE_URL) bundle exec mutant --include lib \
+	@MUTATING=true DATABASE_URL=$(DATABASE_URL) bundle exec mutant --include lib \
 		$(addprefix --require ,$(REQUIRE)) \
 		$(addprefix --ignore-subject ,$(IGNORE)) \
 		--use rspec "$(SUBJECT)"

--- a/ruby_event_store-browser/spec/support/mutant_timeout.rb
+++ b/ruby_event_store-browser/spec/support/mutant_timeout.rb
@@ -2,6 +2,10 @@ require 'timeout'
 
 RSpec.configure do |config|
   config.around(:each) do |example|
-    Timeout.timeout(10, &example)
+    if ENV["MUTATING"]
+      Timeout.timeout(10, &example)
+    else
+      example.call
+    end
   end
 end

--- a/ruby_event_store-rom/Makefile
+++ b/ruby_event_store-rom/Makefile
@@ -60,14 +60,14 @@ test-fast: ## Run unit tests with --fail-fast
 
 mutate: test ## Run mutation tests
 	@echo "Running mutation tests"
-	@DATABASE_URL=$(DATABASE_URL) bundle exec mutant --include lib \
+	@MUTATING=true DATABASE_URL=$(DATABASE_URL) bundle exec mutant --include lib \
 		$(addprefix --require ,$(REQUIRE)) \
 		$(addprefix --ignore-subject ,$(IGNORE)) \
 		--use rspec "$(SUBJECT)"
 
 mutate-fast: ## Run mutation tests with --fail-fast
 	@echo "Running mutation tests with --fail-fast"
-	@DATABASE_URL=$(DATABASE_URL) bundle exec mutant --include lib \
+	@MUTATING=true DATABASE_URL=$(DATABASE_URL) bundle exec mutant --include lib \
 		$(addprefix --require ,$(REQUIRE)) \
 		$(addprefix --ignore-subject ,$(IGNORE)) \
 		--fail-fast \

--- a/ruby_event_store-rom/spec/support/mutant_timeout.rb
+++ b/ruby_event_store-rom/spec/support/mutant_timeout.rb
@@ -2,6 +2,10 @@ require 'timeout'
 
 RSpec.configure do |config|
   config.around(:each) do |example|
-    Timeout.timeout(10, &example)
+    if ENV["MUTATING"]
+      Timeout.timeout(10, &example)
+    else
+      example.call
+    end
   end
 end

--- a/ruby_event_store/spec/support/mutant_timeout.rb
+++ b/ruby_event_store/spec/support/mutant_timeout.rb
@@ -2,7 +2,11 @@ require 'timeout'
 
 RSpec.configure do |config|
   config.around(:each) do |example|
-    timeout = example.metadata[:timeout] || 5
-    Timeout.timeout(timeout, &example)
+    if ENV["MUTATING"]
+      timeout = example.metadata[:timeout] || 5
+      Timeout.timeout(timeout, &example)
+    else
+      example.call
+    end
   end
 end


### PR DESCRIPTION
* We have these timeouts only for the sake of mutant sometimes
  going (intentionally) in infinite loop
* If you wanted to use the debugger, you had to comment these timeouts
* After debugging you had to remember to uncomment the timeouts

This commit solves these problems