### PR TITLE
Browser compatibility with Content Security Policy

### DIFF
--- a/ruby_event_store-browser/elm/src/index.js
+++ b/ruby_event_store-browser/elm/src/index.js
@@ -1,4 +1,8 @@
 require("./style/style.css");
 
-window.RubyEventStore = {};
-window.RubyEventStore.Browser = require("./Main.elm");
+var Browser = require("./Main.elm");
+
+var settings = document.querySelector("meta[name='ruby-event-store-browser-settings']").getAttribute("content");
+console.debug("settings", settings);
+settings = JSON.parse(settings);
+Browser.Elm.Main.init(settings);

--- a/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
+++ b/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
@@ -65,21 +65,13 @@ module RubyEventStore
             <head>
               <title>RubyEventStore::Browser</title>
               <link type="text/css" rel="stylesheet" href="<%= path %>/ruby_event_store_browser.css">
+              <meta name="ruby-event-store-browser-settings" content='<%= browser_settings %>'>
             </head>
             <body>
               <script type="text/javascript" src="<%= path %>/ruby_event_store_browser.js"></script>
-              <script type="text/javascript">
-                RubyEventStore.Browser.Elm.Main.init({
-                  flags: {
-                    rootUrl:    "<%= routing.root_url %>",
-                    apiUrl:     "<%= api_url %>",
-                    resVersion: "<%= RubyEventStore::VERSION %>"
-                  }
-                });
-              </script>
             </body>
           </html>
-        }, locals: { path: settings.root_path || request.script_name, api_url: settings.api_url || routing.api_url }
+        }, locals: { path: settings.root_path || request.script_name }
       end
 
       helpers do
@@ -92,6 +84,16 @@ module RubyEventStore
             settings.host || request.base_url,
             settings.root_path || request.script_name
           )
+        end
+
+        def browser_settings
+          JSON.dump({
+            flags: {
+              rootUrl:    routing.root_url,
+              apiUrl:     settings.api_url || routing.api_url,
+              resVersion: RubyEventStore::VERSION
+            }
+          })
         end
 
         def json(data)

--- a/ruby_event_store-browser/spec/defaults_spec.rb
+++ b/ruby_event_store-browser/spec/defaults_spec.rb
@@ -28,13 +28,13 @@ module RubyEventStore
 
       response = test_client.get "/res"
 
-      expect(response.body).to match %r{apiUrl:\s*"https://example.com/some/custom/api/url"}
+      expect(response.body).to match %r{"apiUrl":\s*"https://example.com/some/custom/api/url"}
     end
 
     it "default #api_url is based on root_path" do
       response = test_client.get "/res"
 
-      expect(response.body).to match %r{apiUrl:\s*"http://railseventstore.org/res/api"}
+      expect(response.body).to match %r{"apiUrl":\s*"http://railseventstore.org/res/api"}
     end
 
     let(:event_store) { RubyEventStore::Client.new(repository: RubyEventStore::InMemoryRepository.new) }


### PR DESCRIPTION
I finally got around to working on a fix for the problem I've described in #1062 and here's what I've come up with.

First of all I added a test to ui tests that serves the browser together with a reasonable CSP header. What's important is that this header does not include a `script-src 'unsafe-inline'` which would be the only way to make the inline script initiating the `Browser` work with CSP. So this test failed before I've implemented the changes.

And the rest is what we've discussed in the issue: I've moved the settings from the inline JS to a `meta` tag and dumped them as JSON. Then the JSON is retrieved in `index.js` and used to initiate the `Browser` there.

I've also removed the code exposing the `Browser` via `window.RubyEventStore.Browser` as @pawelpacana suggested in #1062.