### PR TITLE
Only use requires_new when needed

### DIFF
--- a/rails_event_store_active_record/lib/rails_event_store_active_record/pg_linearized_event_repository.rb
+++ b/rails_event_store_active_record/lib/rails_event_store_active_record/pg_linearized_event_repository.rb
@@ -5,8 +5,8 @@ require "activerecord-import"
 module RailsEventStoreActiveRecord
   class PgLinearizedEventRepository < EventRepository
 
-    def start_transaction(&proc)
-      ActiveRecord::Base.transaction(requires_new: true) do
+    def start_transaction(requires_new, &proc)
+      ActiveRecord::Base.transaction(requires_new: requires_new) do
         ActiveRecord::Base
           .connection
           .execute("SELECT pg_advisory_xact_lock(1845240511599988039) as l")


### PR DESCRIPTION
SAVEPOINTs are costly:
https://www.cybertec-postgresql.com/en/subtransactions-and-performance-in-postgresql/
They were added in fc2ba5693 to stop the events with the wrong version being committed
but if no version is specified then they are not needed.

I've not added any specs as I wanted to know your thoughts on this.