### PR TITLE
Stop skipping tests - link to stream & :auto expected versions

### DIFF
--- a/rails_event_store_active_record/spec/event_repository_spec.rb
+++ b/rails_event_store_active_record/spec/event_repository_spec.rb
@@ -19,7 +19,6 @@ module RailsEventStoreActiveRecord
 
     let(:test_race_conditions_auto)  { !ENV['DATABASE_URL'].include?("sqlite") }
     let(:test_race_conditions_any)   { !ENV['DATABASE_URL'].include?("sqlite") }
-    let(:test_expected_version_auto) { true }
     let(:test_binary)                { true }
     let(:test_change)                { !ENV['DATABASE_URL'].include?("sqlite") }
     let(:mapper)                     { RubyEventStore::Mappers::NullMapper.new }

--- a/rails_event_store_active_record/spec/event_repository_spec.rb
+++ b/rails_event_store_active_record/spec/event_repository_spec.rb
@@ -20,7 +20,6 @@ module RailsEventStoreActiveRecord
     let(:test_race_conditions_auto)  { !ENV['DATABASE_URL'].include?("sqlite") }
     let(:test_race_conditions_any)   { !ENV['DATABASE_URL'].include?("sqlite") }
     let(:test_expected_version_auto) { true }
-    let(:test_link_events_to_stream) { true }
     let(:test_binary)                { true }
     let(:test_change)                { !ENV['DATABASE_URL'].include?("sqlite") }
     let(:mapper)                     { RubyEventStore::Mappers::NullMapper.new }

--- a/rails_event_store_active_record/spec/pg_linearized_event_repository_spec.rb
+++ b/rails_event_store_active_record/spec/pg_linearized_event_repository_spec.rb
@@ -19,7 +19,6 @@ module RailsEventStoreActiveRecord
 
     let(:test_race_conditions_auto)  { false }
     let(:test_race_conditions_any)   { true }
-    let(:test_expected_version_auto) { true }
     let(:test_binary)                { false }
     let(:test_change)                { true }
     let(:mapper)                     { RubyEventStore::Mappers::NullMapper.new }

--- a/rails_event_store_active_record/spec/pg_linearized_event_repository_spec.rb
+++ b/rails_event_store_active_record/spec/pg_linearized_event_repository_spec.rb
@@ -20,7 +20,6 @@ module RailsEventStoreActiveRecord
     let(:test_race_conditions_auto)  { false }
     let(:test_race_conditions_any)   { true }
     let(:test_expected_version_auto) { true }
-    let(:test_link_events_to_stream) { true }
     let(:test_binary)                { false }
     let(:test_change)                { true }
     let(:mapper)                     { RubyEventStore::Mappers::NullMapper.new }

--- a/ruby_event_store-rom/lib/ruby_event_store/spec/rom/event_repository_lint.rb
+++ b/ruby_event_store-rom/lib/ruby_event_store/spec/rom/event_repository_lint.rb
@@ -15,7 +15,6 @@ module RubyEventStore::ROM
 
     let(:test_race_conditions_auto)  { rom_helper.has_connection_pooling? }
     let(:test_race_conditions_any)   { rom_helper.has_connection_pooling? }
-    let(:test_expected_version_auto) { true }
     let(:test_binary) { false }
     let(:test_change) { rom_helper.supports_upsert? }
 

--- a/ruby_event_store-rom/lib/ruby_event_store/spec/rom/event_repository_lint.rb
+++ b/ruby_event_store-rom/lib/ruby_event_store/spec/rom/event_repository_lint.rb
@@ -16,7 +16,6 @@ module RubyEventStore::ROM
     let(:test_race_conditions_auto)  { rom_helper.has_connection_pooling? }
     let(:test_race_conditions_any)   { rom_helper.has_connection_pooling? }
     let(:test_expected_version_auto) { true }
-    let(:test_link_events_to_stream) { true }
     let(:test_binary) { false }
     let(:test_change) { rom_helper.supports_upsert? }
 

--- a/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
@@ -110,7 +110,6 @@ module RubyEventStore
     end
 
     specify 'link_to_stream returns self' do
