### PR TITLE
Browser UI improvements

### DIFF
--- a/ruby_event_store-browser/devserver/config.ru
+++ b/ruby_event_store-browser/devserver/config.ru
@@ -33,7 +33,7 @@ other_event = OtherEvent.new(
   },
 )
 event_store.publish(other_event, stream_name: "OtherStream$91")
-3.times do
+21.times do
   event_store.with_metadata(
     correlation_id: other_event.metadata[:correlation_id] || other_event.event_id,
     causation_id: other_event.event_id

--- a/ruby_event_store-browser/elm/elm.json
+++ b/ruby_event_store-browser/elm/elm.json
@@ -12,12 +12,15 @@
             "elm/html": "1.0.0",
             "elm/http": "1.0.0",
             "elm/json": "1.1.3",
+            "elm/time": "1.0.0",
             "elm/url": "1.0.0",
             "elm-community/maybe-extra": "5.0.0",
-            "klazuka/elm-json-tree-view": "1.0.0"
+            "klazuka/elm-json-tree-view": "1.0.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3",
+            "ryannhg/date-format": "2.3.0"
         },
         "indirect": {
-            "elm/time": "1.0.0",
+            "elm/parser": "1.1.0",
             "elm/virtual-dom": "1.0.2"
         }
     },

--- a/ruby_event_store-browser/elm/src/Api.elm
+++ b/ruby_event_store-browser/elm/src/Api.elm
@@ -2,16 +2,18 @@ module Api exposing (Event, PaginatedList, PaginationLink, PaginationLinks, empt
 
 import Flags exposing (Flags)
 import Http
+import Iso8601
 import Json.Decode exposing (Decoder, Value, at, field, list, maybe, nullable, oneOf, string, succeed, value)
 import Json.Decode.Pipeline exposing (optional, optionalAt, required, requiredAt)
 import Json.Encode exposing (encode)
 import Route exposing (buildUrl)
+import Time
 
 
 type alias Event =
     { eventType : String
     , eventId : String
-    , createdAt : String
+    , createdAt : Time.Posix
     , rawData : String
     , rawMetadata : String
     , correlationStreamName : Maybe String
@@ -54,7 +56,7 @@ eventDecoder_ =
     succeed Event
         |> requiredAt [ "attributes", "event_type" ] string
         |> requiredAt [ "id" ] string
-        |> requiredAt [ "attributes", "metadata", "timestamp" ] string
+        |> requiredAt [ "attributes", "metadata", "timestamp" ] Iso8601.decoder
         |> requiredAt [ "attributes", "data" ] (value |> Json.Decode.map (encode 2))
         |> requiredAt [ "attributes", "metadata" ] (value |> Json.Decode.map (encode 2))
         |> optionalAt [ "attributes", "correlation_stream_name" ] (maybe string) Nothing

--- a/ruby_event_store-browser/elm/src/Main.elm
+++ b/ruby_event_store-browser/elm/src/Main.elm
@@ -150,18 +150,19 @@ viewPage : Page -> ( Maybe String, Html Msg )
 viewPage page =
     case page of
         ViewStream viewStreamUIModel ->
-            let
-                ( pageTitle, pageContent ) =
-                    Page.ViewStream.view viewStreamUIModel
-            in
-            ( Just pageTitle, Html.map GotViewStreamMsg pageContent )
+            viewOnePage GotViewStreamMsg Page.ViewStream.view viewStreamUIModel
 
         ShowEvent openedEventUIModel ->
-            let
-                ( pageTitle, pageContent ) =
-                    Page.ShowEvent.view openedEventUIModel
-            in
-            ( Just pageTitle, Html.map GotShowEventMsg pageContent )
+            viewOnePage GotShowEventMsg Page.ShowEvent.view openedEventUIModel
 
         NotFound ->
             ( Nothing, Layout.viewNotFound )
+
+
+viewOnePage : (pageMsg -> Msg) -> (model -> ( String, Html pageMsg )) -> model -> ( Maybe String, Html Msg )
+viewOnePage pageMsgBuilder pageViewFunction pageModel =
+    let
+        ( pageTitle, pageContent ) =
+            pageViewFunction pageModel
+    in
+    ( Just pageTitle, Html.map pageMsgBuilder pageContent )

--- a/ruby_event_store-browser/elm/src/Main.elm
+++ b/ruby_event_store-browser/elm/src/Main.elm
@@ -127,19 +127,37 @@ urlUpdate model location =
 
 view : Model -> Browser.Document Msg
 view model =
-    { body = [ Layout.view model.flags (viewPage model.page) ]
-    , title = "RubyEventStore::Browser"
+    let
+        ( maybePageTitle, pageContent ) =
+            viewPage model.page
+    in
+    { body = [ Layout.view model.flags pageContent ]
+    , title =
+        case maybePageTitle of
+            Just pageTitle ->
+                "RubyEventStore::Browser - " ++ pageTitle
+
+            Nothing ->
+                "RubyEventStore::Browser"
     }
 
 
-viewPage : Page -> Html Msg
+viewPage : Page -> ( Maybe String, Html Msg )
 viewPage page =
     case page of
         ViewStream viewStreamUIModel ->
-            Html.map GotViewStreamMsg (Page.ViewStream.view viewStreamUIModel)
+            let
+                ( pageTitle, pageContent ) =
+                    Page.ViewStream.view viewStreamUIModel
+            in
+            ( Just pageTitle, Html.map GotViewStreamMsg pageContent )
 
         ShowEvent openedEventUIModel ->
-            Html.map GotShowEventMsg (Page.ShowEvent.view openedEventUIModel)
+            let
+                ( pageTitle, pageContent ) =
+                    Page.ShowEvent.view openedEventUIModel
+            in
+            ( Just pageTitle, Html.map GotShowEventMsg pageContent )
 
         NotFound ->
-            Layout.viewNotFound
+            ( Nothing, Layout.viewNotFound )

--- a/ruby_event_store-browser/elm/src/Main.elm
+++ b/ruby_event_store-browser/elm/src/Main.elm
@@ -132,14 +132,18 @@ view model =
             viewPage model.page
     in
     { body = [ Layout.view model.flags pageContent ]
-    , title =
-        case maybePageTitle of
-            Just pageTitle ->
-                "RubyEventStore::Browser - " ++ pageTitle
-
-            Nothing ->
-                "RubyEventStore::Browser"
+    , title = fullTitle maybePageTitle
     }
+
+
+fullTitle : Maybe String -> String
+fullTitle maybePageTitle =
+    case maybePageTitle of
+        Just pageTitle ->
+            "RubyEventStore::Browser - " ++ pageTitle
+
+        Nothing ->
+            "RubyEventStore::Browser"
 
 
 viewPage : Page -> ( Maybe String, Html Msg )

--- a/ruby_event_store-browser/elm/src/Page/ShowEvent.elm
+++ b/ruby_event_store-browser/elm/src/Page/ShowEvent.elm
@@ -52,7 +52,7 @@ initModel flags eventId =
 type Msg
     = ChangeOpenedEventDataTreeState JsonTree.State
     | ChangeOpenedEventMetadataTreeState JsonTree.State
-    | GetEvent (Result Http.Error Api.Event)
+    | EventFetched (Result Http.Error Api.Event)
     | CausedEventsFetched (Result Http.Error (Api.PaginatedList Api.Event))
 
 
@@ -80,14 +80,14 @@ update msg model =
                 Nothing ->
                     ( model, Cmd.none )
 
-        GetEvent (Ok result) ->
+        EventFetched (Ok result) ->
             let
                 event =
                     apiEventToEvent result
             in
             ( { model | event = Just event }, getCausedEvents model.flags event )
 
-        GetEvent (Err errorMessage) ->
+        EventFetched (Err errorMessage) ->
             ( model, Cmd.none )
 
         CausedEventsFetched (Ok result) ->
@@ -113,7 +113,7 @@ apiEventToEvent e =
 
 getEvent : Flags -> String -> Cmd Msg
 getEvent flags eventId =
-    Api.getEvent GetEvent flags eventId
+    Api.getEvent EventFetched flags eventId
 
 
 getCausedEvents : Flags -> Event -> Cmd Msg

--- a/ruby_event_store-browser/elm/src/Page/ShowEvent.elm
+++ b/ruby_event_store-browser/elm/src/Page/ShowEvent.elm
@@ -128,8 +128,13 @@ getCausedEvents flags event =
 -- VIEW
 
 
-view : Model -> Html Msg
+view : Model -> ( String, Html Msg )
 view model =
+    ( "Event " ++ model.eventId, view_ model )
+
+
+view_ : Model -> Html Msg
+view_ model =
     case model.event of
         Just event ->
             showEvent event model.causedEvents

--- a/ruby_event_store-browser/elm/src/Page/ShowEvent.elm
+++ b/ruby_event_store-browser/elm/src/Page/ShowEvent.elm
@@ -9,7 +9,6 @@ import JsonTree
 import Maybe exposing (withDefault)
 import Maybe.Extra exposing (values)
 import Route
-import Time
 
 
 
@@ -19,7 +18,6 @@ import Time
 type alias Event =
     { eventType : String
     , eventId : String
-    , createdAt : Time.Posix
     , correlationStreamName : Maybe String
     , causationStreamName : Maybe String
     , rawData : String
@@ -102,7 +100,6 @@ apiEventToEvent : Api.Event -> Event
 apiEventToEvent e =
     { eventType = e.eventType
     , eventId = e.eventId
-    , createdAt = e.createdAt
     , rawData = e.rawData
     , rawMetadata = e.rawMetadata
     , correlationStreamName = e.correlationStreamName

--- a/ruby_event_store-browser/elm/src/Page/ShowEvent.elm
+++ b/ruby_event_store-browser/elm/src/Page/ShowEvent.elm
@@ -211,7 +211,7 @@ correlationStreamLink event =
         (\streamName ->
             li []
                 [ text "Correlation stream: "
-                , a [ href ("/#streams/" ++ streamName) ] [ text streamName ]
+                , streamLink streamName
                 ]
         )
         event.correlationStreamName
@@ -223,10 +223,14 @@ causationStreamLink event =
         (\streamName ->
             li []
                 [ text "Causation stream: "
-                , a [ href ("/#streams/" ++ streamName) ] [ text streamName ]
+                , streamLink streamName
                 ]
         )
         event.causationStreamName
+
+streamLink : String -> Html Msg
+streamLink streamName =
+    a [ class "event__stream-link", href ("/#streams/" ++ streamName) ] [ text streamName ]
 
 
 renderCausedEvents : List Api.Event -> Html Msg

--- a/ruby_event_store-browser/elm/src/Page/ShowEvent.elm
+++ b/ruby_event_store-browser/elm/src/Page/ShowEvent.elm
@@ -3,7 +3,7 @@ module Page.ShowEvent exposing (Model, Msg(..), initCmd, initModel, showJsonTree
 import Api
 import Flags exposing (Flags)
 import Html exposing (..)
-import Html.Attributes exposing (class, disabled, href, placeholder)
+import Html.Attributes exposing (class, colspan, disabled, href, placeholder)
 import Http
 import JsonTree
 import Maybe exposing (withDefault)
@@ -228,6 +228,7 @@ causationStreamLink event =
         )
         event.causationStreamName
 
+
 streamLink : String -> Html Msg
 streamLink streamName =
     a [ class "event__stream-link", href ("/#streams/" ++ streamName) ] [ text streamName ]
@@ -248,6 +249,17 @@ renderCausedEvents causedEvents =
                         ]
                     ]
                 , tbody [] (List.map renderCausedEvent causedEvents)
+                , tfoot []
+                    [ tr []
+                        [ td [ colspan 2 ]
+                            [ if List.length causedEvents == 20 then
+                                text "The results may be truncated, check stream for full information."
+
+                              else
+                                text ""
+                            ]
+                        ]
+                    ]
                 ]
 
 

--- a/ruby_event_store-browser/elm/src/Page/ShowEvent.elm
+++ b/ruby_event_store-browser/elm/src/Page/ShowEvent.elm
@@ -9,6 +9,7 @@ import JsonTree
 import Maybe exposing (withDefault)
 import Maybe.Extra exposing (values)
 import Route
+import Time
 
 
 
@@ -18,7 +19,7 @@ import Route
 type alias Event =
     { eventType : String
     , eventId : String
-    , createdAt : String
+    , createdAt : Time.Posix
     , correlationStreamName : Maybe String
     , causationStreamName : Maybe String
     , rawData : String

--- a/ruby_event_store-browser/elm/src/Page/ViewStream.elm
+++ b/ruby_event_store-browser/elm/src/Page/ViewStream.elm
@@ -1,6 +1,7 @@
 module Page.ViewStream exposing (Model, Msg(..), initCmd, initModel, update, view)
 
 import Api
+import DateFormat
 import Flags exposing (Flags)
 import Html exposing (..)
 import Html.Attributes exposing (class, disabled, href, placeholder)
@@ -10,6 +11,7 @@ import Json.Decode exposing (Decoder, Value, at, field, list, maybe, oneOf, stri
 import Json.Decode.Pipeline exposing (optional, required, requiredAt)
 import Json.Encode exposing (encode)
 import Route
+import Time
 import Url
 
 
@@ -166,6 +168,27 @@ itemRow { eventType, createdAt, eventId } =
             ]
         , td [] [ text eventId ]
         , td [ class "u-align-right" ]
-            [ text createdAt
+            [ text (formatTimestamp createdAt)
             ]
         ]
+
+
+formatTimestamp : Time.Posix -> String
+formatTimestamp time =
+    DateFormat.format
+        [ DateFormat.dayOfMonthFixed
+        , DateFormat.text "."
+        , DateFormat.monthFixed
+        , DateFormat.text "."
+        , DateFormat.yearNumber
+        , DateFormat.text ", "
+        , DateFormat.hourMilitaryFixed
+        , DateFormat.text ":"
+        , DateFormat.minuteFixed
+        , DateFormat.text ":"
+        , DateFormat.secondFixed
+        , DateFormat.text "."
+        , DateFormat.millisecondFixed
+        ]
+        Time.utc
+        time

--- a/ruby_event_store-browser/elm/src/Page/ViewStream.elm
+++ b/ruby_event_store-browser/elm/src/Page/ViewStream.elm
@@ -36,24 +36,24 @@ initModel streamName =
 
 type Msg
     = GoToPage Api.PaginationLink
-    | GetEvents (Result Http.Error (Api.PaginatedList Api.Event))
+    | EventsFetched (Result Http.Error (Api.PaginatedList Api.Event))
 
 
 initCmd : Flags -> String -> Cmd Msg
 initCmd flags streamId =
-    Api.getEvents GetEvents (Route.buildUrl flags.streamsUrl streamId)
+    Api.getEvents EventsFetched (Route.buildUrl flags.streamsUrl streamId)
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
         GoToPage paginationLink ->
-            ( model, Api.getEvents GetEvents paginationLink )
+            ( model, Api.getEvents EventsFetched paginationLink )
 
-        GetEvents (Ok result) ->
+        EventsFetched (Ok result) ->
             ( { model | events = result }, Cmd.none )
 
-        GetEvents (Err errorMessage) ->
+        EventsFetched (Err errorMessage) ->
             ( model, Cmd.none )
 
 

--- a/ruby_event_store-browser/elm/src/Page/ViewStream.elm
+++ b/ruby_event_store-browser/elm/src/Page/ViewStream.elm
@@ -62,9 +62,9 @@ update msg model =
 -- VIEW
 
 
-view : Model -> Html Msg
+view : Model -> ( String, Html Msg )
 view model =
-    browseEvents ("Events in " ++ model.streamName) model.events
+    ( "Stream " ++ model.streamName, browseEvents ("Events in " ++ model.streamName) model.events )
 
 
 browseEvents : String -> Api.PaginatedList Api.Event -> Html Msg

--- a/ruby_event_store-browser/elm/src/Page/ViewStream.elm
+++ b/ruby_event_store-browser/elm/src/Page/ViewStream.elm
@@ -1,7 +1,6 @@
 module Page.ViewStream exposing (Model, Msg(..), initCmd, initModel, update, view)
 
 import Api
-import DateFormat
 import Flags exposing (Flags)
 import Html exposing (..)
 import Html.Attributes exposing (class, disabled, href, placeholder)
@@ -11,7 +10,7 @@ import Json.Decode exposing (Decoder, Value, at, field, list, maybe, oneOf, stri
 import Json.Decode.Pipeline exposing (optional, required, requiredAt)
 import Json.Encode exposing (encode)
 import Route
-import Time
+import TimeHelpers exposing (formatTimestamp)
 import Url
 
 
@@ -171,24 +170,3 @@ itemRow { eventType, createdAt, eventId } =
             [ text (formatTimestamp createdAt)
             ]
         ]
-
-
-formatTimestamp : Time.Posix -> String
-formatTimestamp time =
-    DateFormat.format
-        [ DateFormat.dayOfMonthFixed
-        , DateFormat.text "."
-        , DateFormat.monthFixed
-        , DateFormat.text "."
-        , DateFormat.yearNumber
-        , DateFormat.text ", "
-        , DateFormat.hourMilitaryFixed
-        , DateFormat.text ":"
-        , DateFormat.minuteFixed
-        , DateFormat.text ":"
-        , DateFormat.secondFixed
-        , DateFormat.text "."
-        , DateFormat.millisecondFixed
-        ]
-        Time.utc
-        time

--- a/ruby_event_store-browser/elm/src/TimeHelpers.elm
+++ b/ruby_event_store-browser/elm/src/TimeHelpers.elm
@@ -1,0 +1,25 @@
+module TimeHelpers exposing (formatTimestamp)
+
+import DateFormat exposing (..)
+import Time
+
+
+formatTimestamp : Time.Posix -> String
+formatTimestamp time =
+    format
+        [ dayOfMonthFixed
+        , text "."
+        , monthFixed
+        , text "."
+        , yearNumber
+        , text ", "
+        , hourMilitaryFixed
+        , text ":"
+        , minuteFixed
+        , text ":"
+        , secondFixed
+        , text "."
+        , millisecondFixed
+        ]
+        Time.utc
+        time

--- a/ruby_event_store-browser/elm/src/style/base/_tables.scss
+++ b/ruby_event_store-browser/elm/src/style/base/_tables.scss
@@ -28,3 +28,9 @@ th {
 td {
   padding: 0.75rem 0 0 0;
 }
+
+tfoot td {
+  padding: 0 0 0.75rem 0;
+  font-size: 1.2rem;
+  color: $oc-gray-5;
+}

--- a/ruby_event_store-browser/elm/src/style/components/_event.scss
+++ b/ruby_event_store-browser/elm/src/style/components/_event.scss
@@ -36,3 +36,7 @@ $browser-layout: (columns: 2);
     font-size: 2.0rem;
   }
 }
+
+.event__stream-link {
+  text-decoration: none;
+}

--- a/ruby_event_store-browser/elm/tests/DecodersTest.elm
+++ b/ruby_event_store-browser/elm/tests/DecodersTest.elm
@@ -6,6 +6,7 @@ import Json.Decode exposing (list)
 import Main exposing (..)
 import Route exposing (buildUrl)
 import Test exposing (..)
+import Time
 
 
 suite : Test
@@ -50,7 +51,7 @@ suite =
                             { events =
                                 [ { eventType = "DummyEvent"
                                   , eventId = "664ada1e-2f01-4ed0-9c16-63dbc82269d2"
-                                  , createdAt = "2017-12-20T23:49:45.273Z"
+                                  , createdAt = Time.millisToPosix 1513813785273
                                   , rawData = "{\n  \"foo\": 1,\n  \"bar\": 2,\n  \"baz\": \"3\"\n}"
                                   , rawMetadata = "{\n  \"timestamp\": \"2017-12-20T23:49:45.273Z\"\n}"
                                   , correlationStreamName = Nothing
@@ -103,7 +104,7 @@ suite =
                         (Ok
                             { eventType = "DummyEvent"
                             , eventId = "664ada1e-2f01-4ed0-9c16-63dbc82269d2"
-                            , createdAt = "2017-12-20T23:49:45.273Z"
+                            , createdAt = Time.millisToPosix 1513813785273
                             , rawData = "{\n  \"foo\": 1,\n  \"bar\": 3.4,\n  \"baz\": \"3\"\n}"
                             , rawMetadata = "{\n  \"timestamp\": \"2017-12-20T23:49:45.273Z\"\n}"
                             , correlationStreamName = Just "$by_correlation_id_a7243789-999f-4ef2-8511-b1c686b83fad"


### PR DESCRIPTION
- When "Caused events" list is long, display information that it may be truncated.
- Remove underline from stream links, as streams often have `_` in names and it is less readable with underlines.
- Format timestamps nicer, instead of raw iso8601 display something like `10.06.2019, 15:20:57.602`
- Display more relevant html title: Either stream or event you are at, so the flow is nicer when you already have few tabs with browser opened :)