### PR TITLE
Pagination buttons

### DIFF
--- a/ruby_event_store-browser/elm/src/Page/ViewStream.elm
+++ b/ruby_event_store-browser/elm/src/Page/ViewStream.elm
@@ -80,9 +80,9 @@ displayPagination : Api.PaginationLinks -> Html Msg
 displayPagination { first, last, next, prev } =
     ul [ class "pagination" ]
         [ li [] [ firstPageButton first ]
-        , li [] [ lastPageButton last ]
-        , li [] [ nextPageButton next ]
         , li [] [ prevPageButton prev ]
+        , li [] [ nextPageButton next ]
+        , li [] [ lastPageButton last ]
         ]
 
 

--- a/ruby_event_store-browser/elm/src/Page/ViewStream.elm
+++ b/ruby_event_store-browser/elm/src/Page/ViewStream.elm
@@ -79,60 +79,63 @@ browseEvents title { links, events } =
 displayPagination : Api.PaginationLinks -> Html Msg
 displayPagination { first, last, next, prev } =
     ul [ class "pagination" ]
-        [ paginationItem firstPageButton first
-        , paginationItem lastPageButton last
-        , paginationItem nextPageButton next
-        , paginationItem prevPageButton prev
+        [ li [] [ firstPageButton first ]
+        , li [] [ lastPageButton last ]
+        , li [] [ nextPageButton next ]
+        , li [] [ prevPageButton prev ]
         ]
 
 
-paginationItem : (Api.PaginationLink -> Html Msg) -> Maybe Api.PaginationLink -> Html Msg
-paginationItem button link =
+maybeHref : Maybe Api.PaginationLink -> List (Attribute Msg)
+maybeHref link =
     case link of
         Just url ->
-            li [] [ button url ]
+            [ href url
+            , onClick (GoToPage url)
+            ]
 
         Nothing ->
-            li [] []
+            [ disabled True
+            ]
 
 
-nextPageButton : Api.PaginationLink -> Html Msg
-nextPageButton url =
+nextPageButton : Maybe Api.PaginationLink -> Html Msg
+nextPageButton link =
     button
-        [ href url
-        , onClick (GoToPage url)
-        , class "pagination__page pagination__page--next"
-        ]
+        ([ class "pagination__page pagination__page--next"
+         ]
+            ++ maybeHref link
+        )
         [ text "next" ]
 
 
-prevPageButton : Api.PaginationLink -> Html Msg
-prevPageButton url =
+prevPageButton : Maybe Api.PaginationLink -> Html Msg
+prevPageButton link =
     button
-        [ href url
-        , onClick (GoToPage url)
-        , class "pagination__page pagination__page--prev"
-        ]
+        ([ class "pagination__page pagination__page--prev"
+         ]
+            ++ maybeHref link
+        )
         [ text "previous" ]
 
 
-lastPageButton : Api.PaginationLink -> Html Msg
-lastPageButton url =
+lastPageButton : Maybe Api.PaginationLink -> Html Msg
+lastPageButton link =
     button
-        [ href url
-        , onClick (GoToPage url)
-        , class "pagination__page pagination__page--last"
-        ]
+        ([ class "pagination__page pagination__page--last"
+         ]
+            ++ maybeHref link
+        )
         [ text "last" ]
 
 
-firstPageButton : Api.PaginationLink -> Html Msg
-firstPageButton url =
+firstPageButton : Maybe Api.PaginationLink -> Html Msg
+firstPageButton link =
     button
-        [ href url
-        , onClick (GoToPage url)
-        , class "pagination__page pagination__page--first"
-        ]
+        ([ class "pagination__page pagination__page--first"
+         ]
+            ++ maybeHref link
+        )
         [ text "first" ]
 
 

--- a/ruby_event_store-browser/elm/src/Route.elm
+++ b/ruby_event_store-browser/elm/src/Route.elm
@@ -1,4 +1,4 @@
-module Route exposing (Route(..), buildUrl, streamUrl, eventUrl, decodeLocation)
+module Route exposing (Route(..), buildUrl, decodeLocation, eventUrl, streamUrl)
 
 import Url
 import Url.Parser exposing ((</>))
@@ -36,6 +36,7 @@ buildUrl baseUrl id =
 streamUrl : String -> String
 streamUrl streamName =
     buildUrl "#streams" streamName
+
 
 eventUrl : String -> String
 eventUrl eventId =

--- a/ruby_event_store-browser/elm/src/style/components/_pagination.scss
+++ b/ruby_event_store-browser/elm/src/style/components/_pagination.scss
@@ -19,6 +19,12 @@
   &:focus {
     outline: none;
   }
+
+  &:disabled {
+    &:hover {
+      background: none;
+    }
+  }
 }
 
 .pagination__page--previous {

--- a/ruby_event_store-browser/elm/src/style/components/_pagination.scss
+++ b/ruby_event_store-browser/elm/src/style/components/_pagination.scss
@@ -15,10 +15,10 @@
   border-color: $brand-color;
   font-weight: normal;
   font-size: 90%;
-}
 
-.pagination__page:focus {
-  outline: none;
+  &:focus {
+    outline: none;
+  }
 }
 
 .pagination__page--previous {


### PR DESCRIPTION
Little changes to pagination buttons.
Previously only the active buttons were shown, which meant that after few times you've clicked "next" (and got to the last page), you had "previous" button in the same place, which was pretty frustrating experience. Now, the inactive buttons are just disabled. Also, the order of buttons has changed, from `first / last / next / previous` to more commonly used `first / previous / next / last`. 

![Screenshot_20190813_204113](https://user-images.githubusercontent.com/332289/62968773-04beaa00-be0c-11e9-97a3-f09e91a80fe2.png)
