### PR TITLE
No global stream entries in event_store_events_in_streams

### DIFF
--- a/rails_event_store_active_record/Makefile
+++ b/rails_event_store_active_record/Makefile
@@ -22,10 +22,10 @@ install-gemfiles:
 	@BUNDLE_GEMFILE=../support/bundler/Gemfile.0_33_0 bundle check || BUNDLE_GEMFILE=../support/bundler/Gemfile.0_33_0 bundle install
 	@BUNDLE_GEMFILE=../support/bundler/Gemfile.0_34_0 bundle check || BUNDLE_GEMFILE=../support/bundler/Gemfile.0_34_0 bundle install
 	@BUNDLE_GEMFILE=../support/bundler/Gemfile.0_35_0 bundle check || BUNDLE_GEMFILE=../support/bundler/Gemfile.0_35_0 bundle install
-	@BUNDLE_GEMFILE=../support/bundler/Gemfile.1_0_0 bundle check  || BUNDLE_GEMFILE=../support/bundler/Gemfile.1_0_0 bundle install
+	@BUNDLE_GEMFILE=../support/bundler/Gemfile.1_1_1 bundle check  || BUNDLE_GEMFILE=../support/bundler/Gemfile.1_1_1 bundle install
 
 remove-lockfiles:
 	-rm ../support/bundler/Gemfile.0_33_0.lock
 	-rm ../support/bundler/Gemfile.0_34_0.lock
 	-rm ../support/bundler/Gemfile.0_35_0.lock
-	-rm ../support/bundler/Gemfile.1_0_0.lock
+	-rm ../support/bundler/Gemfile.1_1_1.lock

--- a/rails_event_store_active_record/Makefile
+++ b/rails_event_store_active_record/Makefile
@@ -22,8 +22,10 @@ install-gemfiles:
 	@BUNDLE_GEMFILE=../support/bundler/Gemfile.0_33_0 bundle check || BUNDLE_GEMFILE=../support/bundler/Gemfile.0_33_0 bundle install
 	@BUNDLE_GEMFILE=../support/bundler/Gemfile.0_34_0 bundle check || BUNDLE_GEMFILE=../support/bundler/Gemfile.0_34_0 bundle install
 	@BUNDLE_GEMFILE=../support/bundler/Gemfile.0_35_0 bundle check || BUNDLE_GEMFILE=../support/bundler/Gemfile.0_35_0 bundle install
+	@BUNDLE_GEMFILE=../support/bundler/Gemfile.1_0_0 bundle check  || BUNDLE_GEMFILE=../support/bundler/Gemfile.1_0_0 bundle install
 
 remove-lockfiles:
 	-rm ../support/bundler/Gemfile.0_33_0.lock
 	-rm ../support/bundler/Gemfile.0_34_0.lock
 	-rm ../support/bundler/Gemfile.0_35_0.lock
+	-rm ../support/bundler/Gemfile.1_0_0.lock

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/event.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/event.rb
@@ -11,6 +11,6 @@ module RailsEventStoreActiveRecord
   class EventInStream < ::ActiveRecord::Base
     self.primary_key = :id
     self.table_name = 'event_store_events_in_streams'
-    belongs_to :event
+    belongs_to :event, primary_key: :event_id
   end
 end

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository_reader.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository_reader.rb
@@ -10,7 +10,7 @@ module RailsEventStoreActiveRecord
     end
 
     def has_event?(event_id)
-      @event_klass.exists?(id: event_id)
+      @event_klass.exists?(event_id: event_id)
     end
 
     def last_stream_event(stream)
@@ -19,13 +19,12 @@ module RailsEventStoreActiveRecord
     end
 
     def read(spec)
-      raise RubyEventStore::ReservedInternalName if spec.stream.name.eql?(EventRepository::SERIALIZED_GLOBAL_STREAM_NAME)
-
       stream = read_scope(spec)
 
       if spec.batched?
         batch_reader = ->(offset_id, limit) do
-          records = offset_id.nil? ? stream.limit(limit) : stream.where(start_offset_condition(spec, offset_id)).limit(limit)
+          search_in = spec.stream.global? ? 'event_store_events' : 'event_store_events_in_streams'
+          records = offset_id.nil? ? stream.limit(limit) : stream.where(start_offset_condition(spec, offset_id, search_in)).limit(limit)
           [records.map(&method(:record)), records.last]
         end
         BatchEnumerator.new(spec.batch_size, spec.limit, batch_reader).each
