### PR TITLE
Simple benchmark from RES instrumentation

### DIFF
--- a/contrib/measure/Gemfile
+++ b/contrib/measure/Gemfile
@@ -1,0 +1,15 @@
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+# Specify your gem's dependencies in measure.gemspec
+gemspec
+
+gem 'rspec'
+gem 'rails_event_store', path: '../../rails_event_store'
+gem 'ruby_event_store',  path: '../../ruby_event_store'
+gem 'rails_event_store_active_record', path: '../../rails_event_store_active_record'
+gem 'bounded_context', path: '../../bounded_context'
+gem 'aggregate_root', path: '../../aggregate_root'
+gem 'ruby_event_store-browser', path: '../../ruby_event_store-browser'
+gem 'rails'

--- a/contrib/measure/examples/demo
+++ b/contrib/measure/examples/demo
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'measure'
+require 'ruby_event_store'
+require 'active_support/notifications'
+require 'aggregate_root'
+
+asn = ActiveSupport::Notifications
+event_store = RubyEventStore::Client.new(
+  repository: RubyEventStore::InstrumentedRepository.new(RubyEventStore::InMemoryRepository.new, asn),
+  mapper: RubyEventStore::Mappers::InstrumentedMapper.new(RubyEventStore::Mappers::Default.new, asn),
+  dispatcher: RubyEventStore::InstrumentedDispatcher.new(RubyEventStore::PubSub::Dispatcher.new, asn)
+)
+DummyEvent  = Class.new(RubyEventStore::Event)
+dummy = DummyEvent.new
+repo  = AggregateRoot::Repository.new(event_store)
+
+class Bazinga
+  include AggregateRoot
+
+  def do_the_dummy
+    apply(DummyEvent.new)
+  end
+
+  on DummyEvent do |event|
+  end
+end
+
+
+Measure.measure do
+  aggregate = repo.load(Bazinga.new, 'bazinga')
+  100.times { aggregate.do_the_dummy }
+  repo.store(aggregate, 'bazinga')
+end

--- a/contrib/measure/lib/measure.rb
+++ b/contrib/measure/lib/measure.rb
@@ -1,0 +1,50 @@
+require "measure/version"
+
+module Measure
+  METRICS = %w(
+      append_to_stream.repository.rails_event_store
+      link_to_stream.repository.rails_event_store
+      delete_stream.repository.rails_event_store
+      read_event.repository.rails_event_store
+      read.repository.rails_event_store
+      call.dispatcher.rails_event_store
+      serialize.mapper.rails_event_store
+      deserialize.mapper.rails_event_store
+      total
+    ).freeze
+
+  def measure(&block)
+    output = Hash.new { |hash, key| hash[key] = 0 }
+
+    METRICS.each do |name|
+      ActiveSupport::Notifications.subscribe(name) do |name, start, finish, id, payload|
+        metric = ActiveSupport::Notifications::Event.new(name, start, finish, id, payload)
+        metric_name = name.split('.').first
+        output[metric_name] += metric.duration
+      end
+    end
+
+    ActiveSupport::Notifications.instrument('total') do
+      block.call
+    end
+
+    METRICS.each do |name|
+      ActiveSupport::Notifications.unsubscribe(name)
+    end
+
+    total = output.delete('total')
+
+    puts "%s %s %s" % ["metric".ljust(18), "ms".rjust(7), "%".rjust(6)]
+    puts "\u2500" * 33
+
+    output.each do |metric, duration|
+      puts "%s %7.2f %6.2f" % [metric.ljust(18), duration, (duration/total * 100)]
+    end
+
+    puts
+    puts "%s %7.2f %6.2f" % ["total".ljust(18), total, 100]
+
+    output.merge("total" => total)
+  end
+  module_function :measure
+end

--- a/contrib/measure/lib/measure/version.rb
+++ b/contrib/measure/lib/measure/version.rb
@@ -1,0 +1,3 @@
+module Measure
+  VERSION = "0.1.0"
+end

--- a/contrib/measure/measure.gemspec
+++ b/contrib/measure/measure.gemspec
@@ -1,0 +1,22 @@
+
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "measure/version"
+
+Gem::Specification.new do |spec|
+  spec.name          = "measure"
+  spec.version       = Measure::VERSION
+  spec.authors       = ["Paweł Pacana"]
+  spec.email         = ["pawel.pacana@gmail.com"]
+
+  spec.summary       = %q{Doh.}
+
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  end
+  spec.bindir        = "exe"
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
+end

--- a/contrib/measure/spec/measure_spec.rb
+++ b/contrib/measure/spec/measure_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+require 'rails_event_store'
+require 'active_support/core_ext/kernel/reporting'
+
+RSpec.describe Measure do
+  let(:event_store) { RailsEventStore::Client.new(repository: RubyEventStore::InMemoryRepository.new) }
+
+  DummyEvent = Class.new(RubyEventStore::Event)
+
+  class StepClock
+    def initialize(initial_time, step_duration = 1)
+      @initial_time  = initial_time
+      @step_duration = step_duration
+      @step          = 0
+    end
+
+    def now
+      current_time = @initial_time + (@step * @step_duration)
+      @step += 1
+      current_time
+    end
+  end
+
+  let(:step_clock) { StepClock.new(Time.at(0)) }
+
+  specify do
+    operation = -> do
+      event_store.publish(DummyEvent.new)
+    end
+
+    allow(Time).to receive(:now) { step_clock.now }
+
+    expect { Measure.measure(&operation) }.to output(<<~EOS).to_stdout
+      metric                  ms      %
+      ─────────────────────────────────
+      serialize          1000.00  16.67
+      append_to_stream   1000.00  16.67
+      
+      total              6000.00 100.00
+    EOS
+  end
+
+  specify do
+    operation = -> do
+      event_store.publish(DummyEvent.new)
+    end
+
+    allow(Time).to receive(:now) { step_clock.now }
+
+    begin
+      $stdout = File.open('/dev/null', 'w')
+      return_value = Measure.measure(&operation)
+    ensure
+      $stdout = STDOUT
+    end
+
+    expect(return_value).to eq({
+      "total" => 6000,
+      "serialize" => 1000.0,
+      "append_to_stream" => 1000.0
+    })
+  end
+end

--- a/contrib/measure/spec/spec_helper.rb
+++ b/contrib/measure/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+  require '../../support/helpers/rspec_defaults'
+  require 'measure'


### PR DESCRIPTION
Given a block of instrumented RES code, print aggregated time of each RES
metric with percentage of total block execution time.

Example:

```
  metric                  ms      %
  ─────────────────────────────────
  read                  0.02   0.13
  serialize            10.68  66.22
  append_to_stream      0.87   5.41

  total                16.13 100.00
```

Right now, it expects (hardcoded) `ActiveSupport::Notifications` but it
doesn't have to be this way.

Testing unfortunately relies on magic number of mocked Time.now
execution. Something that may unexpectedly change in the future.