### PR TITLE
Make Sinatra 1.4.8 and 2.x compatible by fixing route pattern

### DIFF
--- a/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
+++ b/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
@@ -54,7 +54,15 @@ module RubyEventStore
         )
       end
 
-      get '/streams/:id(/:position/:direction/:count)?' do
+      get '/streams/:id' do
+        json Stream.new(
+          event_store: settings.event_store_locator,
+          params: symbolized_params,
+          url_builder: method(:streams_url_for)
+        )
+      end
+
+      get '/streams/:id/:position/:direction/:count' do
         json Stream.new(
           event_store: settings.event_store_locator,
           params: symbolized_params,

--- a/ruby_event_store-browser/ruby_event_store-browser.gemspec
+++ b/ruby_event_store-browser/ruby_event_store-browser.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sinatra'
 
   spec.add_development_dependency 'rack-test'
-  spec.add_development_dependency 'sinatra'
   spec.add_development_dependency 'rspec', '~> 3.6'
   spec.add_development_dependency 'mutant-rspec', '~> 0.8.17'
   spec.add_development_dependency 'capybara', '< 3.0.0'


### PR DESCRIPTION
This was tested with Sinatra 1.4.8 and 2.x. Not putting a version constraint ought to allow for mounting in any version of Rails.

@pawelpacana does this address (or mitigate) the issue you had?