@@ -41,8 +40,6 @@ module RailsEventStoreActiveRecord
     end
 
     def count(spec)
-      raise RubyEventStore::ReservedInternalName if spec.stream.name.eql?(EventRepository::SERIALIZED_GLOBAL_STREAM_NAME)
-
       read_scope(spec).count
     end
 
@@ -50,43 +47,66 @@ module RailsEventStoreActiveRecord
     attr_reader :serializer
 
     def read_scope(spec)
-      stream = @stream_klass.preload(:event).where(stream: normalize_stream_name(spec))
-      stream = stream.where(event_id: spec.with_ids) if spec.with_ids?
-      stream = stream.joins(:event).where(event_store_events: {event_type: spec.with_types}) if spec.with_types?
-      stream = stream.order(position: order(spec)) unless spec.stream.global?
-      stream = stream.limit(spec.limit) if spec.limit?
-      stream = stream.where(start_condition(spec)) if spec.start
-      stream = stream.where(stop_condition(spec))  if spec.stop
-      stream = stream.joins(:event).where(older_than_condition(spec))          if spec.older_than
-      stream = stream.joins(:event).where(older_than_or_equal_condition(spec)) if spec.older_than_or_equal
-      stream = stream.joins(:event).where(newer_than_condition(spec))          if spec.newer_than
-      stream = stream.joins(:event).where(newer_than_or_equal_condition(spec)) if spec.newer_than_or_equal
-      stream = stream.order(id: order(spec))
-      stream
+      if spec.stream.global?
+        stream = @event_klass.order(id: order(spec))
+        stream = stream.where(event_id: spec.with_ids)                           if spec.with_ids?
+        stream = stream.where(event_type: spec.with_types)                       if spec.with_types?
+        stream = stream.limit(spec.limit)                                        if spec.limit?
+        stream = stream.where(start_condition_in_global_stream(spec))            if spec.start
+        stream = stream.where(stop_condition_in_global_stream(spec))             if spec.stop
+        stream = stream.where(older_than_condition(spec))          if spec.older_than
+        stream = stream.where(older_than_or_equal_condition(spec)) if spec.older_than_or_equal
+        stream = stream.where(newer_than_condition(spec))          if spec.newer_than
+        stream = stream.where(newer_than_or_equal_condition(spec)) if spec.newer_than_or_equal
+        stream
+      else
+        stream = @stream_klass.preload(:event).where(stream: spec.stream.name)
+        stream = stream.where(event_id: spec.with_ids)                                         if spec.with_ids?
+        stream = stream.joins(:event).where(event_store_events: {event_type: spec.with_types}) if spec.with_types?
+        stream = stream.order(position: order(spec), id: order(spec))
+        stream = stream.limit(spec.limit)                                        if spec.limit?
+        stream = stream.where(start_condition(spec))                             if spec.start
+        stream = stream.where(stop_condition(spec))                              if spec.stop
+        stream = stream.joins(:event).where(older_than_condition(spec))          if spec.older_than
+        stream = stream.joins(:event).where(older_than_or_equal_condition(spec)) if spec.older_than_or_equal
+        stream = stream.joins(:event).where(newer_than_condition(spec))          if spec.newer_than
+        stream = stream.joins(:event).where(newer_than_or_equal_condition(spec)) if spec.newer_than_or_equal
+        stream
+      end
     end
 
-    def normalize_stream_name(specification)
-      specification.stream.global? ? EventRepository::SERIALIZED_GLOBAL_STREAM_NAME : specification.stream.name
-    end
-
-    def start_offset_condition(specification, record_id)
-      condition = specification.forward? ? 'event_store_events_in_streams.id > ?' : 'event_store_events_in_streams.id < ?'
+    def start_offset_condition(specification, record_id, search_in)
+      condition = "#{search_in}.id #{specification.forward? ? '>' : '<'} ?"
       [condition, record_id]
     end
 
