### PR TITLE
Make use of of_type in projections to skip irrelevant events

### DIFF
--- a/ruby_event_store/lib/ruby_event_store/projection.rb
+++ b/ruby_event_store/lib/ruby_event_store/projection.rb
@@ -15,8 +15,8 @@ module RubyEventStore
 
     def initialize(streams: [])
       @streams  = streams
-      @handlers = Hash.new { ->(_, _) {} }
-      @init     = -> { Hash.new }
+      @handlers = {}
+      @init     = -> { {} }
     end
 
     attr_reader :streams, :handlers
@@ -98,7 +98,7 @@ module RubyEventStore
     end
 
     def transition(state, event)
-      handlers[event.type].(state, event)
+      handlers.fetch(event.type).call(state, event)
       state
     end
   end

--- a/ruby_event_store/lib/ruby_event_store/projection.rb
+++ b/ruby_event_store/lib/ruby_event_store/projection.rb
@@ -50,6 +50,10 @@ module RubyEventStore
       handlers.keys
     end
 
+    def handled_event_classes
+      handlers.keys.map { |event| Object.const_get(event) }
+    end
+
     def run(event_store, start: nil, count: PAGE_SIZE)
       if streams.any?
         reduce_from_streams(event_store, start, count)
@@ -83,6 +87,7 @@ module RubyEventStore
 
     def read_scope(event_store, stream, count, start)
       scope = event_store.read.in_batches(count)
+      scope = scope.of_type(handled_event_classes)
       scope = scope.stream(stream) if stream
       scope = scope.from(start) if start
       scope

--- a/ruby_event_store/lib/ruby_event_store/projection.rb
+++ b/ruby_event_store/lib/ruby_event_store/projection.rb
@@ -51,7 +51,7 @@ module RubyEventStore
     end
 
     def handled_event_classes
-      handlers.keys.map { |event| Object.const_get(event) }
+      handled_events.map { |event| Object.const_get(event) }
     end
 
     def run(event_store, start: nil, count: PAGE_SIZE)

--- a/ruby_event_store/lib/ruby_event_store/projection.rb
+++ b/ruby_event_store/lib/ruby_event_store/projection.rb
@@ -50,10 +50,6 @@ module RubyEventStore
       handlers.keys
     end
 
-    def handled_event_classes
-      handled_events.map { |event| Object.const_get(event) }
-    end
-
     def run(event_store, start: nil, count: PAGE_SIZE)
       if streams.any?
         reduce_from_streams(event_store, start, count)
@@ -87,7 +83,7 @@ module RubyEventStore
 
     def read_scope(event_store, stream, count, start)
       scope = event_store.read.in_batches(count)
-      scope = scope.of_type(handled_event_classes)
+      scope = scope.of_type(handled_events)
       scope = scope.stream(stream) if stream
       scope = scope.from(start) if start
       scope

--- a/ruby_event_store/spec/projection_spec.rb
+++ b/ruby_event_store/spec/projection_spec.rb
@@ -227,8 +227,8 @@ module RubyEventStore
 
       specification = Specification.new(SpecificationReader.new(repository, mapper))
       expected      = specification.in_batches(100).of_type([MoneyDeposited, MoneyWithdrawn, MoneyLost]).result
-
       expect(repository).to receive(:read).with(expected).and_call_original
+
       balance = Projection.
         from_all_streams.
         init( -> { { total: 0 } }).

--- a/ruby_event_store/spec/projection_spec.rb
+++ b/ruby_event_store/spec/projection_spec.rb
@@ -40,7 +40,7 @@ module RubyEventStore
       expect(account_balance).to eq(total: 5)
     end
 
-    specify "raises proper errors when wrong argument were pass (stream mode)" do
+    specify "raises proper errors when wrong argument were passed (stream mode)" do
       projection = Projection.from_stream("Customer$1", "Customer$2")
       expect {
         projection.run(event_store, start: :last)
@@ -215,9 +215,31 @@ module RubyEventStore
       expect(balance).to eq(total: 6)
     end
 
+    specify "only events that have handlers must be read" do
+      EventWithoutHandler = Class.new(RubyEventStore::Event)
+      EventWithHandler = Class.new(RubyEventStore::Event)
+
+      event_store.publish(EventWithoutHandler.new(data: { amount: 1 }), stream_name: "Customer$234")
+      event_store.publish(EventWithHandler.new(data: { amount: 1 }), stream_name: "Customer$234")
+      event_store.publish(MoneyDeposited.new(data: { amount: 10 }), stream_name: "Customer$123")
+      event_store.publish(MoneyWithdrawn.new(data: { amount: 3 }), stream_name: "Customer$234")
+
+      specification = Specification.new(SpecificationReader.new(repository, mapper))
+      expected      = specification.in_batches(2).of_type([MoneyDeposited, MoneyWithdrawn, EventWithHandler]).result
+
+      expect(repository).to receive(:read).with(expected).and_call_original
+      balance = Projection.
+        from_all_streams.
+        init( -> { { total: 0 } }).
+        when([MoneyDeposited], ->(state, event) { state[:total] += event.data[:amount] }).
+        when([MoneyWithdrawn, EventWithHandler], ->(state, event) { state[:total] -= event.data[:amount] }).
+        run(event_store, count: 2)
+      expect(balance).to eq(total: 6)
+    end
+
     specify do
       specification = Specification.new(SpecificationReader.new(repository, mapper))
-      expected      = specification.in_batches(2).result
+      expected      = specification.in_batches(2).of_type([]).result
       expect(repository).to receive(:read).with(expected).and_return([])
 
       Projection.from_all_streams.run(event_store, count: 2)
@@ -225,7 +247,7 @@ module RubyEventStore
 
     specify do
       specification = Specification.new(SpecificationReader.new(repository, mapper))
-      expected      = specification.in_batches(2).stream("FancyStream").result
+      expected      = specification.in_batches(2).of_type([]).stream("FancyStream").result
       expect(repository).to receive(:read).with(expected).and_return([])
 
       Projection.from_stream("FancyStream").run(event_store, count: 2)


### PR DESCRIPTION
- [x] verify that `events_class_remapping` is supported in `Projection` (it is not)

Closes: #681, #682, #569