### PR TITLE
Evaled Gemfile does not work with dependabot

### DIFF
--- a/aggregate_root/Gemfile
+++ b/aggregate_root/Gemfile
@@ -4,7 +4,11 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
-eval_gemfile File.expand_path('../support/bundler/Gemfile.shared', __dir__)
+gem 'rake',         '>= 10.0'
+gem 'rspec',        '~> 3.6'
+gem 'mutant-rspec', '~> 0.10.15'
+gem 'mutant',       '~> 0.10.15'
+gem 'mutant-license', source: 'https://oss:7AXfeZdAfCqL1PvHm2nvDJO6Zd9UW8IK@gem.mutant.dev'
 
 gem 'ruby_event_store', path: '../ruby_event_store'
 gem 'protobuf_nested_struct'

--- a/aggregate_root/Gemfile.lock
+++ b/aggregate_root/Gemfile.lock
@@ -34,7 +34,7 @@ GEM
     concurrent-ruby (1.1.7)
     diff-lcs (1.4.4)
     equalizer (0.0.11)
-    google-protobuf (3.12.4)
+    google-protobuf (3.12.4-universal-darwin)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)

--- a/bounded_context/Gemfile
+++ b/bounded_context/Gemfile
@@ -4,6 +4,10 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
-eval_gemfile File.expand_path('../support/bundler/Gemfile.shared', __dir__)
+gem 'rake',         '>= 10.0'
+gem 'rspec',        '~> 3.6'
+gem 'mutant-rspec', '~> 0.10.15'
+gem 'mutant',       '~> 0.10.15'
+gem 'mutant-license', source: 'https://oss:7AXfeZdAfCqL1PvHm2nvDJO6Zd9UW8IK@gem.mutant.dev'
 
 gem 'rails', '6.0.3.4'

--- a/bounded_context/Gemfile.rails_5_0
+++ b/bounded_context/Gemfile.rails_5_0
@@ -4,6 +4,10 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
-eval_gemfile File.expand_path('../support/bundler/Gemfile.shared', __dir__)
+gem 'rake',         '>= 10.0'
+gem 'rspec',        '~> 3.6'
+gem 'mutant-rspec', '~> 0.10.15'
+gem 'mutant',       '~> 0.10.15'
+gem 'mutant-license', source: 'https://oss:7AXfeZdAfCqL1PvHm2nvDJO6Zd9UW8IK@gem.mutant.dev'
 
 gem 'rails', '5.0.7.2'

--- a/bounded_context/Gemfile.rails_5_1
+++ b/bounded_context/Gemfile.rails_5_1
@@ -4,6 +4,10 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
-eval_gemfile File.expand_path('../support/bundler/Gemfile.shared', __dir__)
+gem 'rake',         '>= 10.0'
+gem 'rspec',        '~> 3.6'
+gem 'mutant-rspec', '~> 0.10.15'
+gem 'mutant',       '~> 0.10.15'
+gem 'mutant-license', source: 'https://oss:7AXfeZdAfCqL1PvHm2nvDJO6Zd9UW8IK@gem.mutant.dev'
 
 gem 'rails', '5.1.7'

--- a/bounded_context/Gemfile.rails_5_2
+++ b/bounded_context/Gemfile.rails_5_2
@@ -4,6 +4,10 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
-eval_gemfile File.expand_path('../support/bundler/Gemfile.shared', __dir__)
+gem 'rake',         '>= 10.0'
+gem 'rspec',        '~> 3.6'
+gem 'mutant-rspec', '~> 0.10.15'
+gem 'mutant',       '~> 0.10.15'
+gem 'mutant-license', source: 'https://oss:7AXfeZdAfCqL1PvHm2nvDJO6Zd9UW8IK@gem.mutant.dev'
 
 gem 'rails', '5.2.4.4 '

