### PR TITLE
AggregateRoot's repository instrumentation

### DIFF
--- a/aggregate_root/Gemfile
+++ b/aggregate_root/Gemfile
@@ -7,3 +7,4 @@ eval_gemfile File.expand_path('../support/bundler/Gemfile.shared', __dir__)
 gem 'ruby_event_store', path: '../ruby_event_store'
 gem 'protobuf_nested_struct'
 gem 'google-protobuf', '~> 3.7.0'
+gem 'activesupport', '~> 5.0'

--- a/aggregate_root/lib/aggregate_root.rb
+++ b/aggregate_root/lib/aggregate_root.rb
@@ -3,6 +3,7 @@ require 'aggregate_root/configuration'
 require 'aggregate_root/transform'
 require 'aggregate_root/default_apply_strategy'
 require 'aggregate_root/repository'
+require 'aggregate_root/instrumented_repository'
 
 
 module AggregateRoot

--- a/aggregate_root/lib/aggregate_root/instrumented_repository.rb
+++ b/aggregate_root/lib/aggregate_root/instrumented_repository.rb
@@ -24,7 +24,8 @@ module AggregateRoot
     end
 
     def with_aggregate(aggregate, stream_name, &block)
-      repository.with_aggregate(aggregate, stream_name, &block)
+      block.call(load(aggregate, stream_name))
+      store(aggregate, stream_name)
     end
 
     private

--- a/aggregate_root/lib/aggregate_root/instrumented_repository.rb
+++ b/aggregate_root/lib/aggregate_root/instrumented_repository.rb
@@ -1,0 +1,33 @@
+module AggregateRoot
+  class InstrumentedRepository
+    def initialize(repository, instrumentation)
+      @repository = repository
+      @instrumentation = instrumentation
+    end
+
+    def load(aggregate, stream_name)
+      instrumentation.instrument("load.repository.aggregate_root",
+                                 aggregate_class: aggregate.class,
+                                 stream_name: stream_name) do
+        repository.load(aggregate, stream_name)
+      end
+    end
+
+    def store(aggregate, stream_name)
+      instrumentation.instrument("store.repository.aggregate_root",
+                                 aggregate_class: aggregate.class,
+                                 aggregate_version: aggregate.version,
+                                 stored_events: aggregate.unpublished_events.size,
+                                 stream_name: stream_name) do
+        repository.store(aggregate, stream_name)
+      end
+    end
+
+    def with_aggregate(aggregate, stream_name, &block)
+      repository.with_aggregate(aggregate, stream_name, &block)
+    end
+
+    private
+    attr_reader :instrumentation, :repository
+  end
+end

--- a/aggregate_root/lib/aggregate_root/instrumented_repository.rb
+++ b/aggregate_root/lib/aggregate_root/instrumented_repository.rb
@@ -7,18 +7,18 @@ module AggregateRoot
 
     def load(aggregate, stream_name)
       instrumentation.instrument("load.repository.aggregate_root",
-                                 aggregate_class: aggregate.class,
-                                 stream_name: stream_name) do
+                                 aggregate: aggregate,
+                                 stream: stream_name) do
         repository.load(aggregate, stream_name)
       end
     end
 
     def store(aggregate, stream_name)
       instrumentation.instrument("store.repository.aggregate_root",
-                                 aggregate_class: aggregate.class,
-                                 aggregate_version: aggregate.version,
-                                 stored_events: aggregate.unpublished_events.size,
-                                 stream_name: stream_name) do
+                                 aggregate: aggregate,
+                                 version: aggregate.version,
+                                 stored_events: aggregate.unpublished_events.to_a,
+                                 stream: stream_name) do
         repository.store(aggregate, stream_name)
       end
     end

--- a/aggregate_root/spec/instrumented_repostory_spec.rb
+++ b/aggregate_root/spec/instrumented_repostory_spec.rb
@@ -23,8 +23,8 @@ module AggregateRoot
           instrumented_repository.load(aggregate, 'SomeStream')
 
           expect(notification_calls).to eq([{
-            aggregate_class: Order,
-            stream_name: 'SomeStream',
+            aggregate: aggregate,
+            stream: 'SomeStream',
           }])
         end
       end
