### PR TITLE
Symbolize metadata keys by default

### DIFF
--- a/ruby_event_store/lib/ruby_event_store/mappers/default.rb
+++ b/ruby_event_store/lib/ruby_event_store/mappers/default.rb
@@ -31,9 +31,8 @@ module RubyEventStore
       attr_reader :serializer, :events_class_remapping
 
       def symbolize(hash)
-        hash.inject({}) do |memo, (k, v)|
+        hash.each_with_object({}) do |(k, v), memo|
           memo[k.to_sym] = v
-          memo
         end
       end
     end

--- a/ruby_event_store/lib/ruby_event_store/mappers/default.rb
+++ b/ruby_event_store/lib/ruby_event_store/mappers/default.rb
@@ -21,7 +21,7 @@ module RubyEventStore
         event_type = events_class_remapping.fetch(record.event_type) { record.event_type }
         Object.const_get(event_type).new(
           event_id: record.event_id,
-          metadata: serializer.load(record.metadata),
+          metadata: symbolize(serializer.load(record.metadata)),
           data:     serializer.load(record.data)
         )
       end
@@ -30,6 +30,12 @@ module RubyEventStore
 
       attr_reader :serializer, :events_class_remapping
 
+      def symbolize(hash)
+        hash.inject({}) do |memo, (k, v)|
+          memo[k.to_sym] = v
+          memo
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
- it is required now for metadata keys to be symbols
- some serializers (JSON) dump to strings and have no way to figure out
  we want symbols back
- metadata has a flat structure at the time being so no deep symbolize
  is needed

Related:
https://github.com/RailsEventStore/rails_event_store/issues/367#issuecomment-396488606

Data keys being converted to strings left intact. Handling symbol/string
duality would be better suited in your event wrapper:

```ruby
  class MyEvent < RubyEventStore::Event
    def data
      HashWithIndiffetentAccessOrSomethingElse.new(data)
    end
  end
```