### PR TITLE
Only require Sinatra::Base

### DIFF
--- a/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
+++ b/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../browser'
-require 'sinatra'
+require 'sinatra/base'
 
 module RubyEventStore
   module Browser


### PR DESCRIPTION
As of Sinatra 2.0.6, `Sinatra::Application` parses ARGV when the classes are loaded, even if only using `Sinatra::Application` as middleware or not using it at all. Since we switched to using `Sinatra::Base` already, this more specific require should fix things up.