### PR TITLE
Reusing in-memory aggregate instances

### DIFF
--- a/aggregate_root/lib/aggregate_root/repository.rb
+++ b/aggregate_root/lib/aggregate_root/repository.rb
@@ -15,8 +15,8 @@ module AggregateRoot
     def store(aggregate, stream_name)
       event_store.publish(aggregate.unpublished_events.to_a,
         stream_name:      stream_name,
-        expected_version: aggregate.version)
-      aggregate.version = aggregate.version + aggregate.unpublished_events.count
+        expected_version: aggregate.version,
+        after_store_callback: ->() { aggregate.version = aggregate.version + aggregate.unpublished_events.count })
     end
 
     def with_aggregate(aggregate, stream_name, &block)

--- a/aggregate_root/spec/issue_290_spec.rb
+++ b/aggregate_root/spec/issue_290_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+class Aggregate_1
+  include AggregateRoot
+
+  def publish_event_1
+    apply(Event_1.new(data: {}))
+  end
+
+  def do_something_in_reaction_to_event_2
+  end
+
+  def apply_event_1(event)
+  end
+end
+
+class Aggregate_2
+  include AggregateRoot
+
+  def publish_event_2
+    apply(Event_2.new(data: {}))
+  end
+
+  def apply_event_2(event)
+  end
+end
+
+class Event_1 < RubyEventStore::Event
+end
+
+class Event_2 < RubyEventStore::Event
+end
+
+module AggregateRoot
+  RSpec.describe "Issue #290" do
+    specify do
+      event_store = RubyEventStore::Client.new(
+        repository: RubyEventStore::InMemoryRepository.new,
+      )
+      aggregate_repository = AggregateRoot::Repository.new(event_store)
+      aggregate_1 = aggregate_repository.load(Aggregate_1.new, "stream_1")
+
+      event_store.subscribe(
+        -> _ {
+          aggregate_repository = AggregateRoot::Repository.new(event_store)
+          aggregate_2 = aggregate_repository.load(Aggregate_2.new, "stream_2")
+          aggregate_2.publish_event_2
+          aggregate_repository.store(aggregate_2, "stream_2")
+        },
+        to: [Event_1]
+      )
+
+      event_store.subscribe(
+        -> _ {
+          # uncommenting the code should fix the bug
+          # aggregate_1.instance_variable_set(:@version, (aggregate_1.instance_variable_get(:@version) || -1) + aggregate_1.unpublished_events.size)
+          # aggregate_1.instance_variable_set(:@unpublished_events, [])
+          aggregate_1.do_something_in_reaction_to_event_2
+          expect do
+            aggregate_repository.store(aggregate_1, "stream_1")
+          end.not_to raise_error
+        },
+        to: [Event_2]
+      )
+      aggregate_1.publish_event_1
+
+      aggregate_repository.store(aggregate_1, "stream_1")
+    end
+  end
+end

--- a/ruby_event_store/lib/ruby_event_store/client.rb
+++ b/ruby_event_store/lib/ruby_event_store/client.rb
@@ -28,10 +28,11 @@ module RubyEventStore
     # @param stream_name [String] name of the stream for persisting events.
     # @param expected_version [:any, :auto, :none, Integer] controls optimistic locking strategy. {http://railseventstore.org/docs/expected_version/ Read more}
     # @return [self]
-    def publish(events, stream_name: GLOBAL_STREAM, expected_version: :any)
+    def publish(events, stream_name: GLOBAL_STREAM, expected_version: :any, after_store_callback: nil)
       enriched_events = enrich_events_metadata(events)
       records         = transform(enriched_events)
       append_records_to_stream(records, stream_name: stream_name, expected_version: expected_version)
+      after_store_callback.call if after_store_callback
       enriched_events.zip(records) do |event, record|
         with_metadata(
           correlation_id: event.metadata.fetch(:correlation_id),

--- a/ruby_event_store/spec/client_spec.rb
+++ b/ruby_event_store/spec/client_spec.rb
@@ -75,6 +75,14 @@ module RubyEventStore
       expect(client.read.stream(stream).to_a).to eq([first_event, second_event])
     end
 
+    specify 'publishing calls after_store_callback if provided' do
+      some_var = 42
+
+      client.publish(TestEvent.new, after_store_callback: ->() { some_var = 13 })
+
+      expect(some_var).to eq(13)
+    end
+
     specify 'append many events' do
       client = RubyEventStore::Client.new(
         repository: InMemoryRepository.new,


### PR DESCRIPTION
This is WIP.

- [ ] add the same argument to RailsEventStore::Client
- [ ] decide on the naming of `after_store_callback`

About the second point, options were enlisted here: https://github.com/RailsEventStore/rails_event_store/issues/290#issuecomment-505631048

There was no other suggestions than proposed by me in that comment, so:
1) yield
2) callback named argument (of course we can name it differently, if someone has better idea. I also thought that maybe we could name it `_after_store_callback` and NOT mention it in documention to sign that this is experimental/private feature which may change?)