### PR TITLE
Apply matcher for testing AggregateRoot

### DIFF
--- a/rails_event_store-rspec/lib/rails_event_store/rspec.rb
+++ b/rails_event_store-rspec/lib/rails_event_store/rspec.rb
@@ -13,6 +13,7 @@ require "rails_event_store/rspec/be_event"
 require "rails_event_store/rspec/have_published"
 require "rails_event_store/rspec/have_applied"
 require "rails_event_store/rspec/publish"
+require "rails_event_store/rspec/apply"
 require "rails_event_store/rspec/matchers"
 
 ::RSpec.configure do |config|

--- a/rails_event_store-rspec/lib/rails_event_store/rspec/apply.rb
+++ b/rails_event_store-rspec/lib/rails_event_store/rspec/apply.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'rspec/matchers/built_in/base_matcher'
+
+module RailsEventStore
+  module RSpec
+    class Apply
+      def in(aggregate)
+        @aggregate = aggregate
+        self
+      end
+
+      def matches?(event_proc)
+        raise_aggregate_not_set unless @aggregate
+        before = @aggregate.unpublished_events.to_a
+        event_proc.call
+        @applied_events = @aggregate.unpublished_events.to_a - before
+        if match_events?
+          ::RSpec::Matchers::BuiltIn::Include.new(*@expected).matches?(@applied_events)
+        else
+          !@applied_events.empty?
+        end
+      end
+
+      def failure_message
+        if match_events?
+          <<-EOS
+expected block to have applied:
+
+#{@expected}
+
+but applied:
+
+#{@applied_events}
+EOS
+        else
+          "expected block to have applied any events"
+        end
+      end
+
+      def failure_message_when_negated
+        if match_events?
+          <<-EOS
+expected block not to have applied:
+
+#{@expected}
+
+but applied:
+
+#{@applied_events}
+EOS
+        else
+          "expected block not to have applied any events"
+        end
+      end
+
+      def description
+        "apply events"
+      end
+
+      def supports_block_expectations?
+        true
+      end
+
+      private
+
+      def initialize(*expected)
+        @expected = expected
+      end
+
+      def match_events?
+        !@expected.empty?
+      end
+
+      def raise_aggregate_not_set
+        raise SyntaxError, "You have to set the aggregate instance with `in`, e.g. `expect { ... }.to apply(an_event(MyEvent)).in(aggregate)`"
+      end
+    end
+  end
+end

--- a/rails_event_store-rspec/lib/rails_event_store/rspec/apply.rb
+++ b/rails_event_store-rspec/lib/rails_event_store/rspec/apply.rb
@@ -8,13 +8,18 @@ module RailsEventStore
         self
       end
 
+      def strict
+        @matcher = ::RSpec::Matchers::BuiltIn::Match.new(@expected)
+        self
+      end
+
       def matches?(event_proc)
         raise_aggregate_not_set unless @aggregate
         before = @aggregate.unpublished_events.to_a
         event_proc.call
         @applied_events = @aggregate.unpublished_events.to_a - before
         if match_events?
-          ::RSpec::Matchers::BuiltIn::Include.new(*@expected).matches?(@applied_events)
+          @matcher.matches?(@applied_events)
         else
           !@applied_events.empty?
         end
@@ -64,6 +69,7 @@ EOS
 
       def initialize(*expected)
         @expected = expected
+        @matcher   = ::RSpec::Matchers::BuiltIn::Include.new(*expected)
       end
 
       def match_events?

--- a/rails_event_store-rspec/lib/rails_event_store/rspec/apply.rb
+++ b/rails_event_store-rspec/lib/rails_event_store/rspec/apply.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rspec/matchers/built_in/base_matcher'
-
 module RailsEventStore
   module RSpec
     class Apply

--- a/rails_event_store-rspec/lib/rails_event_store/rspec/matchers.rb
+++ b/rails_event_store-rspec/lib/rails_event_store/rspec/matchers.rb
@@ -46,6 +46,10 @@ module RailsEventStore
         Publish.new(*expected)
       end
 
+      def apply(*expected)
+        Apply.new(*expected)
+      end
+
       private
 
       def formatter

--- a/rails_event_store-rspec/lib/rails_event_store/rspec/publish.rb
+++ b/rails_event_store-rspec/lib/rails_event_store/rspec/publish.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rspec/matchers/built_in/base_matcher'
-
 module RailsEventStore
   module RSpec
     class Publish

--- a/rails_event_store-rspec/spec/rails_event_store/rspec/apply_spec.rb
+++ b/rails_event_store-rspec/spec/rails_event_store/rspec/apply_spec.rb
@@ -102,9 +102,27 @@ module RailsEventStore
       end
 
       specify do
-        foo_event = an_event(FooEvent).with_data(any: :thing)
-        matcher_ = matcher(actual = matchers.an_event(foo_event)).in(aggregate)
+        foo_event = matchers.an_event(FooEvent).with_data(any: :thing)
+        matcher_ = matcher(foo_event).in(aggregate)
         matcher_.matches?(Proc.new { aggregate.foo })
+        actual = aggregate.unpublished_events.first
+
+        expect(matcher_.failure_message.to_s).to eq(<<~EOS)
+          expected block to have applied:
+
+          #{[foo_event].inspect}
+
+          but applied:
+
+          #{[actual].inspect}
+        EOS
+      end
+
+      specify do
+        foo_event = matchers.an_event(FooEvent)
+        matcher_ = matcher(foo_event).in(aggregate)
+        matcher_.matches?(Proc.new { aggregate.foo })
+        actual = aggregate.unpublished_events.first
 
         expect(matcher_.failure_message_when_negated.to_s).to eq(<<~EOS)
           expected block not to have applied:

