### PR TITLE
AggregateRoot `on_methods` inheritance

### DIFF
--- a/aggregate_root/lib/aggregate_root.rb
+++ b/aggregate_root/lib/aggregate_root.rb
@@ -14,13 +14,14 @@ module AggregateRoot
         handler_name = "on_#{name}"
         define_method(handler_name, &block)
         @on_methods ||= {}
-        on_methods[name] = handler_name
+        @on_methods[name] = handler_name
         private(handler_name)
       end
     end
 
     def on_methods
-      @on_methods || {}
+      @on_methods ||= {}
+      (superclass.respond_to?(:on_methods) ? superclass.on_methods : {}).merge(@on_methods)
     end
   end
 
@@ -59,7 +60,7 @@ module AggregateRoot
     Module.new do
       def self.included(host_class)
         host_class.extend  OnDSL
-        host_class.include AggregateRoot.with_strategy(->{ DefaultApplyStrategy.new(on_methods: host_class.on_methods) })
+        host_class.include AggregateRoot.with_strategy(->{ DefaultApplyStrategy.new })
       end
     end
   end

--- a/aggregate_root/lib/aggregate_root/default_apply_strategy.rb
+++ b/aggregate_root/lib/aggregate_root/default_apply_strategy.rb
@@ -2,13 +2,12 @@ module AggregateRoot
   MissingHandler = Class.new(StandardError)
 
   class DefaultApplyStrategy
-    def initialize(strict: true, on_methods: {})
+    def initialize(strict: true)
       @strict = strict
-      @on_methods = on_methods
     end
 
     def call(aggregate, event)
-      name = handler_name(event)
+      name = handler_name(aggregate, event)
       if aggregate.respond_to?(name, true)
         aggregate.method(name).call(event)
       else
@@ -18,8 +17,8 @@ module AggregateRoot
 
     private
 
-    def handler_name(event)
-      on_methods.fetch(event.type) { handler_name_by_type(event.type) }
+    def handler_name(aggregate, event)
+      aggregate.class.on_methods.fetch(event.type) { handler_name_by_type(event.type) }
     end
 
     def handler_name_by_type(event_type)

--- a/aggregate_root/spec/aggregate_root_spec.rb
+++ b/aggregate_root/spec/aggregate_root_spec.rb
@@ -221,6 +221,10 @@ RSpec.describe AggregateRoot do
         on Orders::Events::OrderCreated do |_ev|
           @status = :created_inherited
         end
+
+        on Orders::Events::OrderCanceled do |_ev|
+          @status = :canceled_inherited
+        end
       end
 
       order = order_with_ons.new
@@ -232,11 +236,24 @@ RSpec.describe AggregateRoot do
       expect(order.private_methods).to include(:"on_Orders::Events::OrderCreated")
       expect(order.private_methods).to include(:"on_Orders::Events::OrderExpired")
 
+      expect(order_with_ons.on_methods.keys).to include("Orders::Events::OrderCreated")
+      expect(order_with_ons.on_methods.keys).to include("Orders::Events::OrderExpired")
+
       order = inherited_order_with_ons.new
       order.apply(Orders::Events::OrderCreated.new)
       expect(order.status).to eq(:created_inherited)
       order.apply(Orders::Events::OrderExpired.new)
       expect(order.status).to eq(:expired)
+      order.apply(Orders::Events::OrderCanceled.new)
+      expect(order.status).to eq(:canceled_inherited)
+
+      expect(order.private_methods).to include(:"on_Orders::Events::OrderCreated")
+      expect(order.private_methods).to include(:"on_Orders::Events::OrderExpired")
+      expect(order.private_methods).to include(:"on_Orders::Events::OrderCanceled")
+
+      expect(inherited_order_with_ons.on_methods.keys).to include("Orders::Events::OrderCreated")
+      expect(inherited_order_with_ons.on_methods.keys).to include("Orders::Events::OrderExpired")
+      expect(inherited_order_with_ons.on_methods.keys).to include("Orders::Events::OrderCanceled")
     end
 
     it "handles super() with inheritance" do

--- a/aggregate_root/spec/spec_helper.rb
+++ b/aggregate_root/spec/spec_helper.rb
@@ -15,6 +15,7 @@ module Orders
   module Events
     OrderCreated = Class.new(RubyEventStore::Event)
     OrderExpired = Class.new(RubyEventStore::Event)
+    OrderCanceled = Class.new(RubyEventStore::Event)
     SpanishInquisition = Class.new(RubyEventStore::Event)
   end
 end


### PR DESCRIPTION
The problem with the removal of the ancestor chain of `on_methods` is that the default strategy gets a copy of `@on_methods` from the base class that the `AggregateRoot` module is included in. When a class inherits from that base class, any additional events handled in the sublcass are not added to the `@on_methods` hash already captured by the default strategy.

The proposed solution accesses `on_methods` directly on the aggregate inside the default strategy, and restores merging `@on_methods` through the ancestor chain.

Addresses one of the issues mentioned in #596