### PR TITLE
Verify behaviour of an AfterCommitAsyncDispatcher when there was raise in some after_commiit callback

### DIFF
--- a/rails_event_store/lib/rails_event_store/after_commit_async_dispatcher.rb
+++ b/rails_event_store/lib/rails_event_store/after_commit_async_dispatcher.rb
@@ -32,7 +32,7 @@ module RailsEventStore
         @schedule_proc = schedule_proc
       end
 
-      def committed!
+      def committed!(*)
         schedule_proc.call
       end
 

--- a/rails_event_store/spec/after_commit_async_dispatcher_spec.rb
+++ b/rails_event_store/spec/after_commit_async_dispatcher_spec.rb
@@ -14,6 +14,13 @@ module RailsEventStore
       end
     end
 
+    DummyError = Class.new(StandardError)
+
+    class DummyRecord < ActiveRecord::Base
+      self.table_name = "dummy_records"
+      after_commit -> { raise DummyError }
+    end
+
     let(:event) { RailsEventStore::Event.new(event_id: "83c3187f-84f6-4da7-8206-73af5aca7cc8") }
     let(:serialized_event) { RubyEventStore::Mappers::Default.new.event_to_serialized_record(event) }
     it_behaves_like :scheduler, CustomScheduler.new
@@ -126,6 +133,56 @@ module RailsEventStore
       MyAsyncHandler.perform_enqueued_jobs
       expect(MyAsyncHandler.received).to be_nil
     end
+
+    it "dispatch job after transaction commit when there was raise in after_commit callback" do
+      ActiveRecord::Schema.define { create_table(:dummy_records) }
+      dispatcher = AfterCommitAsyncDispatcher.new(scheduler: CustomScheduler.new)
+
+      expect_to_have_enqueued_job(MyAsyncHandler) do
+        begin
+          ActiveRecord::Base.transaction do
+            DummyRecord.new.save!
+            expect_no_enqueued_job(MyAsyncHandler) do
+              dispatcher.call(MyAsyncHandler, event, serialized_event)
+            end
+          end
+        rescue DummyError
+        end
+      end
+      expect(DummyRecord.count).to eq(1)
+      expect(MyAsyncHandler.received).to be_nil
+
+      MyAsyncHandler.perform_enqueued_jobs
+      expect(MyAsyncHandler.received).to eq(serialized_event)
+    end
+
+    it "dispatch job after transaction commit when there was raise in after_commit callback (with raises)" do
+      was = ActiveRecord::Base.raise_in_transactional_callbacks
+      begin
+        ActiveRecord::Base.raise_in_transactional_callbacks = true
+        ActiveRecord::Schema.define { create_table(:dummy_records) }
+        dispatcher = AfterCommitAsyncDispatcher.new(scheduler: CustomScheduler.new)
+
+        expect_to_have_enqueued_job(MyAsyncHandler) do
+          begin
+            ActiveRecord::Base.transaction do
+              DummyRecord.new.save!
+              expect_no_enqueued_job(MyAsyncHandler) do
+                dispatcher.call(MyAsyncHandler, event, serialized_event)
+              end
+            end
+          rescue DummyError
+          end
+        end
+        expect(DummyRecord.count).to eq(1)
+        expect(MyAsyncHandler.received).to be_nil
+
+        MyAsyncHandler.perform_enqueued_jobs
+        expect(MyAsyncHandler.received).to eq(serialized_event)
+      ensure
+        ActiveRecord::Base.raise_in_transactional_callbacks = was
+      end
+    end if ActiveRecord::Base.respond_to?(:raise_in_transactional_callbacks)
 
     describe "#verify" do
       specify do


### PR DESCRIPTION
It is possible that after_commit in one of ActiveRecords has failed
(raised). In such case:

  * error is bubbled up after transaction block
  * commited! is called with additional argument (with specifics
    depending on Rails version)

What it means for us is that:

  * transaction is commited, records are saved (and events appended)
    thus proceeding with scheduling of handling the event
  * AsyncRecord#committed must accept additional arguments to not fail
    scheduling in this case

[#183]