### PR TITLE
Move setting formatter to RSpec module

### DIFF
--- a/ruby_event_store-rspec/lib/ruby_event_store/rspec.rb
+++ b/ruby_event_store-rspec/lib/ruby_event_store/rspec.rb
@@ -15,7 +15,21 @@ require_relative "rspec/have_applied"
 require_relative "rspec/have_subscribed_to_events"
 require_relative "rspec/publish"
 require_relative "rspec/apply"
+require_relative "rspec/crude_failure_message_formatter"
+require_relative "rspec/step_by_step_failure_message_formatter"
 require_relative "rspec/matchers"
+
+module RubyEventStore
+  module RSpec
+    def self.default_formatter=(new_formatter)
+      @@default_formatter = new_formatter
+    end
+
+    def self.default_formatter
+      @@default_formatter ||= CrudeFailureMessageFormatter
+    end
+  end
+end
 
 ::RSpec.configure do |config|
   config.include ::RubyEventStore::RSpec::Matchers

--- a/ruby_event_store-rspec/lib/ruby_event_store/rspec/crude_failure_message_formatter.rb
+++ b/ruby_event_store-rspec/lib/ruby_event_store/rspec/crude_failure_message_formatter.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module RubyEventStore
+  module RSpec
+    module CrudeFailureMessageFormatter
+      def self.have_published
+        HavePublished::CrudeFailureMessageFormatter
+      end
+    end
+  end
+end

--- a/ruby_event_store-rspec/lib/ruby_event_store/rspec/have_published.rb
+++ b/ruby_event_store-rspec/lib/ruby_event_store/rspec/have_published.rb
@@ -198,17 +198,7 @@ module RubyEventStore
         end
       end
 
-      @@default_formatter = CrudeFailureMessageFormatter
-
-      def self.default_formatter=(new_formatter)
-        @@default_formatter = new_formatter
-      end
-
-      def self.default_formatter
-        @@default_formatter
-      end
-
-      def initialize(mandatory_expected, *optional_expected, differ:, phraser:, failure_message_formatter: @@default_formatter)
+      def initialize(mandatory_expected, *optional_expected, differ:, phraser:, failure_message_formatter: RSpec.default_formatter.have_published)
         @expected  = [mandatory_expected, *optional_expected]
         @matcher   = ::RSpec::Matchers::BuiltIn::Include.new(*expected)
         @phraser   = phraser

--- a/ruby_event_store-rspec/lib/ruby_event_store/rspec/step_by_step_failure_message_formatter.rb
+++ b/ruby_event_store-rspec/lib/ruby_event_store/rspec/step_by_step_failure_message_formatter.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module RubyEventStore
+  module RSpec
+    module StepByStepFailureMessageFormatter
+      def self.have_published
+        HavePublished::StepByStepFailureMessageFormatter
+      end
+    end
+  end
+end

--- a/ruby_event_store-rspec/spec/ruby_event_store/rspec/have_published_spec.rb
+++ b/ruby_event_store-rspec/spec/ruby_event_store/rspec/have_published_spec.rb
@@ -275,8 +275,8 @@ module RubyEventStore
       end
 
       specify do
-        old_formatter = HavePublished.default_formatter
-        HavePublished.default_formatter = HavePublished::StepByStepFailureMessageFormatter
+        old_formatter = RSpec.default_formatter
+        RSpec.default_formatter = RSpec::StepByStepFailureMessageFormatter
         matcher_ = matcher(expected = matchers.an_event(BarEvent))
         matcher_.matches?(event_store)
 
@@ -289,7 +289,7 @@ module RubyEventStore
           be an event BarEvent
         to be published, but there is no event with such type
         EOS
-        HavePublished.default_formatter = old_formatter
+        RSpec.default_formatter = old_formatter
       end
     end
   end


### PR DESCRIPTION
setting configuration on RSpec is better than setting it on the class which is not part of the public API (RSpec::HavePublished)