@@ -47,14 +47,16 @@ module AggregateRoot
           aggregate = Order.new
           aggregate.create
           aggregate.expire
+          events = aggregate.unpublished_events.to_a
 
+          expect(repository).to have_received(:store).with(aggregate, 'SomeStream')
           instrumented_repository.store(aggregate, 'SomeStream')
 
           expect(notification_calls).to eq([{
-            aggregate_class: Order,
-            aggregate_version: -1,
-            stored_events: 2,
-            stream_name: 'SomeStream',
+            aggregate: aggregate,
+            version: -1,
+            stored_events: events,
+            stream: 'SomeStream',
           }])
         end
       end

--- a/aggregate_root/spec/instrumented_repostory_spec.rb
+++ b/aggregate_root/spec/instrumented_repostory_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+require 'active_support/notifications'
+
+module AggregateRoot
+  RSpec.describe InstrumentedRepository do
+
+    describe "#load" do
+      specify "wraps around original implementation" do
+        some_repository = spy
+        instrumented_repository = InstrumentedRepository.new(some_repository, ActiveSupport::Notifications)
+        aggregate = Order.new
+
+        instrumented_repository.load(aggregate, 'SomeStream')
+
+        expect(some_repository).to have_received(:load).with(aggregate, 'SomeStream')
+      end
+
+      specify "instruments" do
+        instrumented_repository = InstrumentedRepository.new(spy, ActiveSupport::Notifications)
+        subscribe_to("load.repository.aggregate_root") do |notification_calls|
+          aggregate = Order.new
+
+          instrumented_repository.load(aggregate, 'SomeStream')
+
+          expect(notification_calls).to eq([{
+            aggregate_class: Order,
+            stream_name: 'SomeStream',
+          }])
+        end
+      end
+    end
+
+    describe "#store" do
+      specify "wraps around original implementation" do
+        some_repository = spy
+        instrumented_repository = InstrumentedRepository.new(some_repository, ActiveSupport::Notifications)
+        aggregate = Order.new
+
+        instrumented_repository.store(aggregate, 'SomeStream')
+
+        expect(some_repository).to have_received(:store).with(aggregate, 'SomeStream')
+      end
+
+      specify "instruments" do
+        instrumented_repository = InstrumentedRepository.new(spy, ActiveSupport::Notifications)
+        subscribe_to("store.repository.aggregate_root") do |notification_calls|
+          aggregate = Order.new
+          aggregate.create
+          aggregate.expire
+
+          instrumented_repository.store(aggregate, 'SomeStream')
+
+          expect(notification_calls).to eq([{
+            aggregate_class: Order,
+            aggregate_version: -1,
+            stored_events: 2,
+            stream_name: 'SomeStream',
+          }])
+        end
+      end
+    end
+
+    describe "#with_aggregate" do
+      specify "wraps around original implementation" do
+        some_repository = spy
+        instrumented_repository = InstrumentedRepository.new(some_repository, ActiveSupport::Notifications)
+        aggregate = Order.new
+        specific_block = Proc.new { }
+
+        instrumented_repository.with_aggregate(aggregate, 'SomeStream', &specific_block)
+
+        expect(some_repository).to have_received(:with_aggregate).with(aggregate, 'SomeStream') do |&block|
+          expect(block).to be(specific_block)
+        end
+      end
+    end
+
+    def subscribe_to(name)
+      received_payloads = []
+      callback = ->(_name, _start, _finish, _id, payload) { received_payloads << payload }
+      ActiveSupport::Notifications.subscribed(callback, name) do
+        yield received_payloads
+      end
+    end
+  end
+end

--- a/aggregate_root/spec/instrumented_repostory_spec.rb
+++ b/aggregate_root/spec/instrumented_repostory_spec.rb
@@ -6,20 +6,21 @@ module AggregateRoot
 
     describe "#load" do
       specify "wraps around original implementation" do
