### PR TITLE
Possible fix for in Migrating_Messages.html.md

### DIFF
--- a/railseventstore.org/source/docs/migrating_messages.html.md
+++ b/railseventstore.org/source/docs/migrating_messages.html.md
@@ -24,7 +24,7 @@ end
 
 ```ruby
 event_store.read.in_batches.each_batch do |events|
-  events.select{|ev| OldType === ev }.map do |ev|
+  events = events.select{|ev| OldType === ev }.map do |ev|
     NewType.new(
       event_id: ev.event_id,
       data: ev.data,


### PR DESCRIPTION
I think that the "Change event type" section would not work since it's overwriting with the same array as before. We would need to store the map in a variable, if I am not mistaken.