-      skip unless test_link_events_to_stream
       event0 = SRecord.new
       event1 = SRecord.new
       repository.
@@ -127,7 +126,6 @@ module RubyEventStore
     end
 
     specify 'links an initial event to a new stream' do
-      skip unless test_link_events_to_stream
       repository.
         append_to_stream(event = SRecord.new, stream, version_none).
         link_to_stream(event.event_id, stream_flow, version_none)
@@ -148,7 +146,6 @@ module RubyEventStore
     end
 
     specify 'links multiple initial events to a new stream' do
-      skip unless test_link_events_to_stream
       repository.append_to_stream([
         event0 = SRecord.new,
         event1 = SRecord.new,
@@ -174,7 +171,6 @@ module RubyEventStore
     end
 
     specify 'correct expected version on second link' do
-      skip unless test_link_events_to_stream
       repository.append_to_stream([
         event0 = SRecord.new,
         event1 = SRecord.new,
@@ -206,7 +202,6 @@ module RubyEventStore
     end
 
     specify 'incorrect expected version on second link' do
-      skip unless test_link_events_to_stream
       repository.append_to_stream([
         event0 = SRecord.new,
         event1 = SRecord.new,
@@ -240,7 +235,6 @@ module RubyEventStore
     end
 
     specify ':none on first and subsequent link' do
-      skip unless test_link_events_to_stream
       repository.append_to_stream([
         eventA = SRecord.new,
         eventB = SRecord.new,
@@ -269,7 +263,6 @@ module RubyEventStore
     end
 
     specify ':any allows linking in stream with best-effort order and no guarantee' do
-      skip unless test_link_events_to_stream
       repository.append_to_stream([
         event0 = SRecord.new,
         event1 = SRecord.new,
@@ -307,7 +300,6 @@ module RubyEventStore
 
     specify ':auto queries for last position in given stream when linking' do
       skip unless test_expected_version_auto
-      skip unless test_link_events_to_stream
       repository.append_to_stream([
         eventA = SRecord.new,
         eventB = SRecord.new,
@@ -338,7 +330,6 @@ module RubyEventStore
 
     specify ':auto linking starts from 0' do
       skip unless test_expected_version_auto
-      skip unless test_link_events_to_stream
       repository.append_to_stream([
         event0 = SRecord.new,
       ], stream_other, version_auto)
@@ -373,7 +364,6 @@ module RubyEventStore
 
     specify ':auto queries for last position and follows in incremental way when linking' do
       skip unless test_expected_version_auto
-      skip unless test_link_events_to_stream
       repository.append_to_stream([
         event0 = SRecord.new,
         event1 = SRecord.new,
@@ -409,7 +399,6 @@ module RubyEventStore
 
     specify ':auto is compatible with manual expectation when linking' do
       skip unless test_expected_version_auto
-      skip unless test_link_events_to_stream
       repository.append_to_stream([
         event0 = SRecord.new,
         event1 = SRecord.new,
@@ -440,7 +429,6 @@ module RubyEventStore
 
     specify 'manual is compatible with auto expectation when linking' do
       skip unless test_expected_version_auto
-      skip unless test_link_events_to_stream
       repository.append_to_stream([
         event0 = SRecord.new,
         event1 = SRecord.new,
@@ -496,7 +484,6 @@ module RubyEventStore
 
     specify 'unlimited concurrency for :any - everything should succeed when linking', timeout: 10, mutant: false do
       skip unless test_race_conditions_any
-      skip unless test_link_events_to_stream
       verify_conncurency_assumptions
       begin
         concurrency_level = 4
@@ -586,7 +573,6 @@ module RubyEventStore
     specify 'limited concurrency for :auto - some operations will fail without outside lock, stream is ordered', mutant: false do
       skip unless test_expected_version_auto
       skip unless test_race_conditions_auto
-      skip unless test_link_events_to_stream
 
       verify_conncurency_assumptions
       begin
@@ -657,7 +643,6 @@ module RubyEventStore
     end
 
     it 'data and metadata attributes are retrieved when linking' do
-      skip unless test_link_events_to_stream
       event = SRecord.new(
         data: '{"order_id":3}',
         metadata: '{"request_id":4}',
@@ -682,7 +667,6 @@ module RubyEventStore
     end
 
     it 'does not have deleted streams with linked events' do
-      skip unless test_link_events_to_stream
       repository.
         append_to_stream(e1 = SRecord.new, stream, version_none).
         link_to_stream(e1.event_id, stream_flow, version_none)
@@ -714,7 +698,6 @@ module RubyEventStore
     end
 
     it 'knows last event in stream when linked' do
-      skip unless test_link_events_to_stream
       repository.append_to_stream([
           e0 = SRecord.new(event_id: '00000000-0000-0000-0000-000000000001'),
           e1 = SRecord.new(event_id: '00000000-0000-0000-0000-000000000002'),
@@ -757,7 +740,6 @@ module RubyEventStore
     end
 
     it 'reads batch of linked events from stream forward & backward' do
-      skip unless test_link_events_to_stream
       events = %w[
         96c920b1-cdd0-40f4-907c-861b9fff7d02
         56404f79-0ba0-4aa0-8524-dc3436368ca0
@@ -804,7 +786,6 @@ module RubyEventStore
     end
 
     it 'reads all stream linked events forward & backward' do
-      skip unless test_link_events_to_stream
       s1, fs1, fs2 = stream, stream_flow, stream_other
       repository.
         append_to_stream(a = SRecord.new(event_id: '7010d298-ab69-4bb1-9251-f3466b5d1282'), s1, version_none).
@@ -851,7 +832,6 @@ module RubyEventStore
     end
 
     it 'linked events do not affect reading from all streams - no duplicates' do
-      skip unless test_link_events_to_stream
       events = %w[
         96c920b1-cdd0-40f4-907c-861b9fff7d02
         56404f79-0ba0-4aa0-8524-dc3436368ca0
@@ -927,7 +907,6 @@ module RubyEventStore
     end
 
     it 'does not allow linking same event twice in a stream' do
-      skip unless test_link_events_to_stream
       repository.append_to_stream([
           SRecord.new(event_id: "a1b49edb-7636-416f-874a-88f94b859bef"),
         ], stream,
@@ -961,7 +940,6 @@ module RubyEventStore
     end
 
     specify 'linking non-existent event' do
-      skip unless test_link_events_to_stream
       expect do
         repository.link_to_stream('72922e65-1b32-4e97-8023-03ae81dd3a27', stream_flow, version_none)
       end.to raise_error do |err|
@@ -1173,7 +1151,6 @@ module RubyEventStore
     end
 
     specify do
-      skip unless test_link_events_to_stream
       event_1 = SRecord.new(event_id: '8a6f053e-3ce2-4c82-a55b-4d02c66ae6ea')
       event_2 = SRecord.new(event_id: '8cee1139-4f96-483a-a175-2b947283c3c7')
       event_3 = SRecord.new(event_id: 'd345f86d-b903-4d78-803f-38990c078d9e')

--- a/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
@@ -282,7 +282,6 @@ module RubyEventStore
     end
 
     specify ':auto queries for last position in given stream' do
-      skip unless test_expected_version_auto
       repository.append_to_stream([
         eventA = SRecord.new,
         eventB = SRecord.new,
@@ -299,7 +298,6 @@ module RubyEventStore
     end
 
     specify ':auto queries for last position in given stream when linking' do
-      skip unless test_expected_version_auto
       repository.append_to_stream([
         eventA = SRecord.new,
         eventB = SRecord.new,
@@ -317,7 +315,6 @@ module RubyEventStore
     end
 
     specify ':auto starts from 0' do
-      skip unless test_expected_version_auto
       repository.append_to_stream([
         event0 = SRecord.new,
       ], stream, version_auto)
@@ -329,7 +326,6 @@ module RubyEventStore
     end
 
     specify ':auto linking starts from 0' do
-      skip unless test_expected_version_auto
       repository.append_to_stream([
         event0 = SRecord.new,
       ], stream_other, version_auto)
@@ -344,7 +340,6 @@ module RubyEventStore
     end
 
     specify ':auto queries for last position and follows in incremental way' do
-      skip unless test_expected_version_auto
       # It is expected that there is higher level lock
       # So this query is safe from race conditions
       repository.append_to_stream([
@@ -363,7 +358,6 @@ module RubyEventStore
     end
 
     specify ':auto queries for last position and follows in incremental way when linking' do
-      skip unless test_expected_version_auto
       repository.append_to_stream([
         event0 = SRecord.new,
         event1 = SRecord.new,
@@ -384,7 +378,6 @@ module RubyEventStore
     end
 
     specify ':auto is compatible with manual expectation' do
-      skip unless test_expected_version_auto
       repository.append_to_stream([
         event0 = SRecord.new,
         event1 = SRecord.new,
@@ -398,7 +391,6 @@ module RubyEventStore
     end
 
     specify ':auto is compatible with manual expectation when linking' do
-      skip unless test_expected_version_auto
       repository.append_to_stream([
         event0 = SRecord.new,
         event1 = SRecord.new,
@@ -414,7 +406,6 @@ module RubyEventStore
     end
 
     specify 'manual is compatible with auto expectation' do
-      skip unless test_expected_version_auto
       repository.append_to_stream([
         event0 = SRecord.new,
         event1 = SRecord.new,
@@ -428,7 +419,6 @@ module RubyEventStore
     end
 
     specify 'manual is compatible with auto expectation when linking' do
-      skip unless test_expected_version_auto
       repository.append_to_stream([
         event0 = SRecord.new,
         event1 = SRecord.new,
@@ -529,7 +519,6 @@ module RubyEventStore
     end
 
     specify 'limited concurrency for :auto - some operations will fail without outside lock, stream is ordered', mutant: false do
-      skip unless test_expected_version_auto
       skip unless test_race_conditions_auto
       verify_conncurency_assumptions
       begin
@@ -571,7 +560,6 @@ module RubyEventStore
     end
 
     specify 'limited concurrency for :auto - some operations will fail without outside lock, stream is ordered', mutant: false do
-      skip unless test_expected_version_auto
       skip unless test_race_conditions_auto
 
       verify_conncurency_assumptions

--- a/ruby_event_store/spec/in_memory_repository_spec.rb
+++ b/ruby_event_store/spec/in_memory_repository_spec.rb
@@ -6,7 +6,6 @@ module RubyEventStore
     let(:test_race_conditions_any)   { true }
     let(:test_race_conditions_auto)  { true }
     let(:test_expected_version_auto) { true }
-    let(:test_link_events_to_stream) { true }
     let(:test_binary) { true }
     let(:test_change) { true }
 

--- a/ruby_event_store/spec/in_memory_repository_spec.rb
+++ b/ruby_event_store/spec/in_memory_repository_spec.rb
@@ -5,7 +5,6 @@ module RubyEventStore
   RSpec.describe InMemoryRepository do
     let(:test_race_conditions_any)   { true }
     let(:test_race_conditions_auto)  { true }
-    let(:test_expected_version_auto) { true }
     let(:test_binary) { true }
     let(:test_change) { true }
 

--- a/ruby_event_store/spec/instrumented_repository_spec.rb
+++ b/ruby_event_store/spec/instrumented_repository_spec.rb
@@ -215,7 +215,6 @@ module RubyEventStore
 
     let(:test_race_conditions_any)   { false }
     let(:test_race_conditions_auto)  { false }
-    let(:test_expected_version_auto) { true }
     let(:test_binary) { false }
     let(:test_change) { false }
 

--- a/ruby_event_store/spec/instrumented_repository_spec.rb
+++ b/ruby_event_store/spec/instrumented_repository_spec.rb
@@ -216,7 +216,6 @@ module RubyEventStore
     let(:test_race_conditions_any)   { false }
     let(:test_race_conditions_auto)  { false }
     let(:test_expected_version_auto) { true }
-    let(:test_link_events_to_stream) { true }
     let(:test_binary) { false }
     let(:test_change) { false }
 


### PR DESCRIPTION
No more legacy event repository. All other have support for it. All new ones should have it also.