### PR TITLE
Restore AggregateRoot::Repository

### DIFF
--- a/aggregate_root/lib/aggregate_root.rb
+++ b/aggregate_root/lib/aggregate_root.rb
@@ -49,7 +49,40 @@ module AggregateRoot
     unpublished.each
   end
 
+  def load(stream_name, event_store: default_event_store)
+    warn <<~EOW
+      Method `load` on aggregate is deprecated. Use AggregateRoot::Repository instead.
+      Instead of: `order = Order.new.load("OrderStreamHere")`
+      you need to have code:
+      ```
+      repository = AggregateRoot::Repository.new
+      order = repository.load(Order.new, "OrderStreamHere")
+      ```
+    EOW
+    @loaded_from_stream_name = stream_name
+    Repository.new(event_store).load(self, stream_name)
+  end
+
+  def store(stream_name = loaded_from_stream_name, event_store: default_event_store)
+    warn <<~EOW
+      Method `store` on aggregate is deprecated. Use AggregateRoot::Repository instead.
+      Instead of: `order.store("OrderStreamHere")`
+      you need to have code:
+      ```
+      repository = AggregateRoot::Repository.new
+      # load and order and execute some operation on it here
+      repository.store(order, "OrderStreamHere")
+      ```
+    EOW
+    Repository.new(event_store).store(self, stream_name)
+  end
+
   private
+  attr_reader :loaded_from_stream_name
+
+  def default_event_store
+    AggregateRoot.configuration.default_event_store
+  end
 
   def unpublished
     @unpublished_events ||= []

--- a/aggregate_root/lib/aggregate_root/repository.rb
+++ b/aggregate_root/lib/aggregate_root/repository.rb
@@ -1,0 +1,27 @@
+module AggregateRoot
+  class Repository
+    def initialize(event_store = default_event_store)
+      @event_store = event_store
+    end
+
+    def load(aggregate, stream_name)
+      event_store.read.stream(stream_name).reduce {|_, ev| aggregate.apply(ev) }
+      aggregate.version = aggregate.unpublished_events.count - 1
+      aggregate
+    end
+
+    def store(aggregate, stream_name)
+      event_store.publish(aggregate.unpublished_events.to_a,
+                          stream_name: stream_name,
+                          expected_version: aggregate.version)
+      aggregate.version = aggregate.version + aggregate.unpublished_events.count
+    end
+
+    private
+    attr_reader :event_store
+
+    def default_event_store
+      AggregateRoot.configuration.default_event_store
+    end
+  end
+end

--- a/aggregate_root/lib/aggregate_root/repository.rb
+++ b/aggregate_root/lib/aggregate_root/repository.rb
@@ -17,6 +17,11 @@ module AggregateRoot
       aggregate.version = aggregate.version + aggregate.unpublished_events.count
     end
 
+    def with_aggregate(aggregate, stream_name, &block)
+      block.call(load(aggregate, stream_name))
+      store(aggregate, stream_name)
+    end
+
     private
     attr_reader :event_store
 


### PR DESCRIPTION
It have been killed long time ago https://github.com/RailsEventStore/rails_event_store/commit/54b93a72372314c4a6dbdecf8b3cfc8aa645f577#diff-1d5e211055c3d9a6b2b9e4314668a3dc
Now it is going back. The promisses from `Redesign of aggregate root
module` commit still holds true:
* still no magic
* still no restrictions on how aggregate class should look like, etc

This is a breaking change. Instead of:

```
order = Order.new.load("OrderStreamHere")
...
order.store
```

you need to have code:

```
repository = AggregateRoot::Repository.new
order = repository.load(Order.new, "OrderStreamHere")
...
repository.store(order, "OrderStreamHere")
```