### PR TITLE
Adds time filtering of events

### DIFF
--- a/rails_event_store_active_record/spec/event_repository_spec.rb
+++ b/rails_event_store_active_record/spec/event_repository_spec.rb
@@ -170,6 +170,47 @@ module RailsEventStoreActiveRecord
         id: u1 = SecureRandom.uuid,
         data: '{}',
         metadata: '{}',
+        event_type: "TestDomainEvent"
+      )
+      e2 = Event.create!(
+        id: u2 = SecureRandom.uuid,
+        data: '{}',
+        metadata: '{}',
+        event_type: "TestDomainEvent",
+      )
+      e3 = Event.create!(
+        id: u3 = SecureRandom.uuid,
+        data: '{}',
+        metadata: '{}',
+        event_type: "TestDomainEvent",
+      )
+      EventInStream.create!(
+        stream:   "all",
+        position: 1,
+        event_id: e1.id,
+      )
+      EventInStream.create!(
+        stream:   "all",
+        position: 0,
+        event_id: e2.id,
+      )
+      EventInStream.create!(
+        stream:   "all",
+        position: 2,
+        event_id: e3.id,
+      )
+
+      expect(repository.read(specification.older_than(e3.created_at).result).map(&:event_id)).to eq([u1,u2])
+      expect(repository.read(specification.newer_than(e1.created_at).result).map(&:event_id)).to eq([u2,u3])
+      expect(repository.read(specification.older_than(e3.created_at).backward.result).map(&:event_id)).to eq([u2,u1])
+      expect(repository.read(specification.newer_than(e1.created_at).backward.result).map(&:event_id)).to eq([u3,u2])
+    end
+
+    specify do
+      e1 = Event.create!(
+        id: u1 = SecureRandom.uuid,
+        data: '{}',
+        metadata: '{}',
         event_type: "TestDomainEvent",
       )
       e2 = Event.create!(

--- a/ruby_event_store/lib/ruby_event_store/specification.rb
+++ b/ruby_event_store/lib/ruby_event_store/specification.rb
@@ -33,12 +33,34 @@ module RubyEventStore
     # Limits the query to events before or after another event.
     # {http://railseventstore.org/docs/read/ Find out more}.
     #
-    # @param start [String] id of event to start reading from.
+    # @param stop [String] id of event to start reading from.
     # @return [Specification]
     def to(stop)
       raise InvalidPageStop if stop.nil? || stop.empty?
       raise EventNotFound.new(stop) unless reader.has_event?(stop)
       Specification.new(reader, result.dup { |r| r.stop = stop })
+    end
+
+    # Limits the query to events before or after another event.
+    # {http://railseventstore.org/docs/read/ Find out more}.
+    #
+    # @param date [Date]
+    # @param equals [Boolean] whether you want to include events on that date
+    # @return [Specification]
+    def older_than(date, equals = false)
+      raise InvalidPageStart if date.nil? || date.empty?
+      Specification.new(reader, result.dup { |r| r.older_than = [date, equals] })
+    end
+
+    # Limits the query to events before or after another event.
+    # {http://railseventstore.org/docs/read/ Find out more}.
+    #
+    # @param date [Date]
+    # @param equals [Boolean] whether you want to include events on that date
+    # @return [Specification]
+    def newer_than(date, equals = false)
+      raise InvalidPageStop if date.nil? || date.empty?
+      Specification.new(reader, result.dup { |r| r.newer_than = [date, equals] })
     end
 
     # Sets the order of reading events to ascending (forward from the start).

--- a/ruby_event_store/lib/ruby_event_store/specification_result.rb
+++ b/ruby_event_store/lib/ruby_event_store/specification_result.rb
@@ -3,14 +3,16 @@ module RubyEventStore
     def initialize(direction: :forward,
                    start: nil,
                    stop: nil,
+                   older_than: nil,
+                   newer_than: nil,
                    count: nil,
                    stream: Stream.new(GLOBAL_STREAM),
                    read_as: :all,
                    batch_size: Specification::DEFAULT_BATCH_SIZE,
                    with_ids: nil,
                    with_types: nil)
-      @attributes = Struct.new(:direction, :start, :stop, :count, :stream, :read_as, :batch_size, :with_ids, :with_types)
-        .new(direction, start, stop, count, stream, read_as, batch_size, with_ids, with_types)
+      @attributes = Struct.new(:direction, :start, :stop, :older_than, :newer_than, :count, :stream, :read_as, :batch_size, :with_ids, :with_types)
+        .new(direction, start, stop, older_than, newer_than, count, stream, read_as, batch_size, with_ids, with_types)
       freeze
     end
 
@@ -52,6 +54,22 @@ module RubyEventStore
     # @return [String|Symbol]
     def stop
       attributes.stop
+    end
+
+    # Ending date.
+    # {http://railseventstore.org/docs/read/ Find out more}.
+    #
+    # @return [Array<Date, Boolean>]
+    def older_than
+      attributes.older_than
+    end
+
+    # Starting date.
+    # {http://railseventstore.org/docs/read/ Find out more}.
+    #
+    # @return [Array<Date, Boolean>]
+    def newer_than
+      attributes.newer_than
     end
 
     # Read direction. True is reading forward
@@ -177,6 +195,8 @@ module RubyEventStore
     # * direction
     # * start
     # * stop
+    # * older_than,
+    # * newer_than
     # * count
     # * stream
     # * read_as
@@ -191,6 +211,8 @@ module RubyEventStore
         get_direction,
         start,
         stop,
+        older_than.join(''),
+        newer_than.join(''),
         limit,
         stream,
         attributes.read_as,

--- a/ruby_event_store/spec/specification_spec.rb
+++ b/ruby_event_store/spec/specification_spec.rb
@@ -47,6 +47,12 @@ module RubyEventStore
     specify { expect{specification.to(:dummy) }.to raise_error(EventNotFound, /dummy/) }
     specify { expect{specification.to(none_such_id) }.to raise_error(EventNotFound, /#{none_such_id}/) }
 
+    specify { expect{specification.older_than(nil)}.to raise_error(InvalidPageStart) }
+    specify { expect{specification.older_than('')}.to raise_error(InvalidPageStart) }
+
+    specify { expect{specification.newer_than(nil)}.to raise_error(InvalidPageStop) }
+    specify { expect{specification.newer_than('')}.to raise_error(InvalidPageStop) }
+
     specify { expect(specification.result.with_ids).to be_nil }
     specify { expect(specification.with_id([event_id]).result.with_ids).to eq([event_id]) }
     specify { expect(specification.result.with_ids?).to eq(false) }
@@ -71,12 +77,42 @@ module RubyEventStore
     end
 
     specify do
+      expect(specification.older_than(target_date).result.older_than).to eq([target_date, false])
+    end
+
+    specify do
+      expect(specification.newer_than(target_date).result.newer_than).to eq([target_date, false])
+    end
+
+    specify do
       with_event_of_id(event_id) do
         spec = specification.backward.stream(stream_name).limit(10).from(event_id)
         expect(spec.result.stream.name).to eq(stream_name)
         expect(spec.result.stream.global?).to eq(false)
         expect(spec.result.limit).to eq(10)
         expect(spec.result.start).to eq(event_id)
+        expect(spec.result.backward?).to eq(true)
+      end
+    end
+
+    specify do
+      with_event_of_id(event_id) do
+        spec = specification.backward.stream(stream_name).limit(10).older_than(target_date)
+        expect(spec.result.stream.name).to eq(stream_name)
+        expect(spec.result.stream.global?).to eq(false)
+        expect(spec.result.limit).to eq(10)
+        expect(spec.result.older_than).to eq([target_date, false])
+        expect(spec.result.backward?).to eq(true)
+      end
+    end
+
+    specify do
+      with_event_of_id(event_id) do
+        spec = specification.backward.stream(stream_name).limit(10).newer_than(target_date)
+        expect(spec.result.stream.name).to eq(stream_name)
+        expect(spec.result.stream.global?).to eq(false)
+        expect(spec.result.limit).to eq(10)
+        expect(spec.result.newer_than).to eq([target_date, false])
         expect(spec.result.backward?).to eq(true)
       end
     end
@@ -103,6 +139,8 @@ module RubyEventStore
           specification.limit(10),
           specification.from(event_id),
           specification.to(event_id),
+          specification.older_than(target_date),
+          specification.newer_than(target_date),
           specification.stream(stream_name),
           specification.with_id([event_id]),
           specification.of_type([TestEvent]),
@@ -140,6 +178,30 @@ module RubyEventStore
         expect(specification.to(event_id).forward.result.stop).to eq(event_id)
         expect(specification.to(event_id).backward.result.stop).to eq(event_id)
         expect(specification.read_last.to(event_id).result.last?).to eq(true)
+      end
+    end
+
+    specify do
+      with_event_of_id(event_id) do
+        expect(specification.older_than(target_date).stream('dummy').result.older_than).to eq([target_date, false])
+        expect(specification.older_than(target_date).limit(1).result.older_than).to eq([target_date, false])
+        expect(specification.older_than(target_date).read_first.result.older_than).to eq([target_date, false])
+        expect(specification.older_than(target_date).read_last.result.older_than).to eq([target_date, false])
+        expect(specification.older_than(target_date).forward.result.older_than).to eq([target_date, false])
+        expect(specification.older_than(target_date).backward.result.older_than).to eq([target_date, false])
+        expect(specification.read_first.older_than(target_date).result.first?).to eq(true)
+      end
+    end
+
+    specify do
+      with_event_of_id(event_id) do
+        expect(specification.newer_than(target_date).stream('dummy').result.newer_than).to eq([target_date, false])
+        expect(specification.newer_than(target_date).limit(1).result.newer_than).to eq([target_date, false])
+        expect(specification.newer_than(target_date).read_first.result.newer_than).to eq([target_date, false])
+        expect(specification.newer_than(target_date).read_last.result.newer_than).to eq([target_date, false])
+        expect(specification.newer_than(target_date).forward.result.newer_than).to eq([target_date, false])
+        expect(specification.newer_than(target_date).backward.result.newer_than).to eq([target_date, false])
+        expect(specification.read_last.newer_than(target_date).result.last?).to eq(true)
       end
     end
 
@@ -188,6 +250,28 @@ module RubyEventStore
         expect(spec.result.batch_size).to eq(Specification::DEFAULT_BATCH_SIZE)
 
         spec = specification.to(event_id)
+        expect(spec.result.object_id).not_to eq(specification.result.object_id)
+        expect(spec.result.forward?).to eq(true)
+        expect(spec.result.start).to eq(nil)
+        expect(spec.result.stop).to eq(event_id)
+        expect(spec.result.limit?).to eq(false)
+        expect(spec.result.stream.name).to eq(GLOBAL_STREAM)
+        expect(spec.result.stream.global?).to eq(true)
+        expect(spec.result.all?).to eq(true)
+        expect(spec.result.batch_size).to eq(Specification::DEFAULT_BATCH_SIZE)
+
+        spec = specification.older_than(target_date)
+        expect(spec.result.object_id).not_to eq(specification.result.object_id)
+        expect(spec.result.forward?).to eq(true)
+        expect(spec.result.start).to eq(event_id)
+        expect(spec.result.stop).to eq(nil)
+        expect(spec.result.limit?).to eq(false)
+        expect(spec.result.stream.name).to eq(GLOBAL_STREAM)
+        expect(spec.result.stream.global?).to eq(true)
+        expect(spec.result.all?).to eq(true)
+        expect(spec.result.batch_size).to eq(Specification::DEFAULT_BATCH_SIZE)
+
+        spec = specification.newer_than(target_date)
         expect(spec.result.object_id).not_to eq(specification.result.object_id)
         expect(spec.result.forward?).to eq(true)
         expect(spec.result.start).to eq(nil)
@@ -374,6 +458,24 @@ module RubyEventStore
     end
 
     specify do
+      records = [test_record, test_record]
+      repository.append_to_stream(records, Stream.new("Dummy"), ExpectedVersion.none)
+
+      expect(specification.older_than(records[0].created_a).to_a).to eq(
+        [TestEvent.new(event_id: records[1].event_id)]
+      )
+    end
+
+    specify do
+      records = [test_record, test_record]
+      repository.append_to_stream(records, Stream.new("Dummy"), ExpectedVersion.none)
+
+      expect(specification.newer_than(records[1].created_at).to_a.last.event_id).to eq(
+        records[0].event_id
+      )
+    end
+
+    specify do
       batch_size = 100
       records = (batch_size * 10).times.map { test_record }
       repository.append_to_stream(records, Stream.new("batch"), ExpectedVersion.none)
@@ -456,6 +558,18 @@ module RubyEventStore
 
       expect(specification.from(records[0].event_id).backward.first).to be_nil
       expect(specification.from(records[0].event_id).backward.last).to be_nil
+
+      expect(specification.older_than(records[2].created_at).first).to eq(TestEvent.new(event_id: records[3].event_id))
+      expect(specification.older_than(records[2].created_at).last).to eq(TestEvent.new(event_id: records[4].event_id))
+
+      expect(specification.older_than(records[2].created_at).backward.first).to eq(TestEvent.new(event_id: records[1].event_id))
+      expect(specification.older_than(records[2].created_at).backward.last).to eq(TestEvent.new(event_id: records[0].event_id))
+
+      expect(specification.older_than(records[4].created_at).first).to be_nil
+      expect(specification.older_than(records[4].created_at).last).to be_nil
+
+      expect(specification.older_than(records[0].created_at).backward.first).to be_nil
+      expect(specification.older_than(records[0].created_at).backward.last).to be_nil
     end
 
     specify do
@@ -524,8 +638,9 @@ module RubyEventStore
 
       with_event_of_id(event_id) do
         expect(specification.from(event_id).result.hash).not_to eq(specification.result.hash)
-
         expect(specification.to(event_id).result.hash).not_to eq(specification.result.hash)
+        expect(specification.older_than(target_date).result.hash).not_to eq(specification.result.hash)
+        expect(specification.newer_than(target_date).result.hash).not_to eq(specification.result.hash)
       end
 
       expect(specification.result.hash).not_to eq([
@@ -563,6 +678,7 @@ module RubyEventStore
 
       with_event_of_id(event_id) do
         expect(specification.from(event_id).result).not_to eq(specification.result)
+        expect(specification.older_than(target_date).result).not_to eq(specification.result)
       end
     end
 
@@ -658,6 +774,7 @@ module RubyEventStore
     let(:none_such_id)  { SecureRandom.uuid }
     let(:stream_name)   { SecureRandom.hex }
     let(:test_event)    { TestEvent.new(event_id: event_id) }
+    let(:target_date)   { 1.day.ago }
 
     def test_record(event_id = SecureRandom.uuid, event_type: TestEvent, data: {})
       mapper.event_to_serialized_record(


### PR DESCRIPTION
# Adds filtering of events by time

👋 Hello there!

This is my first PR to the project.
We have this use case where we want to filter events by their creation date. We implemented our own version of the event browser explorer but adapted to our domain. One of the requirements we have is to be able to filter out events by date, but right now there is no easy way to do so with rails event store.

Let me know what you think!