### PR TITLE
docs(delete): add note for immutability of events

### DIFF
--- a/railseventstore.org/source/docs/v2/delete.html.md
+++ b/railseventstore.org/source/docs/v2/delete.html.md
@@ -8,3 +8,5 @@ You can permanently delete all events from a specific stream. Use this wisely.
 stream_name = "product_1"
 client.delete_stream(stream_name)
 ```
+
+NOTE: All events from the stream remain intact but they are no longer linked to the stream.


### PR DESCRIPTION
I wanted to remove all events and event streams from my test app, so I tried the delete_method. I was confused why it did not delete the events themselves, only the streams. Then I found the note on the source code.