### PR TITLE
Add title for the root page

### DIFF
--- a/railseventstore.org/source/index.html.md
+++ b/railseventstore.org/source/index.html.md
@@ -1,3 +1,7 @@
+---
+title: Rails Event Store
+---
+
 <p class="mb-6 mt-12 text-lg sm:text-2xl leading-normal">
     Rails Event Store is a library for publishing, consuming, storing and retrieving events. It's&nbspyour best companion for going with an Event-Driven Architecture for your Rails application.
 </p>


### PR DESCRIPTION
Currently, we have this title for the root page : 

![Capture d’écran 2019-04-12 à 15 51 42](https://user-images.githubusercontent.com/7428736/56042244-e8661000-5d3a-11e9-8985-f2fca1c35a84.png)