-    def stop_offset_condition(specification, record_id)
-      condition = specification.forward? ? 'event_store_events_in_streams.id < ?' : 'event_store_events_in_streams.id > ?'
+    def stop_offset_condition(specification, record_id, search_in)
+      condition = "#{search_in}.id #{specification.forward? ? '<' : '>'} ?"
       [condition, record_id]
     end
 
     def start_condition(specification)
       start_offset_condition(specification,
-        @stream_klass.find_by!(event_id: specification.start, stream: normalize_stream_name(specification)))
+        @stream_klass.find_by!(event_id: specification.start, stream: specification.stream.name),
+        'event_store_events_in_streams')
     end
 
     def stop_condition(specification)
       stop_offset_condition(specification,
-        @stream_klass.find_by!(event_id: specification.stop, stream: normalize_stream_name(specification)))
+        @stream_klass.find_by!(event_id: specification.stop, stream: specification.stream.name),
+        'event_store_events_in_streams')
+    end
+
+    def start_condition_in_global_stream(specification)
+      start_offset_condition(specification,
+        @event_klass.find_by!(event_id: specification.start),
+        'event_store_events')
+    end
+
+    def stop_condition_in_global_stream(specification)
+      stop_offset_condition(specification,
+        @event_klass.find_by!(event_id: specification.stop),
+        'event_store_events')
     end
 
     def older_than_condition(specification)
@@ -105,18 +125,19 @@ module RailsEventStoreActiveRecord
       ['event_store_events.created_at >= ?', specification.newer_than_or_equal]
     end
 
-
     def order(spec)
       spec.forward? ? 'ASC' : 'DESC'
     end
 
     def record(record)
+      record = record.event if @stream_klass === record
+
       RubyEventStore::SerializedRecord.new(
-        event_id: record.event.id,
-        metadata: record.event.metadata,
-        data: record.event.data,
-        event_type: record.event.event_type,
-        timestamp: record.event.created_at.iso8601(RubyEventStore::TIMESTAMP_PRECISION),
+        event_id: record.event_id,
+        metadata: record.metadata,
+        data: record.data,
+        event_type: record.event_type,
+        timestamp: record.created_at.iso8601(RubyEventStore::TIMESTAMP_PRECISION),
       ).deserialize(serializer)
     end
   end

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/generators/created_at_precision_generator.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/generators/created_at_precision_generator.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+begin
+  require 'rails/generators'
+rescue LoadError
+end
+
+module RailsEventStoreActiveRecord
+  class CreatedAtPrecisionGenerator < Rails::Generators::Base
+    source_root File.expand_path(File.join(File.dirname(__FILE__), '../generators/templates'))
+
+    def create_migration
+      template "created_at_precision_template.rb", "db/migrate/#{timestamp}_created_at_precision.rb"
+    end
+
+    private
+
+    def rails_version
+      Rails::VERSION::STRING
+    end
+
+    def migration_version
+      return nil if Gem::Version.new(rails_version) < Gem::Version.new("5.0.0")
+      "[4.2]"
+    end
+
+    def timestamp
+      Time.now.strftime("%Y%m%d%H%M%S")
+    end
+  end
+end if defined?(Rails::Generators::Base)

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/generators/no_global_stream_entries_generator.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/generators/no_global_stream_entries_generator.rb
@@ -1,0 +1,29 @@
+begin
+  require 'rails/generators'
+rescue LoadError
+end
+
+module RailsEventStoreActiveRecord
+  class NoGlobalStreamEntries < Rails::Generators::Base
+    source_root File.expand_path(File.join(File.dirname(__FILE__), '../generators/templates'))
+
+    def create_migration
+      template "no_global_stream_entries_template.rb", "db/migrate/#{timestamp}_no_global_stream_entries.rb"
+    end
+
+    private
+
+    def rails_version
+      Rails::VERSION::STRING
+    end
+
+    def migration_version
+      return nil if Gem::Version.new(rails_version) < Gem::Version.new("5.0.0")
+      "[4.2]"
+    end
+
+    def timestamp
+      Time.now.strftime("%Y%m%d%H%M%S")
+    end
+  end
+end if defined?(Rails::Generators::Base)

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/generators/templates/created_at_precision_template.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/generators/templates/created_at_precision_template.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class CreatedAtPrecision < ActiveRecord::Migration<%= migration_version %>
+  def change
+    unless ActiveRecord::Base.connection.adapter_name == "PostgreSQL"
+      change_column :event_store_events,            :created_at, :datetime, precision: 6
+      change_column :event_store_events_in_streams, :created_at, :datetime, precision: 6
+    end
+  end
+end

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/generators/templates/no_global_stream_entries_template.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/generators/templates/no_global_stream_entries_template.rb
@@ -1,0 +1,48 @@
+class NoGlobalStreamEntries < ActiveRecord::Migration<%= migration_version %>
+  def change
+    case ActiveRecord::Base.connection.adapter_name
+    when "SQLite"
+      rename_table :event_store_events, :old_event_store_events
+      create_table(:event_store_events, force: false) do |t|
+        t.references  :event,       null: false, type: :string, limit: 36
+        t.string      :event_type,  null: false
+        t.binary      :metadata
+        t.binary      :data,        null: false
+        t.datetime    :created_at,  null: false
+      end
+      add_index :event_store_events, :event_id, unique: true
+      add_index :event_store_events, :created_at
+      add_index :event_store_events, :event_type
+
+      execute <<-SQL
+        INSERT INTO event_store_events(event_id, event_type, metadata, data, created_at)
+        SELECT id, event_type, metadata, data, created_at FROM old_event_store_events;
+      SQL
+      drop_table :old_event_store_events
+    when "PostgreSQL"
+      rename_column :event_store_events, :id, :event_id
+      change_column_default :event_store_events, :event_id, nil
+      add_column :event_store_events, :id, :serial
+
+      execute <<-SQL
+        ALTER TABLE event_store_events DROP CONSTRAINT event_store_events_pkey;
+        ALTER TABLE event_store_events ADD PRIMARY KEY (id);
+      SQL
+      add_index :event_store_events, :event_id, unique: true
+    else
+      rename_column :event_store_events, :id, :event_id
+      add_column :event_store_events, :id, :integer
+
+      execute <<-SQL
+        UPDATE event_store_events
+        INNER JOIN event_store_events_in_streams ON (event_store_events.event_id = event_store_events_in_streams.event_id)
+        SET event_store_events.id = event_store_events_in_streams.id
+        WHERE event_store_events_in_streams.stream = 'all';
+      SQL
+
+      execute 'ALTER TABLE event_store_events DROP PRIMARY KEY, ADD PRIMARY KEY (id), MODIFY id INT AUTO_INCREMENT;'
+
+      add_index :event_store_events, :event_id, unique: true
+    end
+  end
+end

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/generators/templates/no_global_stream_entries_template.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/generators/templates/no_global_stream_entries_template.rb
@@ -8,7 +8,7 @@ class NoGlobalStreamEntries < ActiveRecord::Migration<%= migration_version %>
         t.string      :event_type,  null: false
         t.binary      :metadata
         t.binary      :data,        null: false
