### PR TITLE
Upgrade ROM adapter dependencies (dry-types v1.0, rom v5.0, rom-sql v3.0)

### DIFF
--- a/ruby_event_store-rom/lib/ruby_event_store/rom.rb
+++ b/ruby_event_store-rom/lib/ruby_event_store/rom.rb
@@ -45,8 +45,12 @@ module RubyEventStore
       def handle_error(type, *args, swallow: [])
         yield
       rescue StandardError => e
-        resolve(:"#{type}_error_handlers").each { |h| h.call(e, *args) }
-        raise e
+        begin
+          resolve(:"#{type}_error_handlers").each { |h| h.call(e, *args) }
+          raise e
+        rescue *swallow
+          # swallow
+        end
       end
     end
 

--- a/ruby_event_store-rom/lib/ruby_event_store/rom/adapters/memory/relations/stream_entries.rb
+++ b/ruby_event_store-rom/lib/ruby_event_store/rom/adapters/memory/relations/stream_entries.rb
@@ -4,9 +4,9 @@ module RubyEventStore
       module Relations
         class StreamEntries < ::ROM::Relation[:memory]
           schema(:stream_entries) do
-            attribute(:id, ::ROM::Types::Strict::Int.meta(primary_key: true).default { RubyEventStore::ROM::Memory.fetch_next_id })
+            attribute(:id, ::ROM::Types::Strict::Integer.meta(primary_key: true).default { RubyEventStore::ROM::Memory.fetch_next_id })
             attribute :stream, ::ROM::Types::Strict::String
-            attribute :position, ::ROM::Types::Strict::Int.optional
+            attribute :position, ::ROM::Types::Strict::Integer.optional
             attribute :event_id, ::ROM::Types::Strict::String.meta(foreign_key: true, relation: :events)
             attribute :created_at, RubyEventStore::ROM::Types::DateTime
 

--- a/ruby_event_store-rom/lib/ruby_event_store/rom/adapters/memory/unit_of_work.rb
+++ b/ruby_event_store-rom/lib/ruby_event_store/rom/adapters/memory/unit_of_work.rb
@@ -13,7 +13,7 @@ module RubyEventStore
             begin
               until changesets.empty?
                 changeset = changesets.shift
-                relation = env.container.relations[changeset.relation.name]
+                relation = env.rom_container.relations[changeset.relation.name]
 
                 committed << [changeset, relation]
 

--- a/ruby_event_store-rom/lib/ruby_event_store/rom/adapters/sql/changesets/update_events.rb
+++ b/ruby_event_store-rom/lib/ruby_event_store/rom/adapters/sql/changesets/update_events.rb
@@ -5,7 +5,7 @@ module RubyEventStore
         class UpdateEvents < ::ROM::Changeset::Create
           include ROM::Changesets::UpdateEvents::Defaults
 
-          UPSERT_COLUMNS = %i[event_type data metadata created_at]
+          UPSERT_COLUMNS = %i[event_type data metadata created_at].freeze
 
           def commit
             if SQL.supports_on_duplicate_key_update?(relation.dataset.db)

--- a/ruby_event_store-rom/lib/ruby_event_store/rom/adapters/sql/tasks/migration_tasks.rake
+++ b/ruby_event_store-rom/lib/ruby_event_store/rom/adapters/sql/tasks/migration_tasks.rake
@@ -5,7 +5,7 @@ MIGRATIONS_PATH = 'db/migrate'.freeze
 desc 'Setup ROM EventRespository environment'
 task 'db:setup' do
   Dir.chdir(Dir.pwd)
-  ROM::SQL::RakeSupport.env = ::RubyEventStore::ROM.configure(:sql).container
+  ROM::SQL::RakeSupport.env = ::RubyEventStore::ROM.configure(:sql).rom_container
 end
 
 desc 'Copy RubyEventStore SQL migrations to db/migrate'

--- a/ruby_event_store-rom/lib/ruby_event_store/rom/event_repository.rb
+++ b/ruby_event_store-rom/lib/ruby_event_store/rom/event_repository.rb
@@ -13,8 +13,8 @@ module RubyEventStore
         raise ArgumentError, 'Must specify rom' unless rom && rom.instance_of?(Env)
 
         @rom = rom
-        @events = Repositories::Events.new(rom.container)
-        @stream_entries = Repositories::StreamEntries.new(rom.container)
+        @events = Repositories::Events.new(rom.rom_container)
+        @stream_entries = Repositories::StreamEntries.new(rom.rom_container)
       end
 
       def append_to_stream(events, stream, expected_version)