-        some_repository = spy
-        instrumented_repository = InstrumentedRepository.new(some_repository, ActiveSupport::Notifications)
+        repository = instance_double(Repository)
+        instrumented_repository = InstrumentedRepository.new(repository, ActiveSupport::Notifications)
         aggregate = Order.new
 
+        expect(repository).to receive(:load).with(aggregate, 'SomeStream')
         instrumented_repository.load(aggregate, 'SomeStream')
-
-        expect(some_repository).to have_received(:load).with(aggregate, 'SomeStream')
       end
 
       specify "instruments" do
-        instrumented_repository = InstrumentedRepository.new(spy, ActiveSupport::Notifications)
+        repository = instance_double(Repository)
+        instrumented_repository = InstrumentedRepository.new(repository, ActiveSupport::Notifications)
         subscribe_to("load.repository.aggregate_root") do |notification_calls|
           aggregate = Order.new
 
+          expect(repository).to receive(:load).with(aggregate, 'SomeStream')
           instrumented_repository.load(aggregate, 'SomeStream')
 
           expect(notification_calls).to eq([{
@@ -32,24 +33,24 @@ module AggregateRoot
 
     describe "#store" do
       specify "wraps around original implementation" do
-        some_repository = spy
-        instrumented_repository = InstrumentedRepository.new(some_repository, ActiveSupport::Notifications)
+        repository = instance_double(Repository)
+        instrumented_repository = InstrumentedRepository.new(repository, ActiveSupport::Notifications)
         aggregate = Order.new
 
+        expect(repository).to receive(:store).with(aggregate, 'SomeStream')
         instrumented_repository.store(aggregate, 'SomeStream')
-
-        expect(some_repository).to have_received(:store).with(aggregate, 'SomeStream')
       end
 
       specify "instruments" do
-        instrumented_repository = InstrumentedRepository.new(spy, ActiveSupport::Notifications)
+        repository = instance_double(Repository)
+        instrumented_repository = InstrumentedRepository.new(repository, ActiveSupport::Notifications)
         subscribe_to("store.repository.aggregate_root") do |notification_calls|
           aggregate = Order.new
           aggregate.create
           aggregate.expire
           events = aggregate.unpublished_events.to_a
 
-          expect(repository).to have_received(:store).with(aggregate, 'SomeStream')
+          expect(repository).to receive(:store).with(aggregate, 'SomeStream')
           instrumented_repository.store(aggregate, 'SomeStream')
 
           expect(notification_calls).to eq([{
@@ -64,16 +65,15 @@ module AggregateRoot
 
     describe "#with_aggregate" do
       specify "wraps around original implementation" do
-        some_repository = spy
-        instrumented_repository = InstrumentedRepository.new(some_repository, ActiveSupport::Notifications)
+        repository = instance_double(Repository)
+        instrumented_repository = InstrumentedRepository.new(repository, ActiveSupport::Notifications)
         aggregate = Order.new
         specific_block = Proc.new { }
 
-        instrumented_repository.with_aggregate(aggregate, 'SomeStream', &specific_block)
-
-        expect(some_repository).to have_received(:with_aggregate).with(aggregate, 'SomeStream') do |&block|
+        expect(repository).to receive(:with_aggregate).with(aggregate, 'SomeStream') do |&block|
           expect(block).to be(specific_block)
         end
+        instrumented_repository.with_aggregate(aggregate, 'SomeStream', &specific_block)
       end
     end
 

--- a/aggregate_root/spec/spec_helper.rb
+++ b/aggregate_root/spec/spec_helper.rb
@@ -27,6 +27,14 @@ class Order
     @status = :draft
   end
 
+  def create
+    apply OrderCreated.new
+  end
+
+  def expire
+    apply OrderExpired.new
+  end
+
   attr_accessor :status
   private
 


### PR DESCRIPTION
Instruments `load` & `store` methods. Tracks aggregate class, stream and
for storing also current aggregate version & number of events stored.