### PR TITLE
Resurrect RailsEventStore::Browser.

### DIFF
--- a/rails_event_store-rspec/Gemfile
+++ b/rails_event_store-rspec/Gemfile
@@ -4,6 +4,7 @@ gemspec
 gem 'rails_event_store',               path: '../rails_event_store'
 gem 'rails_event_store_active_record', path: '../rails_event_store_active_record'
 gem 'ruby_event_store',                path: '../ruby_event_store'
+gem 'ruby_event_store-browser',        path: '../ruby_event_store-browser'
 gem 'aggregate_root',                  path: '../aggregate_root'
 gem 'bounded_context',                 path: '../bounded_context'
 

--- a/rails_event_store/Gemfile
+++ b/rails_event_store/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'ruby_event_store',                path: '../ruby_event_store'
+gem 'ruby_event_store-browser',        path: '../ruby_event_store-browser'
 gem 'rails_event_store_active_record', path: '../rails_event_store_active_record'
 gem 'aggregate_root',                  path: '../aggregate_root'
 gem 'bounded_context',                 path: '../bounded_context'

--- a/rails_event_store/lib/rails_event_store/all.rb
+++ b/rails_event_store/lib/rails_event_store/all.rb
@@ -8,6 +8,7 @@ require 'rails_event_store/active_job_scheduler'
 require 'rails_event_store/client'
 require 'rails_event_store/version'
 require 'rails_event_store/railtie'
+require 'rails_event_store/browser'
 
 module RailsEventStore
   Event                       = RubyEventStore::Event

--- a/rails_event_store/lib/rails_event_store/browser.rb
+++ b/rails_event_store/lib/rails_event_store/browser.rb
@@ -1,0 +1,5 @@
+require 'ruby_event_store/browser/app'
+
+module RailsEventStore
+  Browser = RubyEventStore::Browser::App.for(event_store_locator: -> { Rails.configuration.event_store })
+end

--- a/rails_event_store/rails_event_store.gemspec
+++ b/rails_event_store/rails_event_store.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
 
   spec.add_dependency 'ruby_event_store', '= 0.33.0'
+  spec.add_dependency 'ruby_event_store-browser', '= 0.33.0'
   spec.add_dependency 'rails_event_store_active_record', '= 0.33.0'
   spec.add_dependency 'aggregate_root', '= 0.33.0'
   spec.add_dependency 'bounded_context', '= 0.33.0'

--- a/rails_event_store/spec/browser_integration_spec.rb
+++ b/rails_event_store/spec/browser_integration_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+require 'rails_event_store/middleware'
+require 'rack/test'
+require 'rack/lint'
+require 'support/test_application'
+
+module RailsEventStore
+  RSpec.describe Browser do
+    specify 'root' do
+      request  = ::Rack::MockRequest.new(app)
+      response = request.get('/res')
+
+      expect(response.body).to match %r{<script type="text/javascript" src="/res/ruby_event_store_browser.js"></script>}
+    end
+
+    specify 'api' do
+      event_store.publish(events = 21.times.map { DummyEvent.new })
+      request  = ::Rack::MockRequest.new(app)
+      response = request.get('/res/streams/all')
+
+      expect(JSON.parse(response.body)["links"]).to eq({
+        "last" => "http://example.org/res/streams/all/head/forward/20",
+        "next" => "http://example.org/res/streams/all/#{events[1].event_id}/backward/20"
+      })
+    end
+
+    def event_store
+      Client.new
+    end
+
+    def app
+      TestApplication.tap do |app|
+        app.routes.draw { mount Browser => '/res' }
+      end
+    end
+  end
+end
+
+

--- a/rails_event_store/spec/middleware_integration_spec.rb
+++ b/rails_event_store/spec/middleware_integration_spec.rb
@@ -6,8 +6,6 @@ require 'support/test_application'
 
 module RailsEventStore
   RSpec.describe Middleware do
-    DummyEvent = Class.new(RailsEventStore::Event)
-
     specify 'works without event store instance' do
       event_store = Client.new
       request = ::Rack::MockRequest.new(middleware)

--- a/rails_event_store/spec/spec_helper.rb
+++ b/rails_event_store/spec/spec_helper.rb
@@ -23,3 +23,5 @@ end
 $verbose = ENV.has_key?('VERBOSE') ? true : false
 ActiveJob::Base.logger = nil unless $verbose
 ActiveRecord::Schema.verbose = $verbose
+
+DummyEvent = Class.new(RailsEventStore::Event)

--- a/rails_event_store/spec/support/test_application.rb
+++ b/rails_event_store/spec/support/test_application.rb
@@ -5,6 +5,7 @@ require 'securerandom'
 class TestApplication < Rails::Application
   config.eager_load = false
   config.secret_key_base = SecureRandom.hex(16)
+  config.event_store = RailsEventStore::Client.new
   initialize!
   routes.default_url_options = { host: 'example.org' }
 end

--- a/ruby_event_store-browser/spec/defaults_spec.rb
+++ b/ruby_event_store-browser/spec/defaults_spec.rb
@@ -3,8 +3,7 @@ require 'spec_helper'
 module RubyEventStore
   RSpec.describe Browser do
     it "takes path from request" do
-      events = 21.times.map { DummyEvent.new }
-      event_store.publish(events)
+      event_store.publish(events = 21.times.map { DummyEvent.new })
       test_client.get('/res/streams/all')
 
       expect(test_client.parsed_body["links"]).to eq({


### PR DESCRIPTION
Except it is really tiny this time:
- provide event_store location OOTB
- depend on browser, like all-batteries included RailsEventStore should

[#483]