### PR TITLE
Improve documentation readability in `Reading events`

### DIFF
--- a/railseventstore.org/source/docs/read.html.md.erb
+++ b/railseventstore.org/source/docs/read.html.md.erb
@@ -2,28 +2,29 @@
 title: Reading events
 ---
 
-## Specification of read scope
+## Specifying read scope
 
-You could use a speciffication pattern to prepare a read scope.
+You could use a specification pattern to prepare a read scope.
 The read scope defines what domain events will be read.
 
 The available specification methods are:
 
-* `stream(stream_name)` - specify name of a stream to read,
-   if no stream will be specified a global stream (all domain events)
+* `stream(stream_name)` - specify the name of a stream to read.
+   If no stream is specified, a global stream (all domain events)
    will be read.
-* `from(start)` - specify the starting point (event id) for read operation. This will read all domain events after (not including) the specified domain event id.
+* `from(start)` - specify the starting point (event id) for read operation. 
+   This will read all domain events after (but not including) the specified domain event id.
 * `to(stop)` - specify the stop point (event id) for the read operation. This will
-    read all domain events until (not including) the specified domain event id.
-* `forward`  - reading direction, from oldest to newest domain events.
+   read all domain events up until (but not including) the specified domain event id.
+* `forward` - reading direction, from oldest to newest domain events.
 * `backward` - reading direction, from newest to oldest  domain events.
-* `limit(count)` - total number of events to read (could be less).
-* `in_batches(batch_size)` - read will be performed in batches of specified size.
+* `limit(count)` - maximum number of events to read.
+* `in_batches(batch_size)` - read will be performed in batches of the specified size.
    RailsEventStore never reads all domain events at once. Even if you don't specify
-   batch size, the read operation will be performed in batches of size 100.
-* `of_type(types)` - read only specified types of domain events ignoring all others.
+   a batch size, the read operation will be performed in batches of 100.
+* `of_type(types)` - read only specified types of domain events, ignoring all others.
 
-The read scope could be defined by chaining the specification methods, i.e.:
+The read scope could be defined by chaining the specification methods, e.g.:
 
 ```ruby
 scope = client.read
@@ -33,24 +34,24 @@ scope = client.read
   .of_type([Customer::GoldStatusGranted])
 ```
 
-When the read scope will be defined several methods could be used to get the data:
+When the read scope is defined, several methods can be used to get the data:
 
 * `count` - returns total number of domain events to be read.
-* `each` - returns enumerator for all domain events in the read scope.
-* `each_batch` - returns enumerator of batches of specified size (or 100 if no
-   batch size have been specified).
-* `to_a` - returns an array with all domain events from the scope, equals to `each.to_a`.
-* `first` - returns first domain event from the read scope.
-* `last` - returns last domain event from the read scope.
-* `event(event_id)` - return event of given id if found in the read scope, otherwise `nil`.
-* `event!(event_id)` - return event of given id if found in the read scope,
-  otherwise raises `RubyEventStore::EventNotfound` error.
-* `events(event_ids)` - returns list of domain events of given ids found in read scope,
-  if there is no event of some event id it is ignored (not all domain events must be found).
+* `each` - returns an enumerator for all domain events in the read scope.
+* `each_batch` - returns an enumerator of batches of specified size (or 100 if no
+   batch size has been specified).
+* `to_a` - returns an array with all domain events from the scope, equal to `each.to_a`.
+* `first` - returns the first domain event from the read scope.
+* `last` - returns the last domain event from the read scope.
+* `event(event_id)` - return an event of a given id if found in the read scope, otherwise `nil`.
+* `event!(event_id)` - return an event of a given id if found in the read scope,
+   otherwise raises `RubyEventStore::EventNotfound` error.
+* `events(event_ids)` - returns a list of domain events of given ids found in the read scope.
+   If there is no event for one or more provided event id, that id will be ignored (not all domain events must be found).
 
 ## Examples
 
-### Reading stream's events forward in batch — starting from first event
+### Reading a stream's events forward in batches — starting from the first event
 
 ```ruby
 stream_name = "order_1"
@@ -58,7 +59,7 @@ count = 40
 client.read.stream(stream_name).limit(count).to_a
 ```
 
