### PR TITLE
to_h is no longer callled on event data

### DIFF
--- a/ruby_event_store/lib/ruby_event_store/event.rb
+++ b/ruby_event_store/lib/ruby_event_store/event.rb
@@ -12,10 +12,10 @@ module RubyEventStore
     #   part of your domain such as remote_ip, request_id, correlation_id,
     #   causation_id etc.
     # @return [Event]
-    def initialize(event_id: SecureRandom.uuid, metadata: nil, data: nil)
+    def initialize(event_id: SecureRandom.uuid, metadata: nil, data: {})
       @event_id = event_id.to_s
       @metadata = Metadata.new(metadata.to_h)
-      @data     = data.to_h
+      @data     = data
     end
 
     attr_reader :event_id, :metadata, :data

--- a/ruby_event_store/lib/ruby_event_store/mappers/protobuf.rb
+++ b/ruby_event_store/lib/ruby_event_store/mappers/protobuf.rb
@@ -1,9 +1,7 @@
 module RubyEventStore
   class Proto < RubyEventStore::Event
     def initialize(event_id: SecureRandom.uuid, metadata: nil, data:)
-      @event_id = event_id
-      @metadata = Metadata.new(metadata.to_h)
-      @data     = data
+      super
     end
 
     def type

--- a/ruby_event_store/spec/event_spec.rb
+++ b/ruby_event_store/spec/event_spec.rb
@@ -50,6 +50,11 @@ module RubyEventStore
       expect(event.metadata.to_h).to eq({})
     end
 
+    specify 'data can be anything' do
+      event = Test::TestCreated.new(data: nil)
+      expect(event.data).to be_nil
+    end
+
     specify 'UUID should be String' do
       event_1 = Test::TestCreated.new({event_id: 1})
       event_2 = Test::TestCreated.new


### PR DESCRIPTION
This allows putting anything as data, eg. nil, Array, Struct, etc.

However, we added {} as a default value for the data to prevent breaking
applications relying on data being hash and using methods like [] or
fetch.

[#395]