### PR TITLE
Have a constructor while still allowing redefining initialize.

### DIFF
--- a/aggregate_root/lib/aggregate_root.rb
+++ b/aggregate_root/lib/aggregate_root.rb
@@ -24,8 +24,8 @@ module AggregateRoot
   end
 
   module Constructor
-    def new(*)
-      super.tap do |instance|
+    def new
+      super().tap do |instance|
         instance.instance_variable_set(:@version, -1)
         instance.instance_variable_set(:@unpublished_events, [])
       end

--- a/aggregate_root/spec/aggregate_root_spec.rb
+++ b/aggregate_root/spec/aggregate_root_spec.rb
@@ -288,13 +288,6 @@ RSpec.describe AggregateRoot do
     end
   end
 
-  describe '.include' do
-    it 'extend class with AggregateRoot::ClassMethods' do
-      expect(Order).to receive(:extend).with(AggregateRoot::OnDSL)
-      Order.include(AggregateRoot)
-    end
-  end
-
   it "uses with_aggregate to simplify aggregate usage" do
     event_store.publish(Orders::Events::OrderCreated.new, stream_name: "Order$1")
     order_expired = Orders::Events::OrderExpired.new


### PR DESCRIPTION
This allows an aggregate to have its initializer while still being able
to set our ivars when object is constructed.

https://ruby-doc.org/core-2.2.0/Class.html#method-i-new