### PR TITLE
Allow missing encryption keys

### DIFF
--- a/ruby_event_store/lib/ruby_event_store/mappers/transformation/encryption.rb
+++ b/ruby_event_store/lib/ruby_event_store/mappers/transformation/encryption.rb
@@ -97,7 +97,7 @@ module RubyEventStore
         def encrypt_attribute(data, attribute, meta)
           case meta
           when Leaf
-            value = data.fetch(attribute)
+            value = data.fetch(attribute, nil)
             return unless value
 
             encryption_key = key_repository.key_of(meta.fetch(:identifier))

--- a/ruby_event_store/spec/mappers/transformation/encryption_spec.rb
+++ b/ruby_event_store/spec/mappers/transformation/encryption_spec.rb
@@ -138,6 +138,7 @@ module RubyEventStore
               sender: sender.merge(name: nil),
               recipient: recipient
             })
+
             expect(event.metadata).to eq(metadata)
           end
         end

--- a/ruby_event_store/spec/mappers/transformation/encryption_spec.rb
+++ b/ruby_event_store/spec/mappers/transformation/encryption_spec.rb
@@ -137,7 +137,6 @@ module RubyEventStore
               sender: sender.merge(name: nil),
               recipient: recipient
             })
-
             expect(event.metadata).to eq(metadata)
           end
         end

--- a/ruby_event_store/spec/mappers/transformation/encryption_spec.rb
+++ b/ruby_event_store/spec/mappers/transformation/encryption_spec.rb
@@ -115,6 +115,32 @@ module RubyEventStore
           expect(event.metadata).to eq(metadata)
         end
 
+        context "when encryptable event keys are missing" do
+          let(:sender) do
+            {
+              user_id: sender_id,
+              email: sender_email,
+              twitter: '@alice'
+            }
+          end
+
+          specify 'transforms missing data keys into nil values' do
+            key_repository.create(sender_id)
+            key_repository.create(recipient_id)
+
+            event = decrypt(encrypt(ticket_transferred))
+
+            expect(event.event_id).to eq(event_id)
+
+            expect(event.data).to eq({
+              ticket_id: ticket_id,
+              sender: sender.merge(name: nil),
+              recipient: recipient
+            })
+            expect(event.metadata).to eq(metadata)
+          end
+        end
+
         specify 'obfuscates data for missing keys on decryption' do
           key_repository.create(sender_id)
           key_repository.create(recipient_id)

--- a/ruby_event_store/spec/mappers/transformation/encryption_spec.rb
+++ b/ruby_event_store/spec/mappers/transformation/encryption_spec.rb
@@ -137,6 +137,7 @@ module RubyEventStore
               sender: sender.merge(name: nil),
               recipient: recipient
             })
+
             expect(event.metadata).to eq(metadata)
           end
         end

--- a/ruby_event_store/spec/mappers/transformation/encryption_spec.rb
+++ b/ruby_event_store/spec/mappers/transformation/encryption_spec.rb
@@ -112,6 +112,7 @@ module RubyEventStore
             sender: sender,
             recipient: recipient
           })
+
           expect(event.metadata).to eq(metadata)
         end
 


### PR DESCRIPTION
We have some fields in our events that are optional. But if they are present they should be encrypted. I created at fix for that  