### PR TITLE
Improve documentation readability

### DIFF
--- a/railseventstore.org/source/docs/app.html.md.erb
+++ b/railseventstore.org/source/docs/app.html.md.erb
@@ -4,7 +4,7 @@ title: Event Sourcing with AggregateRoot
 
 ## Configuration
 
-Choose your event store client. To do so add configuration in environment setup. Example using [RailsEventStore](https://github.com/RailsEventStore/rails_event_store/):
+Choose your event store client. To do so add configuration in your environment setup. Example using [RailsEventStore](https://github.com/RailsEventStore/rails_event_store/):
 
 ```ruby
 AggregateRoot.configure do |config|
@@ -14,11 +14,11 @@ AggregateRoot.configure do |config|
 end
 ```
 
-Remember that this is only a default event store used by `AggregateRoot` module to initialize `AggregateRoot::Repository` when no event store is given in repository's constructor as argument.
+Remember that this is only a default event store used by the `AggregateRoot` module to initialize `AggregateRoot::Repository` when no event store is given in the repository's constructor as an argument.
 
 ## Usage
 
-To create a new aggregate domain object include `AggregateRoot` module.
+To create a new aggregate domain object, include the `AggregateRoot` module.
 
 ```ruby
 class Order
@@ -71,11 +71,11 @@ class Order
 end
 ```
 
-The convention is to use `apply_` plus an underscored event class name for event handler methods. I.e. when you apply `OrderExpired` event, the `apply_order_expired` method is called.
+The convention is to use `apply_` plus an underscored event class name for event handler methods. I.e. when you apply the `OrderExpired` event, the `apply_order_expired` method is called.
 
 #### Alternative syntax for event handler methods.
 
-You can use class method `on(event_klass, &method)` for defining those methods alternatively. This is useful because you can more easily grep/find where events are used in your codebase.
+Alternatively, you can use the class method `on(event_klass, &method)` for defining those methods. This is useful because you can more easily grep/find where events are used in your codebase.
 
 ```ruby
 class Order
@@ -113,16 +113,16 @@ class Order
 end
 ```
 
-#### Loading an aggregate root object from event store
+#### Loading an aggregate root object from an event store
 
 ```ruby
 stream_name = "Order$123"
 order = AggregateRoot::Repository.new.load(Order.new, stream_name)
 ```
 
-To restore the state of your aggregate you need to use `AggregateRoot::Repository`. Repository's `#load` gets all domain events stored for the aggregate in event store stream `Order$123` and applies them to newly created order object in order to rebuild aggregate's state.
+To restore the state of your aggregate you need to use `AggregateRoot::Repository`. Repository's `#load` gets all domain events stored for the aggregate in the event store stream `Order$123` and applies them to the newly created order object in order to rebuild the aggregate's state.
 
-#### Storing an aggregate root's changes in event store
+#### Storing an aggregate root's changes in an event store
 
 ```ruby
 stream_name = "Order$123"
@@ -132,11 +132,11 @@ order.submit
 repository.store(order, stream_name)
 ```
 
-Also storing (publishing) aggregate changes is performed by `AggregateRoot::Repository` object. Repository's `#store` gets all unpublished aggregate's domain events (added by executing a domain logic method like `submit`) from `unpublished_events` and publishes them in order of creation to event store.
+Storing (publishing) aggregate changes is also performed by the `AggregateRoot::Repository` object. Repository's `#store` gets all the unpublished aggregate's domain events (added by executing a domain logic method like `submit`) from `unpublished_events` and publishes them in order of creation to the event store.
 
 #### Simplify loading/storing aggregates
 
-`AggregateRoot::Repository` delivers convinient method to handle typical flow of work with aggregates. The `with_aggregate` method will load an aggregate from given stream, yield block to allow perform action on aggregate object (aggregate object will be yielded as block argument) and then publish all changes in aggregate to event store provided to repository.
+`AggregateRoot::Repository` delivers a convenient method to handle a typical workflow with aggregates. The `with_aggregate` method will load an aggregate from a given stream, yield a block to allow performing an action on the aggregate object (the aggregate object will be yielded as a block argument), and then publish all changes in aggregate to the event store provided to the repository.
 
 ```ruby
 stream_name = "Order$123"
@@ -146,7 +146,7 @@ repository.with_aggregate(Order.new, stream_name) do |order|
 end
 ```
 
-You could also privide specific repository for `Order` aggregate to make this code event better:
+You could also provide a specific repository for `Order` aggregate to make this code event better:
 
 ```ruby
 class OrderRepository
@@ -164,7 +164,7 @@ class OrderRepository
 end
 ```
 
-And then you code to submit order maight look like:
+And then your code to submit an order might look like:
 
 ```ruby
 repository = OrderRepository.new
@@ -175,7 +175,7 @@ end
 
 ## Overwriting default apply_strategy
 
-You can change the way how aggregate methods are called in response to applied events. Let's say we want to call `order_has_expired` when `OrderExpired` event is applied. To achieve this we'll provide our implementation for the `apply_strategy` method:
+You can change the way how aggregate methods are called in response to applied events. Let's say we want to call `order_has_expired` when the `OrderExpired` event is applied. To achieve this, we'll provide our implementation for the `apply_strategy` method:
 
 ```ruby
 class Order
@@ -223,9 +223,9 @@ class Order
 end
 ```
 
-The `apply_strategy` method must return a _callable_, that responds to `#call`. We've used lambda in the example above. This lambda takes two arguments -- `aggreate` which in this case is `self` and a an `event` being applied.
+The `apply_strategy` method must return a _callable_ that responds to `#call`. We've used lambda in the example above. This lambda takes two arguments -- `aggreate` which in this case is `self` and an `event` being applied.
 
-The `case` statement is one way to implement such dispatch. The following example shows an equivalent implemented with `Hash`:
+The `case` statement is one way to implement such a dispatch. The following example shows an equivalent implementation with `Hash`:
 
 ```ruby
 def apply_strategy
@@ -248,7 +248,7 @@ def apply_strategy
 
 ## Resources
 
-There're already few blog posts about building an event sourced applications with [rails_event_store](https://github.com/RailsEventStore/rails_event_store) and `aggregate_root` gems:
+There're already a few blog posts about building event sourced applications with [rails_event_store](https://github.com/RailsEventStore/rails_event_store) and `aggregate_root` gems:
 
 - [Why use Event Sourcing](https://blog.arkency.com/2015/03/why-use-event-sourcing/)
 - [The Event Store for Rails developers](https://blog.arkency.com/2015/04/the-event-store-for-rails-developers/)


### PR DESCRIPTION
This PR just adds a few missing definite or indefinite articles to the explanations provided in the documentation, corrects several spelling mistakes to yield a more readable sentence structure. No changes to the code examples.