### PR TITLE
Update rspec dependency

### DIFF
--- a/rails_event_store-rspec/rails_event_store-rspec.gemspec
+++ b/rails_event_store-rspec/rails_event_store-rspec.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rspec', '~> 3.0'
+  spec.add_runtime_dependency 'rspec', '>= 3.0'
 end


### PR DESCRIPTION
This is not allowing us to upgrade to Rails 6 :grimacing: