### PR TITLE
Ensure only supported any usage by default

### DIFF
--- a/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
+++ b/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
@@ -33,7 +33,7 @@ module RubyEventStore
       attr_accessor :record
     end
 
-    def initialize(serializer: NULL, ensure_supported_any_usage: false)
+    def initialize(serializer: NULL, ensure_supported_any_usage: true)
       @serializer = serializer
       @streams = Hash.new { |h, k| h[k] = Array.new }
       @mutex   = Mutex.new


### PR DESCRIPTION
Breaks backwards compatibility, so to be merged with RES 3.x.

We may also consider adding some configuration option to turn it off.