--- a/ruby_event_store-rom/lib/ruby_event_store/rom/memory.rb
+++ b/ruby_event_store-rom/lib/ruby_event_store/rom/memory.rb
@@ -52,7 +52,7 @@ module RubyEventStore
         end
 
         def gateway
-          env.container.gateways.fetch(:default)
+          env.rom_container.gateways.fetch(:default)
         end
 
         def drop_gateway_schema

--- a/ruby_event_store-rom/lib/ruby_event_store/rom/sql.rb
+++ b/ruby_event_store-rom/lib/ruby_event_store/rom/sql.rb
@@ -63,7 +63,7 @@ module RubyEventStore
 
         def supports_upsert?(db)
           supports_on_duplicate_key_update?(db) ||
-          supports_insert_conflict_update?(db)
+            supports_insert_conflict_update?(db)
         end
 
         def supports_on_duplicate_key_update?(db)
@@ -76,7 +76,7 @@ module RubyEventStore
             true
           when :sqlite
             # Sqlite 3.24.0+ supports PostgreSQL upsert syntax
-            db.sqlite_version >= 32400
+            db.sqlite_version >= 32_400
           else
             false
           end
@@ -91,7 +91,7 @@ module RubyEventStore
             :sql,
             database_uri,
             max_connections: database_uri =~ /sqlite/ ? 1 : 5,
-            preconnect: :concurrently,
+            preconnect: :concurrently
             # sql_mode: %w[NO_AUTO_VALUE_ON_ZERO STRICT_ALL_TABLES]
           )
           # $stdout.sync = true
@@ -113,7 +113,7 @@ module RubyEventStore
         end
 
         def gateway
-          env.container.gateways.fetch(:default)
+          env.rom_container.gateways.fetch(:default)
         end
 
         def gateway_type?(name)

--- a/ruby_event_store-rom/lib/ruby_event_store/rom/types.rb
+++ b/ruby_event_store-rom/lib/ruby_event_store/rom/types.rb
@@ -2,7 +2,16 @@ module RubyEventStore
   module ROM
     module Types
       DateTime = ::ROM::Types::DateTime
-                 .constructor { |value| value.is_a?(::String) ? ::DateTime.iso8601(value) : value }
+                 .constructor do |value|
+                   case value
+                   when nil
+                     Dry::Core::Constants::Undefined
+                   when ::String
+                     ::DateTime.iso8601(value)
+                   else
+                     value
+                   end
+                 end
                  .default { ::DateTime.now.new_offset(0) }
 
       SerializedRecordSerializer = ::ROM::Types::String

--- a/ruby_event_store-rom/lib/ruby_event_store/rom/unit_of_work.rb
+++ b/ruby_event_store-rom/lib/ruby_event_store/rom/unit_of_work.rb
@@ -8,7 +8,7 @@ module RubyEventStore
       end
 
       def call(**options)
-        gateway = @env.container.gateways.fetch(options.delete(:gateway) { :default })
+        gateway = @env.rom_container.gateways.fetch(options.delete(:gateway) { :default })
 
         yield(changesets = [])
 

--- a/ruby_event_store-rom/lib/ruby_event_store/rom/version.rb
+++ b/ruby_event_store-rom/lib/ruby_event_store/rom/version.rb
@@ -1,5 +1,5 @@
 module RubyEventStore
   module ROM
-    VERSION = "0.39.0"
+    VERSION = '0.39.0'.freeze
   end
 end

--- a/ruby_event_store-rom/lib/ruby_event_store/spec/rom/event_repository_lint.rb
+++ b/ruby_event_store-rom/lib/ruby_event_store/spec/rom/event_repository_lint.rb
@@ -6,8 +6,8 @@ module RubyEventStore::ROM
     subject(:repository) { repository_class.new(rom: env) }
 
     let(:env) { rom_helper.env }
-    let(:container) { env.container }
-    let(:rom_db) { container.gateways[:default] }
+    let(:rom_container) { env.rom_container }
+    let(:rom_db) { rom_container.gateways[:default] }
 
     around(:each) do |example|
       rom_helper.run_lifecycle { example.run }
@@ -68,7 +68,7 @@ module RubyEventStore::ROM
         RubyEventStore::SRecord.new(event_id: u3 = SecureRandom.uuid)
       ]
 
