### PR TITLE
Verify Protobuf event data presence in mapper

### DIFF
--- a/railseventstore.org/source/docs/exceptions.html.md
+++ b/railseventstore.org/source/docs/exceptions.html.md
@@ -113,3 +113,7 @@ Raised when using `RailsEventStoreActiveRecord::Legacy` repository on unsupporte
 ### RubyEventStore::ReservedInternalName
 
 Occurs when passing stream name of `all` when using `RailsEventStoreActiveRecord` of `RubyEventStore::ROM` repository. This stream name is used internally to implement global stream. Use dedicated global stream readers in order to read events from it.
+
+### RubyEventStore::ProtobufEncodingFailed
+
+Raised when event's `data` is not serializable by `RubyEventStore::Mappers::Protobuf`.

--- a/ruby_event_store/lib/ruby_event_store/errors.rb
+++ b/ruby_event_store/lib/ruby_event_store/errors.rb
@@ -1,17 +1,19 @@
 module RubyEventStore
-  WrongExpectedEventVersion  = Class.new(StandardError)
-  InvalidExpectedVersion     = Class.new(StandardError)
-  IncorrectStreamData        = Class.new(StandardError)
-  SubscriberNotExist         = Class.new(StandardError)
-  InvalidPageStart           = Class.new(ArgumentError)
-  InvalidPageSize            = Class.new(ArgumentError)
-  EventDuplicatedInStream    = Class.new(StandardError)
-  NotSupported               = Class.new(StandardError)
-  ReservedInternalName       = Class.new(StandardError)
-  InvalidHandler             = Class.new(StandardError)
+  WrongExpectedEventVersion = Class.new(StandardError)
+  InvalidExpectedVersion    = Class.new(StandardError)
+  IncorrectStreamData       = Class.new(StandardError)
+  SubscriberNotExist        = Class.new(StandardError)
+  InvalidPageStart          = Class.new(ArgumentError)
+  InvalidPageSize           = Class.new(ArgumentError)
+  EventDuplicatedInStream   = Class.new(StandardError)
+  NotSupported              = Class.new(StandardError)
+  ReservedInternalName      = Class.new(StandardError)
+  InvalidHandler            = Class.new(StandardError)
+  ProtobufEncodingFailed    = Class.new(StandardError)
 
   class EventNotFound < StandardError
     attr_reader :event_id
+
     def initialize(event_id)
       super("Event not found: #{event_id}")
       @event_id = event_id

--- a/ruby_event_store/spec/mappers/protobuf_spec.rb
+++ b/ruby_event_store/spec/mappers/protobuf_spec.rb
@@ -253,6 +253,31 @@ module RubyEventStore
         expect(event.data.class).to eq(ResTesting::OrderCreated)
         expect(event.type).to eq("res_testing.OrderCreated")
       end
+
+      specify '#event_to_serialized_record raises error when no data' do
+        domain_event =
+          RubyEventStore::Proto.new(
+            event_id: "f90b8848-e478-47fe-9b4a-9f2a1d53622b",
+            data:     nil,
+            metadata: metadata,
+          )
+        expect do
+          subject.event_to_serialized_record(domain_event)
+        end.to raise_error(ProtobufEncodingFailed)
+      end
+
+      specify '#event_to_serialized_record raises error when wrong data' do
+        domain_event =
+          RubyEventStore::Proto.new(
+            event_id: "f90b8848-e478-47fe-9b4a-9f2a1d53622b",
+            data:     {},
+            metadata: metadata,
+            )
+
+        expect do
+          subject.event_to_serialized_record(domain_event)
+        end.to raise_error(ProtobufEncodingFailed)
+      end
     end
   end
 end


### PR DESCRIPTION
This allows dropping custom initializer for RubyEventStore::Proto

[#409]