### PR TITLE
Allow to specify event type resolver for subscriptions

### DIFF
--- a/ruby_event_store/lib/ruby_event_store/client.rb
+++ b/ruby_event_store/lib/ruby_event_store/client.rb
@@ -132,7 +132,7 @@ module RubyEventStore
     # @param to [Class, String] type of events to get list of sybscribed handlers
     # @return [Array<Object, Class>]
     def subscribers_for(event_type)
-      subscriptions.all_for(event_type.to_s)
+      subscriptions.all_for(event_type)
     end
 
     # Builder object for collecting temporary handlers (subscribers)

--- a/ruby_event_store/lib/ruby_event_store/spec/subscriptions_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/subscriptions_lint.rb
@@ -114,4 +114,23 @@ RSpec.shared_examples :subscriptions do |subscriptions_class|
 
     expect(subscriptions.all_for('Test1DomainEvent')).to eq([handler, handler])
   end
+
+  it 'subscribes by type of event which is a class' do
+    handler         = TestHandler.new
+    subscriptions.add_subscription(handler, [Test1DomainEvent])
+    subscriptions.add_thread_subscription(handler, [Test1DomainEvent])
+
+    expect(subscriptions.all_for('Test1DomainEvent')).to eq([handler, handler])
+    expect(subscriptions.all_for(Test1DomainEvent)).to eq([handler, handler])
+  end
+
+  it 'subscribes by type of event which is a class or string with custom type resolver' do
+    subscriptions = subscriptions_class.new(event_type_resolver: ->(type) { type.to_s.reverse })
+    handler         = TestHandler.new
+    subscriptions.add_subscription(handler, [Test1DomainEvent])
+    subscriptions.add_thread_subscription(handler, ['Test1DomainEvent'])
+
+    expect(subscriptions.all_for('Test1DomainEvent')).to eq([handler, handler])
+    expect(subscriptions.all_for(Test1DomainEvent)).to eq([handler, handler])
+  end
 end

--- a/ruby_event_store/spec/client_spec.rb
+++ b/ruby_event_store/spec/client_spec.rb
@@ -873,6 +873,25 @@ module RubyEventStore
         expect(client.subscribers_for("ProductAdded")).to eq [handler]
         expect(client.subscribers_for(OrderCreated)).to   eq [block]
       end
+
+      specify do
+        subscriptions = Subscriptions.new(event_type_resolver: ->(type) { type.to_s.reverse })
+        client = RubyEventStore::Client.new(
+          repository: InMemoryRepository.new,
+          mapper: Mappers::NullMapper.new,
+          subscriptions: subscriptions,
+          correlation_id_generator: correlation_id_generator
+        )
+
+        handler = Subscribers::ValidHandler.new
+        client.subscribe(handler, to: [ProductAdded])
+        block = Proc.new { "Event published!" }
+        client.subscribe(to: [OrderCreated], &block)
+
+        expect(client.subscribers_for(ProductAdded)).to   eq [handler]
+        expect(client.subscribers_for("ProductAdded")).to eq [handler]
+        expect(client.subscribers_for(OrderCreated)).to   eq [block]
+      end
     end
 
     specify "#inspect" do


### PR DESCRIPTION
Make implicit explicit. Type resolver is reponsible
for converting event type from anything (class, string, etc)
to event type (string preffered here).

Default implementation (backward compatible) is just
lambda using to_s method to convert event type
given as class or string to string.