-      repo = Repositories::Events.new(container)
+      repo = Repositories::Events.new(rom_container)
       repo.create_changeset(events).commit
 
       expect(repo.events.to_a.size).to eq(3)
@@ -100,7 +100,7 @@ module RubyEventStore::ROM
         RubyEventStore::SRecord.new(event_id: u3 = SecureRandom.uuid)
       ]
 
-      repo = Repositories::Events.new(container)
+      repo = Repositories::Events.new(rom_container)
       repo.create_changeset(events).commit
 
       expect(repo.events.to_a.size).to eq(3)
@@ -145,9 +145,9 @@ module RubyEventStore::ROM
 
     # TODO: Port from AR to ROM
     def additional_limited_concurrency_for_auto_check
-      positions = container.relations[:stream_entries]
-                           .ordered(:forward, default_stream)
-                           .map { |entity| entity[:position] }
+      positions = rom_container.relations[:stream_entries]
+                               .ordered(:forward, default_stream)
+                               .map { |entity| entity[:position] }
       expect(positions).to eq((0..positions.size - 1).to_a)
     end
 

--- a/ruby_event_store-rom/lib/ruby_event_store/spec/rom/relations/events_lint.rb
+++ b/ruby_event_store-rom/lib/ruby_event_store/spec/rom/relations/events_lint.rb
@@ -1,9 +1,9 @@
 RSpec.shared_examples :events_relation do |_relation_class|
-  subject(:relation) { container.relations[:events] }
+  subject(:relation) { rom_container.relations[:events] }
 
   let(:env) { rom_helper.env }
-  let(:container) { env.container }
-  let(:rom_db) { container.gateways[:default] }
+  let(:rom_container) { env.rom_container }
+  let(:rom_db) { rom_container.gateways[:default] }
 
   around(:each) do |example|
     rom_helper.run_lifecycle { example.run }

--- a/ruby_event_store-rom/lib/ruby_event_store/spec/rom/relations/stream_entries_lint.rb
+++ b/ruby_event_store-rom/lib/ruby_event_store/spec/rom/relations/stream_entries_lint.rb
@@ -1,9 +1,9 @@
 RSpec.shared_examples :stream_entries_relation do |_relation_class|
-  subject(:relation) { container.relations[:stream_entries] }
+  subject(:relation) { rom_container.relations[:stream_entries] }
 
   let(:env) { rom_helper.env }
-  let(:container) { env.container }
-  let(:rom_db) { container.gateways[:default] }
+  let(:rom_container) { env.rom_container }
+  let(:rom_db) { rom_container.gateways[:default] }
 
   around(:each) do |example|
     rom_helper.run_lifecycle { example.run }

--- a/ruby_event_store-rom/lib/ruby_event_store/spec/rom/spec_helper_lint.rb
+++ b/ruby_event_store-rom/lib/ruby_event_store/spec/rom/spec_helper_lint.rb
@@ -1,15 +1,15 @@
 module RubyEventStore::ROM
   RSpec.shared_examples :rom_spec_helper do |_rom_spec_helper_class|
     let(:env) { rom_helper.env }
-    let(:container) { env.container }
-    let(:rom_db) { container.gateways[:default] }
+    let(:rom_container) { env.rom_container }
+    let(:rom_db) { rom_container.gateways[:default] }
 
     around(:each) do |example|
       rom_helper.run_lifecycle { example.run }
     end
 
     specify '#env gives access to ROM container' do
-      expect(subject.env.container).to be_a(::ROM::Container)
+      expect(subject.env.rom_container).to be_a(::ROM::Container)
     end
   end
 end

--- a/ruby_event_store-rom/lib/ruby_event_store/spec/rom/unit_of_work_lint.rb
+++ b/ruby_event_store-rom/lib/ruby_event_store/spec/rom/unit_of_work_lint.rb
@@ -3,15 +3,15 @@ module RubyEventStore::ROM
     subject(:unit_of_work) { unit_of_work_class.new(rom: env) }
 
     let(:env) { rom_helper.env }
-    let(:container) { env.container }
-    let(:rom_db) { container.gateways[:default] }
+    let(:v) { env.rom_container }
+    let(:rom_db) { rom_container.gateways[:default] }
 
     around(:each) do |example|
       rom_helper.run_lifecycle { example.run }
     end
 
     specify '#env gives access to ROM container' do
-      expect(subject.env.container).to be_a(::ROM::Container)
+      expect(subject.env.rom_container).to be_a(::ROM::Container)
     end
 
     specify '#call to throw an exeption' do

