### PR TITLE
Don't display "Related streams" header on the bottom if the feature i…

### DIFF
--- a/railseventstore.org/source/docs/browser.html.md
+++ b/railseventstore.org/source/docs/browser.html.md
@@ -126,3 +126,30 @@ end
 ### Sinatra
 
 You can use Rack-based middleware such as HTTP Basic Auth (as illustrated in the Rails example above) to control access to the browser Rack app.
+
+### Related Streams
+
+Often you have streams, which are closely related to each other. To ease debugging, you may want to create custom links between streams. For example, if you are viewing stream `Ordering::Order$123`, you may want to link to stream `Payments::Transaction$456`.
+
+You can do that by passing related streams query object to browser configuration. Related streams query object can be anything, which reponds to `call(stream_name)` and always return an array (i.e. it can be simple lambda).
+
+Related streams will be displayed in stream view, at the bottom.
+
+Example usage:
+
+```
+class RelatedStreamsQuery
+  def call(stream_name)
+    prefix, suffix = stream_name.split("$")
+    if prefix == "Ordering::Order"
+      transaction_id = # some way to fetch transaction id for that order
+      return ["Payments::Transaction$#{transaction_id}"]
+    end
+    return []
+  end
+end
+
+RubyEventStore::Browser::App.for(
+  related_streams_query: RelatedStreamsQuery.new
+)
+```

--- a/ruby_event_store-browser/elm/src/Api.elm
+++ b/ruby_event_store-browser/elm/src/Api.elm
@@ -43,7 +43,7 @@ type alias PaginationLinks =
 
 type alias Stream =
     { eventsRelationshipLink : String
-    , relatedStreams : List String
+    , relatedStreams : Maybe (List String)
     }
 
 
@@ -98,7 +98,7 @@ streamDecoder_ : Decoder Stream
 streamDecoder_ =
     succeed Stream
         |> requiredAt [ "relationships", "events", "links", "self" ] string
-        |> requiredAt [ "attributes", "related_streams" ] (list string)
+        |> optionalAt [ "attributes", "related_streams" ] (maybe (list string)) Nothing
 
 
 getEvents : (Result Http.Error (PaginatedList Event) -> msg) -> String -> Cmd msg

--- a/ruby_event_store-browser/elm/src/Page/ViewStream.elm
+++ b/ruby_event_store-browser/elm/src/Page/ViewStream.elm
@@ -21,7 +21,7 @@ import Url
 type alias Model =
     { events : Api.PaginatedList Api.Event
     , streamName : String
-    , relatedStreams : List String
+    , relatedStreams : Maybe (List String)
     }
 
 
@@ -29,7 +29,7 @@ initModel : String -> Model
 initModel streamName =
     { streamName = streamName
     , events = Api.emptyPaginatedList
-    , relatedStreams = []
+    , relatedStreams = Nothing
     }
 
 
@@ -76,7 +76,7 @@ view model =
     ( "Stream " ++ model.streamName, browseEvents ("Events in " ++ model.streamName) model.events model.relatedStreams )
 
 
-browseEvents : String -> Api.PaginatedList Api.Event -> List String -> Html Msg
+browseEvents : String -> Api.PaginatedList Api.Event -> Maybe (List String) -> Html Msg
 browseEvents title { links, events } relatedStreams =
     div [ class "browser" ]
         [ h1 [ class "browser__title" ] [ text title ]
@@ -86,12 +86,22 @@ browseEvents title { links, events } relatedStreams =
         ]
 
 
-renderRelatedStreams : List String -> Html Msg
-renderRelatedStreams relatedStreams =
-    div [ class "event__related-streams" ]
-        [ h2 [] [ text "Related streams:" ]
-        , ul [] (List.map (\relatedStream -> li [] [ streamLink relatedStream ]) relatedStreams)
-        ]
+renderRelatedStreams : Maybe (List String) -> Html Msg
+renderRelatedStreams relatedStreams_ =
+    case relatedStreams_ of
+        Just relatedStreams ->
+            div [ class "event__related-streams" ]
+                [ h2 [] [ text "Related streams:" ]
+                , ul [] (List.map (\relatedStream -> li [] [ streamLink relatedStream ]) relatedStreams)
+                ]
+
+        Nothing ->
+            emptyHtml
+
+
+emptyHtml : Html a
+emptyHtml =
+    text ""
 
 
 streamLink : String -> Html Msg

--- a/ruby_event_store-browser/lib/ruby_event_store/browser/get_stream.rb
+++ b/ruby_event_store-browser/lib/ruby_event_store/browser/get_stream.rb
@@ -30,7 +30,9 @@ module RubyEventStore
       attr_reader :stream_name, :routing, :related_streams_query
 
       def related_streams
-        related_streams_query.call(stream_name)
+        unless related_streams_query.equal?(DEFAULT_RELATED_STREAMS_QUERY)
+          related_streams_query.call(stream_name)
+        end
       end
     end
   end

--- a/ruby_event_store-browser/spec/api_spec.rb
+++ b/ruby_event_store-browser/spec/api_spec.rb
@@ -10,7 +10,7 @@ module RubyEventStore
         "id" => "all",
         "type" => "streams",
         "attributes" => {
-          "related_streams" => [],
+          "related_streams" => nil,
         },
         "relationships" => {
           "events" => {
@@ -37,6 +37,18 @@ module RubyEventStore
       test_client.get "/streams/dummy"
       expect(test_client.last_response).to be_ok
       expect(test_client.parsed_body["data"]["attributes"]["related_streams"]).to eq(["even-dummier"])
+    end
+
+    specify "default related streams query returns nil" do
+      app = RubyEventStore::Browser::App.for(
+        event_store_locator: -> { event_store },
+        host: 'http://www.example.com'
+      )
+      test_client = TestClient.with_linter(app)
+
+      test_client.get "/streams/all"
+      expect(test_client.last_response).to be_ok
+      expect(test_client.parsed_body["data"]["attributes"]["related_streams"]).to eq(nil)
     end
 
     specify do


### PR DESCRIPTION
…s not used

Default related streams query will return empty list of streams, so
it's kind of pointless to display it, it looks like something is broken.