### PR TITLE
Allow to pass data and metadata instances to event linter

### DIFF
--- a/ruby_event_store/lib/ruby_event_store/spec/event_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/event_lint.rb
@@ -1,9 +1,7 @@
-RSpec.shared_examples :event do |event_class|
+RSpec.shared_examples :event do |event_class, data, metadata|
   it 'allows initialization' do
     expect {
-      metadata = double(:metadata)
-      allow(metadata).to receive(:to_h).and_return({})
-      event_class.new(event_id: Object.new, data: Object.new, metadata: metadata)
+      event_class.new(event_id: Object.new, data: data || Object.new, metadata: metadata || {})
     }.not_to raise_error
   end
 


### PR DESCRIPTION
Some Event class implementation could use different models
for data & metadata attribute. Some of them might have requirements
that could not be fulfilled by Object instance. By default Event linter
will use new object instance for as adata object and empty hash as
metadata (to match all requirements for metadata) but will allow
to pass exact instances to be used while checking event's class
implementation.