--- a/rails_event_store-rspec/Gemfile
+++ b/rails_event_store-rspec/Gemfile
@@ -2,7 +2,11 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
-eval_gemfile File.expand_path('../support/bundler/Gemfile.shared', __dir__)
+gem 'rake',         '>= 10.0'
+gem 'rspec',        '~> 3.6'
+gem 'mutant-rspec', '~> 0.10.15'
+gem 'mutant',       '~> 0.10.15'
+gem 'mutant-license', source: 'https://oss:7AXfeZdAfCqL1PvHm2nvDJO6Zd9UW8IK@gem.mutant.dev'
 
 gem 'rails_event_store', path: '../rails_event_store'
 gem 'rails_event_store_active_record', path: '../rails_event_store_active_record'

--- a/rails_event_store-rspec/Gemfile.rails_5_0
+++ b/rails_event_store-rspec/Gemfile.rails_5_0
@@ -2,7 +2,11 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
-eval_gemfile File.expand_path('../support/bundler/Gemfile.shared', __dir__)
+gem 'rake',         '>= 10.0'
+gem 'rspec',        '~> 3.6'
+gem 'mutant-rspec', '~> 0.10.15'
+gem 'mutant',       '~> 0.10.15'
+gem 'mutant-license', source: 'https://oss:7AXfeZdAfCqL1PvHm2nvDJO6Zd9UW8IK@gem.mutant.dev'
 
 gem 'rails_event_store', path: '../rails_event_store'
 gem 'rails_event_store_active_record', path: '../rails_event_store_active_record'

--- a/rails_event_store-rspec/Gemfile.rails_5_1
+++ b/rails_event_store-rspec/Gemfile.rails_5_1
@@ -2,7 +2,11 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
-eval_gemfile File.expand_path('../support/bundler/Gemfile.shared', __dir__)
+gem 'rake',         '>= 10.0'
+gem 'rspec',        '~> 3.6'
+gem 'mutant-rspec', '~> 0.10.15'
+gem 'mutant',       '~> 0.10.15'
+gem 'mutant-license', source: 'https://oss:7AXfeZdAfCqL1PvHm2nvDJO6Zd9UW8IK@gem.mutant.dev'
 
 gem 'rails_event_store', path: '../rails_event_store'
 gem 'rails_event_store_active_record', path: '../rails_event_store_active_record'

--- a/rails_event_store-rspec/Gemfile.rails_5_2
+++ b/rails_event_store-rspec/Gemfile.rails_5_2
@@ -2,7 +2,11 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
-eval_gemfile File.expand_path('../support/bundler/Gemfile.shared', __dir__)
+gem 'rake',         '>= 10.0'
+gem 'rspec',        '~> 3.6'
+gem 'mutant-rspec', '~> 0.10.15'
+gem 'mutant',       '~> 0.10.15'
+gem 'mutant-license', source: 'https://oss:7AXfeZdAfCqL1PvHm2nvDJO6Zd9UW8IK@gem.mutant.dev'
 
 gem 'rails_event_store', path: '../rails_event_store'
 gem 'rails_event_store_active_record', path: '../rails_event_store_active_record'

--- a/rails_event_store/Gemfile
+++ b/rails_event_store/Gemfile
@@ -2,7 +2,11 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
-eval_gemfile File.expand_path('../support/bundler/Gemfile.shared', __dir__)
+gem 'rake',         '>= 10.0'
+gem 'rspec',        '~> 3.6'
+gem 'mutant-rspec', '~> 0.10.15'
+gem 'mutant',       '~> 0.10.15'
+gem 'mutant-license', source: 'https://oss:7AXfeZdAfCqL1PvHm2nvDJO6Zd9UW8IK@gem.mutant.dev'
 
 gem 'ruby_event_store', path: '../ruby_event_store'
 gem 'ruby_event_store-browser', path: '../ruby_event_store-browser'

--- a/rails_event_store/Gemfile.lock
+++ b/rails_event_store/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
     erubi (1.10.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    google-protobuf (3.12.4)
+    google-protobuf (3.12.4-universal-darwin)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)