-        t.datetime    :created_at,  null: false
+        t.datetime    :created_at,  precision: 6, null: false
       end
       add_index :event_store_events, :event_id, unique: true
       add_index :event_store_events, :created_at

--- a/rails_event_store_active_record/lib/rails_event_store_active_record/index_violation_detector.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/index_violation_detector.rb
@@ -2,10 +2,10 @@
 
 module RailsEventStoreActiveRecord
   class IndexViolationDetector
-    MYSQL5_PKEY_ERROR   = "for key 'PRIMARY'".freeze
-    MYSQL8_PKEY_ERROR   = "for key 'event_store_events.PRIMARY'".freeze
-    POSTGRES_PKEY_ERROR = 'event_store_events_pkey'.freeze
-    SQLITE3_PKEY_ERROR  = 'event_store_events.id'.freeze
+    MYSQL5_PKEY_ERROR   = "for key 'index_event_store_events_on_event_id'".freeze
+    MYSQL8_PKEY_ERROR   = "for key 'event_store_events.index_event_store_events_on_event_id'".freeze
+    POSTGRES_PKEY_ERROR = "Key (event_id)".freeze
+    SQLITE3_PKEY_ERROR  = "event_store_events.event_id".freeze
 
     MYSQL5_INDEX_ERROR   = "for key 'index_event_store_events_in_streams_on_stream_and_event_id'".freeze
     MYSQL8_INDEX_ERROR   = "for key 'event_store_events_in_streams.index_event_store_events_in_streams_on_stream_and_event_id'".freeze

--- a/rails_event_store_active_record/spec/migrations_spec.rb
+++ b/rails_event_store_active_record/spec/migrations_spec.rb
@@ -72,6 +72,9 @@ RSpec.describe "database schema migrations" do
 
         client = RubyEventStore::Client.new(repository: RailsEventStoreActiveRecord::EventRepository.new(serializer: YAML))
         client.append(DummyEvent.new(event_id: 'f5253bb5-9307-4a87-ab2d-c170df2874e6'))
