### PR TITLE
Bump to mutant 0.10.14

### DIFF
--- a/support/bundler/Gemfile.shared
+++ b/support/bundler/Gemfile.shared
@@ -2,6 +2,6 @@ ENV['RAILS_VERSION'] ||= File.read(File.join(__dir__, '../..', 'RAILS_VERSION'))
 
 gem 'rake',         '>= 10.0'
 gem 'rspec',        '~> 3.6'
-gem 'mutant-rspec', '~> 0.10.13'
-gem 'mutant',       '~> 0.10.13'
+gem 'mutant-rspec', '~> 0.10.14'
+gem 'mutant',       '~> 0.10.14'
 gem 'mutant-license', source: 'https://oss:7AXfeZdAfCqL1PvHm2nvDJO6Zd9UW8IK@gem.mutant.dev'


### PR DESCRIPTION
* This release changes to consider mutations that make rspec crash as
  covered as long `process_abort: true` is active as a coverage criteria.