--- a/rails_event_store/Gemfile.rails_5_0
+++ b/rails_event_store/Gemfile.rails_5_0
@@ -2,7 +2,11 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
-eval_gemfile File.expand_path('../support/bundler/Gemfile.shared', __dir__)
+gem 'rake',         '>= 10.0'
+gem 'rspec',        '~> 3.6'
+gem 'mutant-rspec', '~> 0.10.15'
+gem 'mutant',       '~> 0.10.15'
+gem 'mutant-license', source: 'https://oss:7AXfeZdAfCqL1PvHm2nvDJO6Zd9UW8IK@gem.mutant.dev'
 
 gem 'ruby_event_store', path: '../ruby_event_store'
 gem 'ruby_event_store-browser', path: '../ruby_event_store-browser'

--- a/rails_event_store/Gemfile.rails_5_1
+++ b/rails_event_store/Gemfile.rails_5_1
@@ -2,7 +2,11 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
-eval_gemfile File.expand_path('../support/bundler/Gemfile.shared', __dir__)
+gem 'rake',         '>= 10.0'
+gem 'rspec',        '~> 3.6'
+gem 'mutant-rspec', '~> 0.10.15'
+gem 'mutant',       '~> 0.10.15'
+gem 'mutant-license', source: 'https://oss:7AXfeZdAfCqL1PvHm2nvDJO6Zd9UW8IK@gem.mutant.dev'
 
 gem 'ruby_event_store', path: '../ruby_event_store'
 gem 'ruby_event_store-browser', path: '../ruby_event_store-browser'

--- a/rails_event_store/Gemfile.rails_5_2
+++ b/rails_event_store/Gemfile.rails_5_2
@@ -2,7 +2,11 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
-eval_gemfile File.expand_path('../support/bundler/Gemfile.shared', __dir__)
+gem 'rake',         '>= 10.0'
+gem 'rspec',        '~> 3.6'
+gem 'mutant-rspec', '~> 0.10.15'
+gem 'mutant',       '~> 0.10.15'
+gem 'mutant-license', source: 'https://oss:7AXfeZdAfCqL1PvHm2nvDJO6Zd9UW8IK@gem.mutant.dev'
 
 gem 'ruby_event_store', path: '../ruby_event_store'
 gem 'ruby_event_store-browser', path: '../ruby_event_store-browser'

--- a/rails_event_store_active_record/Gemfile
+++ b/rails_event_store_active_record/Gemfile
@@ -2,7 +2,11 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
-eval_gemfile File.expand_path('../support/bundler/Gemfile.shared', __dir__)
+gem 'rake',         '>= 10.0'
+gem 'rspec',        '~> 3.6'
+gem 'mutant-rspec', '~> 0.10.15'
+gem 'mutant',       '~> 0.10.15'
+gem 'mutant-license', source: 'https://oss:7AXfeZdAfCqL1PvHm2nvDJO6Zd9UW8IK@gem.mutant.dev'
 
 gem 'ruby_event_store', path: '../ruby_event_store'
 gem 'pg', '1.2.2'

--- a/rails_event_store_active_record/Gemfile.rails_5_0
+++ b/rails_event_store_active_record/Gemfile.rails_5_0
@@ -2,7 +2,11 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
-eval_gemfile File.expand_path('../support/bundler/Gemfile.shared', __dir__)
+gem 'rake',         '>= 10.0'
+gem 'rspec',        '~> 3.6'
+gem 'mutant-rspec', '~> 0.10.15'
+gem 'mutant',       '~> 0.10.15'
+gem 'mutant-license', source: 'https://oss:7AXfeZdAfCqL1PvHm2nvDJO6Zd9UW8IK@gem.mutant.dev'
 
 gem 'ruby_event_store', path: '../ruby_event_store'
 gem 'pg', '1.2.2'

