### PR TITLE
Fix read events

### DIFF
--- a/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
@@ -1200,6 +1200,7 @@ module RubyEventStore
         '8a6f053e-3ce2-4c82-a55b-4d02c66ae6ea',
         'd345f86d-b903-4d78-803f-38990c078d9e'
       ]).in_batches.result).to_a[0]).to eq([e1,e3])
+      expect(repository.read(specification.with_id([]).result).to_a).to eq([])
     end
 
     specify do

--- a/ruby_event_store/lib/ruby_event_store/specification_result.rb
+++ b/ruby_event_store/lib/ruby_event_store/specification_result.rb
@@ -90,7 +90,7 @@ module RubyEventStore
     #
     # @return [Boolean]
     def with_ids?
-      !(with_ids || []).empty?
+      !with_ids.nil?
     end
 
     # Event types to be read (if any given)

--- a/ruby_event_store/spec/specification_spec.rb
+++ b/ruby_event_store/spec/specification_spec.rb
@@ -48,6 +48,7 @@ module RubyEventStore
     specify { expect(specification.with_id([event_id]).result.with_ids).to eq([event_id]) }
     specify { expect(specification.result.with_ids?).to eq(false) }
     specify { expect(specification.with_id([event_id]).result.with_ids?).to eq(true) }
+    specify { expect(specification.with_id([]).result.with_ids?).to eq(true) }
 
     specify { expect(specification.result.with_types).to be_nil }
     specify { expect(specification.of_type([TestEvent]).result.with_types).to eq(['TestEvent']) }


### PR DESCRIPTION
Because current implementation of `with_ids?` method ignores the fact that it might be no ids to read at all what leads to unfortunate result:

`res.read.events([]) => all domain events stored in event store`