+        client.append(DummyEvent.new(event_id: '2ed455ad-a335-40f9-9249-98ad81bdbfa9'),
+          stream_name: 'some_stream_to_trigger_two_entries_in_streams_table_per_event')
+
         raise unless client.read.to_a.map(&:event_id) == %w[
           96c920b1-cdd0-40f4-907c-861b9fff7d02
           56404f79-0ba0-4aa0-8524-dc3436368ca0
@@ -84,6 +87,23 @@ RSpec.describe "database schema migrations" do
           ab60114c-011d-4d58-ab31-7ba65d99975e
           868cac42-3d19-4b39-84e8-cd32d65c2445
           f5253bb5-9307-4a87-ab2d-c170df2874e6
+          2ed455ad-a335-40f9-9249-98ad81bdbfa9
+        ]
+
+        raise unless client.read
+          .stream('some_stream_to_trigger_two_entries_in_streams_table_per_event')
+          .to_a.map(&:event_id) == %w[
+          96c920b1-cdd0-40f4-907c-861b9fff7d02
+          56404f79-0ba0-4aa0-8524-dc3436368ca0
+          6a54dd21-f9d8-4857-a195-f5588d9e406c
+          0e50a9cd-f981-4e39-93d5-697fc7285b98
+          d85589bc-b993-41d4-812f-fc631d9185d5
+          96bdacda-77dd-4d7d-973d-cbdaa5842855
+          94688199-e6b7-4180-bf8e-825b6808e6cc
+          68fab040-741e-4bc2-9cca-5b8855b0ca19
+          ab60114c-011d-4d58-ab31-7ba65d99975e
+          868cac42-3d19-4b39-84e8-cd32d65c2445
+          2ed455ad-a335-40f9-9249-98ad81bdbfa9
         ]
       EOF
     end

--- a/rails_event_store_active_record/spec/migrations_spec.rb
+++ b/rails_event_store_active_record/spec/migrations_spec.rb
@@ -41,10 +41,10 @@ RSpec.describe "database schema migrations" do
     end
   end
 
-  specify "migrate from v1.0.0 to master" do
-    validate_migration('Gemfile.1_0_0', 'Gemfile.master',
+  specify "migrate from v1.1.1 to master" do
+    validate_migration('Gemfile.1_1_1', 'Gemfile.master',
       source_template_name: 'create_event_store_events') do
-      run_code(<<~EOF, gemfile: 'Gemfile.1_0_0')
+      run_code(<<~EOF, gemfile: 'Gemfile.1_1_1')
         DummyEvent = Class.new(RubyEventStore::Event)
 
         client = RubyEventStore::Client.new(repository: RailsEventStoreActiveRecord::EventRepository.new)
@@ -65,6 +65,7 @@ RSpec.describe "database schema migrations" do
           end
       EOF
 
+      run_migration('created_at_precision')
       run_migration('no_global_stream_entries')
 
       run_code(<<~EOF, gemfile: 'Gemfile.master')

--- a/rails_event_store_active_record/spec/migrations_spec.rb
+++ b/rails_event_store_active_record/spec/migrations_spec.rb
@@ -1,12 +1,11 @@
 require 'spec_helper'
 
-
 RSpec.describe "database schema migrations" do
   include SchemaHelper
 
   specify "migrate from v0.33.0 to v0.34.0" do
     validate_migration('Gemfile.0_33_0', 'Gemfile.0_34_0',
-                       source_template_name: 'migration') do
+      source_template_name: 'migration') do
       run_migration('index_by_event_type')
       run_migration('limit_for_event_id')
     end
@@ -38,6 +37,54 @@ RSpec.describe "database schema migrations" do
           a: 1,
           text: "text",
         }