--- a/rails_event_store_active_record/Gemfile.rails_5_1
+++ b/rails_event_store_active_record/Gemfile.rails_5_1
@@ -2,7 +2,11 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
-eval_gemfile File.expand_path('../support/bundler/Gemfile.shared', __dir__)
+gem 'rake',         '>= 10.0'
+gem 'rspec',        '~> 3.6'
+gem 'mutant-rspec', '~> 0.10.15'
+gem 'mutant',       '~> 0.10.15'
+gem 'mutant-license', source: 'https://oss:7AXfeZdAfCqL1PvHm2nvDJO6Zd9UW8IK@gem.mutant.dev'
 
 gem 'ruby_event_store', path: '../ruby_event_store'
 gem 'pg', '1.2.2'

--- a/rails_event_store_active_record/Gemfile.rails_5_2
+++ b/rails_event_store_active_record/Gemfile.rails_5_2
@@ -2,7 +2,11 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
-eval_gemfile File.expand_path('../support/bundler/Gemfile.shared', __dir__)
+gem 'rake',         '>= 10.0'
+gem 'rspec',        '~> 3.6'
+gem 'mutant-rspec', '~> 0.10.15'
+gem 'mutant',       '~> 0.10.15'
+gem 'mutant-license', source: 'https://oss:7AXfeZdAfCqL1PvHm2nvDJO6Zd9UW8IK@gem.mutant.dev'
 
 gem 'ruby_event_store', path: '../ruby_event_store'
 gem 'pg', '1.2.2'

--- a/ruby_event_store-browser/Gemfile
+++ b/ruby_event_store-browser/Gemfile
@@ -2,7 +2,11 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
-eval_gemfile File.expand_path('../support/bundler/Gemfile.shared', __dir__)
+gem 'rake',         '>= 10.0'
+gem 'rspec',        '~> 3.6'
+gem 'mutant-rspec', '~> 0.10.15'
+gem 'mutant',       '~> 0.10.15'
+gem 'mutant-license', source: 'https://oss:7AXfeZdAfCqL1PvHm2nvDJO6Zd9UW8IK@gem.mutant.dev'
 
 gem 'ruby_event_store', path: '../ruby_event_store'
 gem 'aggregate_root',   path: '../aggregate_root'

--- a/ruby_event_store-rom/Gemfile
+++ b/ruby_event_store-rom/Gemfile
@@ -2,7 +2,11 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
-eval_gemfile File.expand_path('../support/bundler/Gemfile.shared', __dir__)
+gem 'rake',         '>= 10.0'
+gem 'rspec',        '~> 3.6'
+gem 'mutant-rspec', '~> 0.10.15'
+gem 'mutant',       '~> 0.10.15'
+gem 'mutant-license', source: 'https://oss:7AXfeZdAfCqL1PvHm2nvDJO6Zd9UW8IK@gem.mutant.dev'
 
 gem 'mysql2', '>= 0.5.3'
 gem 'pg', '>= 1.2.2'

--- a/ruby_event_store/Gemfile
+++ b/ruby_event_store/Gemfile
@@ -3,7 +3,11 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec
 
-eval_gemfile File.expand_path('../support/bundler/Gemfile.shared', __dir__)
+gem 'rake',         '>= 10.0'
+gem 'rspec',        '~> 3.6'
+gem 'mutant-rspec', '~> 0.10.15'
+gem 'mutant',       '~> 0.10.15'
+gem 'mutant-license', source: 'https://oss:7AXfeZdAfCqL1PvHm2nvDJO6Zd9UW8IK@gem.mutant.dev'
 
 gem 'protobuf_nested_struct'
 gem 'google-protobuf', '~> 3.12.2', '>= 3.12.2'

--- a/support/bundler/Gemfile.shared
+++ b/support/bundler/Gemfile.shared
@@ -1,5 +1,0 @@
-gem 'rake',         '>= 10.0'
-gem 'rspec',        '~> 3.6'
-gem 'mutant-rspec', '~> 0.10.15'
-gem 'mutant',       '~> 0.10.15'
-gem 'mutant-license', source: 'https://oss:7AXfeZdAfCqL1PvHm2nvDJO6Zd9UW8IK@gem.mutant.dev'


### PR DESCRIPTION
I'd very much like to use dependabot to bump dev dependencies,
especially with regard to rails and mutant versions used.
