### PR TITLE
Ensure AfterCommitAsyncDispatcher runs handlers in tests

### DIFF
--- a/rails_event_store/lib/rails_event_store/after_commit_async_dispatcher.rb
+++ b/rails_event_store/lib/rails_event_store/after_commit_async_dispatcher.rb
@@ -13,11 +13,12 @@ module RailsEventStore
     end
 
     def run(&schedule_proc)
-      if ActiveRecord::Base.connection.transaction_open?
-        ActiveRecord::Base
-          .connection
-          .current_transaction
-          .add_record(AsyncRecord.new(self, schedule_proc))
+      transaction = ActiveRecord::Base.connection.current_transaction
+
+      if transaction.joinable?
+        transaction.add_record(
+          AsyncRecord.new(self, schedule_proc)
+        )
       else
         yield
       end

--- a/rails_event_store/spec/after_commit_async_dispatcher_spec.rb
+++ b/rails_event_store/spec/after_commit_async_dispatcher_spec.rb
@@ -209,11 +209,33 @@ module RailsEventStore
         end
       end
 
-      it "dispatches the job after a nested transaction commits" do
-        expect_to_have_enqueued_job(MyAsyncHandler) do
-          ActiveRecord::Base.transaction do
-            expect_no_enqueued_job(MyAsyncHandler) do
-              dispatcher.call(MyAsyncHandler, event, serialized_event)
+      context "with < Rails 5" do
+        before do
+          skip if ActiveRecord.version >= Gem::Version.new("5")
+        end
+
+        it "does not dispatch the job after a nested transaction commits" do
+          expect_no_enqueued_job(MyAsyncHandler) do
+            ActiveRecord::Base.transaction do
+              expect_no_enqueued_job(MyAsyncHandler) do
+                dispatcher.call(MyAsyncHandler, event, serialized_event)
+              end
+            end
+          end
+        end
+      end
+
+      context "with Rails 5+" do
+        before do
+          skip if ActiveRecord.version < Gem::Version.new("5")
+        end
+
+        it "dispatches the job after a nested transaction commits" do
+          expect_to_have_enqueued_job(MyAsyncHandler) do
+            ActiveRecord::Base.transaction do
+              expect_no_enqueued_job(MyAsyncHandler) do
+                dispatcher.call(MyAsyncHandler, event, serialized_event)
+              end
             end
           end
         end


### PR DESCRIPTION
I was using the `AfterCommitAsyncDispatcher` along with Sidekiq workers and I couldn't get integration tests working (with inlined Sidekiq workers and Database Cleaner's transaction strategy).

This solution follows a similar pattern from change to Rails https://github.com/rails/rails/pull/18458