### PR TITLE
Drop unused fill_ids method

### DIFF
--- a/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/event_repository.rb
@@ -88,7 +88,6 @@ module RailsEventStoreActiveRecord
             event_id: event_id,
           }
         end
-        fill_ids(in_stream)
         @stream_klass.import(in_stream) unless stream.global?
       end
       self
@@ -126,10 +125,6 @@ module RailsEventStoreActiveRecord
 
     def optimize_timestamp(valid_at, created_at)
       valid_at unless valid_at.eql?(created_at)
-    end
-
-    # Overwritten in a sub-class
-    def fill_ids(_in_stream)
     end
 
     def start_transaction(&block)

--- a/rails_event_store_active_record/spec/event_repository_spec.rb
+++ b/rails_event_store_active_record/spec/event_repository_spec.rb
@@ -289,43 +289,6 @@ module RailsEventStoreActiveRecord
       end
     end
 
-    class FillInRepository < EventRepository
-      def fill_ids(in_stream)
-        in_stream.each.with_index.map do |is, index|
-          is[:id] = index + 987_654_321
-          is[:id] += 3 if is[:stream] == "whoo"
-        end
-      end
-    end
-
-    specify 'fill_ids in append_to_stream' do
-      repository = FillInRepository.new(serializer: YAML)
-      repository.append_to_stream(
-        [event = RubyEventStore::SRecord.new],
-        RubyEventStore::Stream.new('stream'),
-        RubyEventStore::ExpectedVersion.any
-      )
-
-      expect(EventInStream.find(987_654_321).stream).to eq("stream")
-    end
-
-    specify 'fill_ids in link_to_stream' do
-      repository = FillInRepository.new(serializer: YAML)
-      repository.append_to_stream(
-        [event = RubyEventStore::SRecord.new],
-        RubyEventStore::Stream.new('stream'),
-        RubyEventStore::ExpectedVersion.any
-      )
-      repository.link_to_stream(
-        [event.event_id],
-        RubyEventStore::Stream.new("whoo"),
-        RubyEventStore::ExpectedVersion.any
-      )
-
-      expect(EventInStream.find(987_654_321).stream).to eq("stream")
-      expect(EventInStream.find(987_654_324).stream).to eq("whoo")
-    end
-
     specify 'read in batches forward' do
       events = Array.new(200) { RubyEventStore::SRecord.new }
       repository.append_to_stream(


### PR DESCRIPTION
It has been used bt DRES, but seems to be not there anymore