### PR TITLE
Add missing end in the docs

### DIFF
--- a/railseventstore.org/source/docs/request_metadata.html.md
+++ b/railseventstore.org/source/docs/request_metadata.html.md
@@ -63,6 +63,7 @@ module YourAppName
         { remote_ip:  request.remote_ip,
           request_id: request.uuid,
         }
+      end
     )
 
     # ...


### PR DESCRIPTION
Putting an `end` to on a super minor issue in the docs 😄. Setting request metadata example was missing `end`.