--- a/rails_event_store-rspec/spec/rails_event_store/rspec/apply_spec.rb
+++ b/rails_event_store-rspec/spec/rails_event_store/rspec/apply_spec.rb
@@ -136,6 +136,20 @@ module RailsEventStore
       end
 
       specify do
+        expect {
+          aggregate.foo
+          aggregate.bar
+        }.to matcher(matchers.an_event(FooEvent), matchers.an_event(BarEvent)).in(aggregate).strict
+      end
+
+      specify do
+        expect {
+          aggregate.foo
+          aggregate.bar
+        }.not_to matcher(matchers.an_event(BarEvent)).in(aggregate).strict
+      end
+
+      specify do
         matcher_ = matcher
         expect(matcher_.description).to eq("apply events")
       end

--- a/rails_event_store-rspec/spec/rails_event_store/rspec/apply_spec.rb
+++ b/rails_event_store-rspec/spec/rails_event_store/rspec/apply_spec.rb
@@ -1,0 +1,126 @@
+require "spec_helper"
+
+module RailsEventStore
+  module RSpec
+    ::RSpec.describe Apply do
+      let(:matchers) { Object.new.tap { |o| o.extend(Matchers) } }
+      let(:aggregate) { TestAggregate.new }
+
+      def matcher(*expected)
+        Apply.new(*expected)
+      end
+
+      specify do
+        expect {
+          expect {
+            true
+          }.to matcher
+        }.to raise_error(SyntaxError, "You have to set the aggregate instance with `in`, e.g. `expect { ... }.to apply(an_event(MyEvent)).in(aggregate)`")
+      end
+
+      specify do
+        expect {
+          true
+        }.not_to matcher.in(aggregate)
+      end
+
+      specify do
+        expect {
+          aggregate.foo
+        }.to matcher.in(aggregate)
+      end
+
+      specify do
+        expect {
+          aggregate.foo
+        }.not_to matcher(matchers.an_event(BarEvent)).in(aggregate)
+      end
+
+      specify do
+        expect {
+          aggregate.foo
+        }.to matcher(matchers.an_event(FooEvent)).in(aggregate)
+      end
+
+      specify do
+        aggregate.foo
+        aggregate.foo
+        aggregate.foo
+        expect {
+          aggregate.bar
+        }.to matcher(matchers.an_event(BarEvent)).in(aggregate)
+        expect {
+          aggregate.bar
+        }.not_to matcher(matchers.an_event(FooEvent)).in(aggregate)
+      end
+
+      specify do
+        expect {
+          aggregate.foo
+          aggregate.bar
+        }.to matcher(matchers.an_event(FooEvent), matchers.an_event(BarEvent)).in(aggregate)
+      end
+
+      specify do
+        aggregate.foo
+        expect {
+          aggregate.bar
+        }.not_to matcher(matchers.an_event(FooEvent)).in(aggregate)
+      end
+
+      specify do
+        matcher_ = matcher.in(aggregate)
+        matcher_.matches?(Proc.new { })
+
+        expect(matcher_.failure_message_when_negated.to_s).to eq(<<~EOS.strip)
+          expected block not to have applied any events
+        EOS
+      end
+
+      specify do
+        matcher_ = matcher.in(aggregate)
+        matcher_.matches?(Proc.new { })
+
+        expect(matcher_.failure_message.to_s).to eq(<<~EOS.strip)
+          expected block to have applied any events
+        EOS
+      end
+
+      specify do
+        matcher_ = matcher(actual = matchers.an_event(FooEvent)).in(aggregate)
+        matcher_.matches?(Proc.new { })
+
+        expect(matcher_.failure_message.to_s).to eq(<<~EOS)
+          expected block to have applied:
+
+          #{[actual].inspect}
+
+          but applied:
+
+          []
+        EOS
+      end
+
+      specify do
+        foo_event = an_event(FooEvent).with_data(any: :thing)
+        matcher_ = matcher(actual = matchers.an_event(foo_event)).in(aggregate)
+        matcher_.matches?(Proc.new { aggregate.foo })
+
+        expect(matcher_.failure_message_when_negated.to_s).to eq(<<~EOS)
+          expected block not to have applied:
+
+          #{[foo_event].inspect}
+
+          but applied:
+
+          #{[actual].inspect}
+        EOS
+      end
+
+      specify do
+        matcher_ = matcher
+        expect(matcher_.description).to eq("apply events")
+      end
+    end
+  end
+end

--- a/rails_event_store-rspec/spec/rails_event_store/rspec/matchers_spec.rb
+++ b/rails_event_store-rspec/spec/rails_event_store/rspec/matchers_spec.rb
@@ -72,6 +72,24 @@ module RailsEventStore
       specify do
         expect(matchers.publish).to be_a(Publish)
       end
+
+      specify do
+        aggregate = TestAggregate.new
+        expect {
+          aggregate.foo
+        }.to apply(matchers.an_event(FooEvent)).in(aggregate)
+      end
+
+      specify do
+        aggregate = TestAggregate.new
+        expect {
+          aggregate.foo
+        }.not_to apply(matchers.an_event(BarEvent)).in(aggregate)
+      end
+
+      specify do
+        expect(matchers.apply).to be_a(Apply)
+      end
     end
 
     module Matchers


### PR DESCRIPTION
Instead of checking what have_applied by aggregate action this matcher
will check what have applied during the action.

This will allow to write test like:

```
aggtegate = SomeAggregate.new
aggregate.do_something

expect { aggregate.do_anything_else }.to
  apply(an_event(SomeEvent)).in(aggregate)
```

The advantage is that we will be able what exactly have been
applied during the aggregate logic execution.