### PR TITLE
Minimize API: remove to_h from RubyEventStore::Event

### DIFF
--- a/ruby_event_store/lib/ruby_event_store/event.rb
+++ b/ruby_event_store/lib/ruby_event_store/event.rb
@@ -34,20 +34,6 @@ module RubyEventStore
       self.class.name
     end
 
-    # Returns a hash representation of the event.
-    #
-    # Metadata is converted to hash as well
-    #
-    # @return [Hash] with :event_id, :metadata, :data, :type keys
-    def to_h
-      {
-          event_id:   event_id,
-          metadata:   metadata.to_h,
-          data:       data,
-          type:       type,
-      }
-    end
-
     # Timestamp from metadata
     #
     # @return [Time, nil]

--- a/ruby_event_store/spec/event_spec.rb
+++ b/ruby_event_store/spec/event_spec.rb
@@ -106,16 +106,6 @@ module RubyEventStore
       expect(event).not_to eq(object)
     end
 
-    specify 'convert to hash' do
-      hash = {
-          data: { data: 'sample' },
-          event_id: 'b2d506fd-409d-4ec7-b02f-c6d2295c7edd',
-          metadata: { meta: 'test'},
-      }
-      event = Test::TestCreated.new(**hash)
-      expect(event.to_h).to eq(hash.merge(type: 'Test::TestCreated'))
-    end
-
     specify 'only events with the same class, event_id & data are equal' do
       event_1 = Test::TestCreated.new
       event_2 = Test::TestCreated.new


### PR DESCRIPTION
* not used anywhere within RailsEventStore
* if you need to_h for your events, you should create
  a wrapper or your own Event class - see example here:
  https://github.com/RailsEventStore/cqrs-es-sample-with-res/blob/master/lib/event.rb