### PR TITLE
Allow missing events

### DIFF
--- a/ruby_event_store/lib/ruby_event_store/mappers/transformation/domain_event.rb
+++ b/ruby_event_store/lib/ruby_event_store/mappers/transformation/domain_event.rb
@@ -19,6 +19,8 @@ module RubyEventStore
             metadata: item.metadata,
             data:     item.data
           )
+        rescue NameError => e
+          raise e unless ENV.fetch('RAILS_ENV_STORE_ALLOW_MISSING_EVENTS', false)
         end
       end
     end


### PR DESCRIPTION
Proposal for allowing missing events ( for example in local dev env)

Often when developing I change my mind about naming of events and I rename them. It then annoys me that I cant see any events in ruby event store browser.