--- a/ruby_event_store-rom/ruby_event_store-rom.gemspec
+++ b/ruby_event_store-rom/ruby_event_store-rom.gemspec
@@ -24,12 +24,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'dry-initializer', '= 2.5.0'
-  spec.add_dependency 'dry-types', '~> 0.12.2'
-  spec.add_dependency 'dry-container', '< 0.7.0'
-  spec.add_dependency 'rom-changeset', '>= 1.0'
-  spec.add_dependency 'rom-repository', '>= 2.0'
-  spec.add_dependency 'rom-sql', '>= 2.4'
+  spec.add_dependency 'dry-container', '>= 0.6'
+  spec.add_dependency 'dry-initializer', '>= 3.0'
+  spec.add_dependency 'dry-types', '>= 1.0'
+  spec.add_dependency 'rom-changeset', '>= 5.0'
+  spec.add_dependency 'rom-repository', '>= 5.0'
+  spec.add_dependency 'rom-sql', '>= 3.0'
   spec.add_dependency 'ruby_event_store', '= 0.39.0'
   spec.add_dependency 'sequel', '>= 5.11.0'
 end

--- a/ruby_event_store-rom/ruby_event_store-rom.gemspec
+++ b/ruby_event_store-rom/ruby_event_store-rom.gemspec
@@ -24,6 +24,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.4'
+
   spec.add_dependency 'dry-container', '>= 0.6'
   spec.add_dependency 'dry-initializer', '>= 3.0'
   spec.add_dependency 'dry-types', '>= 1.0'

--- a/ruby_event_store-rom/spec/rom/adapters/memory/relations/events_spec.rb
+++ b/ruby_event_store-rom/spec/rom/adapters/memory/relations/events_spec.rb
@@ -6,11 +6,11 @@ module RubyEventStore::ROM::Memory
   RSpec.describe Relations::Events do
     let(:rom_helper) { SpecHelper.new }
 
-    subject(:relation) { container.relations[:events] }
+    subject(:relation) { rom_container.relations[:events] }
 
     let(:env) { rom_helper.env }
-    let(:container) { env.container }
-    let(:rom_db) { container.gateways[:default] }
+    let(:rom_container) { env.rom_container }
+    let(:rom_db) { rom_container.gateways[:default] }
 
     around(:each) do |example|
       rom_helper.run_lifecycle { example.run }

--- a/ruby_event_store-rom/spec/rom/adapters/memory/relations/stream_entries_spec.rb
+++ b/ruby_event_store-rom/spec/rom/adapters/memory/relations/stream_entries_spec.rb
@@ -9,7 +9,7 @@ module RubyEventStore::ROM::Memory
     it_behaves_like :stream_entries_relation, Relations::StreamEntries
 
     specify '#insert raises errors' do
-      relation = rom_helper.env.container.relations[:stream_entries]
+      relation = rom_helper.env.rom_container.relations[:stream_entries]
 
       stream_entries = [
         { stream: 'stream', position: 0, event_id: id1 = SecureRandom.uuid },

--- a/ruby_event_store-rom/spec/rom/env_spec.rb
+++ b/ruby_event_store-rom/spec/rom/env_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 module RubyEventStore::ROM
   RSpec.describe Env do
-    let(:container) { ::ROM.container }
-    let(:instance) { Env.new(container) }
+    let(:rom_container) { ::ROM.container }
+    let(:instance) { Env.new(rom_container) }
 
     specify '#container gives access to ROM container' do
-      expect(instance.container).to be_a(::ROM::Container)
+      expect(instance.rom_container).to be_a(::ROM::Container)
     end
 
     specify '#logger gives access to Logger' do

--- a/ruby_event_store-rom/spec/spec_helper.rb
+++ b/ruby_event_store-rom/spec/spec_helper.rb
@@ -16,11 +16,11 @@ module RomHelpers
     rom_helper.env
   end
 
-  def container
-    env.container
+  def rom_container
+    env.rom_container
   end
 
   def rom_db
-    container.gateways[:default]
+    rom_container.gateways[:default]
   end
 end


### PR DESCRIPTION
This upgrade of dry-types introduces breaking changes for any dry-* dependencies projects may have.

There are no breaking changes in RES, only minor updates to internals.

@paneq @pawelpacana I'll let you guys merge this. Not sure if you have any concerns or opinions about this upgrade -- it should only affect projects using the ROM adapter who also depend on DRY gems.