+      EOF
+    end
+  end
+
+  specify "migrate from v1.0.0 to master" do
+    validate_migration('Gemfile.1_0_0', 'Gemfile.master',
+      source_template_name: 'create_event_store_events') do
+      run_code(<<~EOF, gemfile: 'Gemfile.1_0_0')
+        DummyEvent = Class.new(RubyEventStore::Event)
+
+        client = RubyEventStore::Client.new(repository: RailsEventStoreActiveRecord::EventRepository.new)
+        %w[
+          96c920b1-cdd0-40f4-907c-861b9fff7d02
+          56404f79-0ba0-4aa0-8524-dc3436368ca0
+          6a54dd21-f9d8-4857-a195-f5588d9e406c
+          0e50a9cd-f981-4e39-93d5-697fc7285b98
+          d85589bc-b993-41d4-812f-fc631d9185d5
+          96bdacda-77dd-4d7d-973d-cbdaa5842855
+          94688199-e6b7-4180-bf8e-825b6808e6cc
+          68fab040-741e-4bc2-9cca-5b8855b0ca19
+          ab60114c-011d-4d58-ab31-7ba65d99975e
+          868cac42-3d19-4b39-84e8-cd32d65c2445
+        ].map.with_index do |event_id, idx|
+          client.append(DummyEvent.new(event_id: event_id),
+            stream_name: 'some_stream_to_trigger_two_entries_in_streams_table_per_event')
+          end
+      EOF
+
+      run_migration('no_global_stream_entries')
+
+      run_code(<<~EOF, gemfile: 'Gemfile.master')
+        DummyEvent = Class.new(RubyEventStore::Event)
+
+        client = RubyEventStore::Client.new(repository: RailsEventStoreActiveRecord::EventRepository.new(serializer: YAML))
+        client.append(DummyEvent.new(event_id: 'f5253bb5-9307-4a87-ab2d-c170df2874e6'))
+        raise unless client.read.to_a.map(&:event_id) == %w[
+          96c920b1-cdd0-40f4-907c-861b9fff7d02
+          56404f79-0ba0-4aa0-8524-dc3436368ca0
+          6a54dd21-f9d8-4857-a195-f5588d9e406c
+          0e50a9cd-f981-4e39-93d5-697fc7285b98
+          d85589bc-b993-41d4-812f-fc631d9185d5
+          96bdacda-77dd-4d7d-973d-cbdaa5842855
+          94688199-e6b7-4180-bf8e-825b6808e6cc
+          68fab040-741e-4bc2-9cca-5b8855b0ca19
+          ab60114c-011d-4d58-ab31-7ba65d99975e
+          868cac42-3d19-4b39-84e8-cd32d65c2445
+          f5253bb5-9307-4a87-ab2d-c170df2874e6
+        ]
       EOF
     end
   end

--- a/ruby_event_store/spec/specification_spec.rb
+++ b/ruby_event_store/spec/specification_spec.rb
@@ -38,7 +38,6 @@ module RubyEventStore
 
     specify { expect{specification.from(nil)}.to raise_error(InvalidPageStart) }
     specify { expect{specification.from('')}.to raise_error(InvalidPageStart) }
-    specify { expect{specification.from(:head)}.to raise_error(EventNotFound, /head/) }
     specify { expect{specification.from(:dummy)}.to raise_error(EventNotFound, /dummy/) }
     specify { expect{specification.from(none_such_id) }.to raise_error(EventNotFound, /#{none_such_id}/) }
 

--- a/support/bundler/Gemfile.1_0_0
+++ b/support/bundler/Gemfile.1_0_0
@@ -1,0 +1,14 @@
+source 'https://rubygems.org'
+
+ENV['RAILS_VERSION'] ||= File.read(File.join(__dir__, '../..', 'RAILS_VERSION'))
+
+gem 'rails_event_store', '1.0.0'
+gem 'rails', ENV['RAILS_VERSION']
+gem 'pg', '1.2.2'
+gem 'mysql2', '0.5.3'
+
+if Gem::Version.new(ENV['RAILS_VERSION']) >= Gem::Version.new('6.0.0')
+  gem 'sqlite3', '1.4.2'
+else
+  gem 'sqlite3', '1.3.13'
+end

--- a/support/bundler/Gemfile.1_1_1
+++ b/support/bundler/Gemfile.1_1_1
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 ENV['RAILS_VERSION'] ||= File.read(File.join(__dir__, '../..', 'RAILS_VERSION'))
 
-gem 'rails_event_store', '1.0.0'
+gem 'rails_event_store', '1.1.1'
 gem 'rails', ENV['RAILS_VERSION']
 gem 'pg', '1.2.2'
 gem 'mysql2', '0.5.3'

--- a/support/helpers/schema_helper.rb
+++ b/support/helpers/schema_helper.rb
@@ -37,7 +37,6 @@ module SchemaHelper
 
   def build_schema(gemfile, template_name: nil)
     run_in_subprocess(<<~EOF, gemfile: gemfile)
-      require 'rails/generators'
       require 'rails_event_store_active_record'
       require 'ruby_event_store'
       require 'logger'


### PR DESCRIPTION
What this means is that we get one INSERT statement less for non-named stream appends and we store half of the entries in event_store_events (if all your event publishes are in named-streams). 

Reduced storage size and theoretical write-side improvement in one case.

- [x] adjust initial migration and adapter
- [x] add 0.39.0 to current migration
- [x] testing not only reads but also subsequent writes after migration
- [x] document suggested migration procedure (blogged — https://blog.arkency.com/how-to-migrate-large-database-tables-without-a-headache/)
- [ ] tested manually on larger postgresql dataset
- [ ] tested manually on larger mysql dataset
