### PR TITLE
Exclude concurrency-related tests from mutant selection.

### DIFF
--- a/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
@@ -541,7 +541,7 @@ module RubyEventStore
       end
     end
 
-    specify 'limited concurrency for :auto - some operations will fail without outside lock, stream is ordered' do
+    specify 'limited concurrency for :auto - some operations will fail without outside lock, stream is ordered', mutant: false do
       skip unless test_expected_version_auto
       skip unless test_race_conditions_auto
       verify_conncurency_assumptions
@@ -583,7 +583,7 @@ module RubyEventStore
       end
     end
 
-    specify 'limited concurrency for :auto - some operations will fail without outside lock, stream is ordered' do
+    specify 'limited concurrency for :auto - some operations will fail without outside lock, stream is ordered', mutant: false do
       skip unless test_expected_version_auto
       skip unless test_race_conditions_auto
       skip unless test_link_events_to_stream


### PR DESCRIPTION
https://mutation-testing.slack.com/archives/C0A0RSER3/p1548119255010800