### PR TITLE
Update messages with ROM repository

### DIFF
--- a/ruby_event_store-rom/db/migrate/20180327044629_create_ruby_event_store_tables.rb
+++ b/ruby_event_store-rom/db/migrate/20180327044629_create_ruby_event_store_tables.rb
@@ -4,7 +4,7 @@ require 'rom/sql'
   change do
     postgres = database_type =~ /postgres/
     sqlite   = database_type =~ /sqlite/
-    
+
     run 'CREATE EXTENSION IF NOT EXISTS pgcrypto;' if postgres
 
     create_table? :event_store_events_in_streams do
@@ -20,7 +20,7 @@ require 'rom/sql'
       end
 
       column :created_at, DateTime, null: false, index: 'index_event_store_events_in_streams_on_created_at'
-      
+
       index %i[stream position], unique: true, name: 'index_event_store_events_in_streams_on_stream_and_position'
       index %i[stream event_id], unique: true, name: 'index_event_store_events_in_streams_on_stream_and_event_id'
     end

--- a/ruby_event_store-rom/lib/ruby_event_store/rom/adapters/memory/commands/batch_update.rb
+++ b/ruby_event_store-rom/lib/ruby_event_store/rom/adapters/memory/commands/batch_update.rb
@@ -1,0 +1,19 @@
+module RubyEventStore
+  module ROM
+    module Memory
+      module Commands
+        class BatchUpdate < ::ROM::Commands::Update[:memory]
+          register_as :batch_update
+          relation :events
+
+          def execute(tuples)
+            Array([tuples]).flatten.each do |params|
+              attributes = input[params].to_h.delete_if { |k, v| k == :created_at && v.nil? }
+              relation.by_pk(params.fetch(:id)).dataset.map { |tuple| tuple.update(attributes) }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/ruby_event_store-rom/lib/ruby_event_store/rom/adapters/memory/relations/events.rb
+++ b/ruby_event_store-rom/lib/ruby_event_store/rom/adapters/memory/relations/events.rb
@@ -4,10 +4,10 @@ module RubyEventStore
       module Relations
         class Events < ::ROM::Relation[:memory]
           schema(:events) do
-            attribute :id, ::ROM::Types::Strict::String.meta(primary_key: true)
+            attribute :id,         ::ROM::Types::Strict::String.meta(primary_key: true)
             attribute :event_type, ::ROM::Types::Strict::String
-            attribute :metadata, ::ROM::Types::Strict::String.optional
-            attribute :data, ::ROM::Types::Strict::String
+            attribute :metadata,   ::ROM::Types::Strict::String.optional
+            attribute :data,       ::ROM::Types::Strict::String
             attribute :created_at, ::ROM::Types::Strict::Time.default { Time.now }
           end
 
@@ -15,11 +15,11 @@ module RubyEventStore
             verify_uniquness!(tuple)
             super
           end
-          
+
           def for_stream_entries(_assoc, stream_entries)
             restrict(id: stream_entries.map { |e| e[:event_id] })
           end
-    
+
           def by_pk(id)
             restrict(id: id)
           end
@@ -31,11 +31,12 @@ module RubyEventStore
           def pluck(name)
             map { |e| e[name] }
           end
-      
-        private
+
+          private
 
           def verify_uniquness!(tuple)
             return unless by_pk(tuple[:id]).exist?
+
             raise TupleUniquenessError.for_event_id(tuple[:id])
           end
         end

--- a/ruby_event_store-rom/lib/ruby_event_store/rom/adapters/sql/commands/batch_update.rb
+++ b/ruby_event_store-rom/lib/ruby_event_store/rom/adapters/sql/commands/batch_update.rb
@@ -1,0 +1,26 @@
+module RubyEventStore
+  module ROM
+    module SQL
+      module Commands
+        class BatchUpdate < ::ROM::Commands::Update[:sql]
+          register_as :batch_update
+          relation :events
+
+          def execute(tuples)
+            dataset = relation.dataset.unfiltered
+
+            statements = Array([tuples]).flatten.map do |params|
+              attributes = input[params].to_h.delete_if { |k, v| k == :created_at && v.nil? }
+              id = attributes.delete(primary_key)
+              dataset.where(primary_key => id).update_sql(attributes)
+            end
+
+            dataset.db[statements.join(";\n")].update
+
+            tuples.to_a
+          end
+        end
+      end
+    end
+  end
+end

--- a/ruby_event_store-rom/lib/ruby_event_store/rom/adapters/sql/unit_of_work.rb
+++ b/ruby_event_store-rom/lib/ruby_event_store/rom/adapters/sql/unit_of_work.rb
@@ -27,7 +27,12 @@ module RubyEventStore
   
           gateway.transaction(options) do
             changesets.each do |changeset|
-              changeset.relation.multi_insert(changeset.to_a)
+              case changeset
+              when ROM::Repositories::Events::BatchUpdate
+                changeset.commit
+              else
+                changeset.relation.multi_insert(changeset.to_a)
+              end
             end
           end
         end

--- a/ruby_event_store-rom/lib/ruby_event_store/rom/mappers/event_to_serialized_record.rb
+++ b/ruby_event_store-rom/lib/ruby_event_store/rom/mappers/event_to_serialized_record.rb
@@ -6,7 +6,7 @@ module RubyEventStore
       class EventToSerializedRecord < ::ROM::Transformer
         relation :events
         register_as :event_to_serialized_record
-      
+
         map_array do
           rename_keys id: :event_id
           accept_keys %i[event_id data metadata event_type]

--- a/ruby_event_store-rom/lib/ruby_event_store/rom/mappers/stream_entry_to_serialized_record.rb
+++ b/ruby_event_store-rom/lib/ruby_event_store/rom/mappers/stream_entry_to_serialized_record.rb
@@ -6,7 +6,7 @@ module RubyEventStore
       class StreamEntryToSerializedRecord < ::ROM::Transformer
         relation :stream_entries
         register_as :stream_entry_to_serialized_record
-      
+
         map_array do
           unwrap :event, %i[data metadata event_type]
           accept_keys %i[event_id data metadata event_type]

--- a/ruby_event_store-rom/lib/ruby_event_store/spec/rom/event_repository_lint.rb
+++ b/ruby_event_store-rom/lib/ruby_event_store/spec/rom/event_repository_lint.rb
@@ -18,7 +18,7 @@ module RubyEventStore::ROM
     let(:test_expected_version_auto) { true }
     let(:test_link_events_to_stream) { true }
     let(:test_binary) { false }
-    let(:test_change) { false }
+    let(:test_change) { true }
 
     let(:default_stream) { RubyEventStore::Stream.new('stream') }
     let(:global_stream) { RubyEventStore::Stream.new('all') }

--- a/ruby_event_store-rom/spec/spec_helper.rb
+++ b/ruby_event_store-rom/spec/spec_helper.rb
@@ -23,7 +23,7 @@ module RomHelpers
   def container
     env.container
   end
-  
+
   def rom_db
     container.gateways[:default]
   end


### PR DESCRIPTION
* Implements `update_messages`
* Uses concatenated SQL `UPDATE` statements to batch update event records rather than utilizing "upsert" method used by AR repository

@pawelpacana @paneq do you prefer using "upsert" updates rather than SQL `UPDATE`?