### PR TITLE
Yay, stock protobuf gems.

### DIFF
--- a/ruby_event_store/Gemfile
+++ b/ruby_event_store/Gemfile
@@ -4,5 +4,5 @@ gemspec
 eval_gemfile File.expand_path('../lib/Gemfile.shared', __dir__)
 
 gem 'protobuf_nested_struct'
-gem 'google-protobuf', '= 3.6.1', source: 'https://gem.fury.io/pawelpacana/'
+gem 'google-protobuf', '~> 3.7.0'
 gem 'activesupport', '~> 5.0'


### PR DESCRIPTION
No need for custom-built on private gem server. That would work for the rest of the year until new Ruby release...