-### Reading stream's events forward in batch — starting from given event
+### Reading a stream's events forward in batches — starting from a given event
 
 ```ruby
 # last_read_event is any domain event read or published by rails_event_store
@@ -69,9 +70,9 @@ count = 40
 client.read.stream(stream_name).from(start).limit(count).to_a
 ```
 
-### Reading stream's events backward in batch
+### Reading a stream's events backward in batches
 
-As in examples above, just append `.backward` instead before `.each`.
+As in examples above, just append `.backward` before `.each`.
 
 ```ruby
 stream_name = "order_1"
@@ -80,18 +81,18 @@ count = 40
 client.read.backward.stream(stream_name).from(start).limit(count).to_a
 ```
 
-### Reading all events from stream forward
+### Reading all events from a stream forward
 
-This method allows us to load all stream's events ascending.
+This method allows us to load all of a stream's events in ascending order.
 
 ```ruby
 stream_name = "order_1"
 client.read.stream(stream_name).to_a
 ```
 
-### Reading all events from stream backward
+### Reading all events from a stream backward
 
-This method allows us to load all stream's events descending.
+This method allows us to load all of a stream's events in descending order.
 
 ```ruby
 stream_name = "order_1"
@@ -100,22 +101,22 @@ client.read.backward.stream(stream_name).to_a
 
 ### Reading all events forward
 
-This method allows us to load all stored events ascending.
+This method allows us to load all stored events in ascending order.
 
-This will read first 100 domain events stored in event store.
+This will read first 100 domain events stored in the event store.
 
 ```ruby
 client.read.limit(100).to_a
 ```
 
-When not specified otherwise it reads events starting from first domain event
-stored in event store and without limit.
+When not specified, it reads events starting from the first domain event
+stored in the event store, with no limit applied.
 
 ```ruby
 client.read.to_a
 ```
 
-You could also read batch of domain events starting from any read or published event.
+You can also read batch of domain events starting from any read or published event.
 
 ```ruby
 client.read.from(last_read_event.event_id).limit(100).to_a
@@ -123,26 +124,26 @@ client.read.from(last_read_event.event_id).limit(100).to_a
 
 ### Reading all events backward
 
-This method allows us to load all stored events descending.
+This method allows us to load all stored events in descending order.
 
-This will read last 100 domain events stored in event store.
+This will read last 100 domain events stored in the event store.
 
 ```ruby
 client.read.backward.limit(100).to_a
 ```
 
-When not specified otherwise it reads events starting from last domain event
-stored in event store and without limit.
+When not specified, it reads events starting from the last domain event
+stored in event store, with no limit applied.
 
 ```ruby
 client.read.backward.to_a
 ```
 
 
-## Reading specified events
+## Reading specific events
 
-RailsEventStore let's you read specific event (or a list of events).
-You need to know ids of events you want to read.
+RailsEventStore lets you read a specific event (or a list of events).
+You need to know the ids of events you want to read.
 
 Fetch a single event (will return a single domain event):
 
@@ -150,15 +151,15 @@ Fetch a single event (will return a single domain event):
 client.read.event('some-event-id-here')
 ```
 
-The `read.event` method will return `nil` if event cound not be found.
-Use `read.event!` method to raise an `EventNotFound` error if event cound not be found.
+The `read.event` method will return `nil` if the event cannot be found.
+Use `read.event!` method to raise an `EventNotFound` error if the event cannot be found.
 
 
-Fetch a multiple events at once (will return an array of domain events):
+Fetch multiple events at once (will return an array of domain events):
 
 ```ruby
 client.read.events(['event-1-id', 'event-2-id', ... 'event-N-id'])
 ```
 
 The `read.events` method will return only existing events. If none of given ids
-could not be found it will return empty collection.
+can be found, it will return an empty collection.


### PR DESCRIPTION
Adds definite and indefinite articles where appropriate, and fixes tense to improve consistency and overall readability of the documentation. No changes to the code examples.