### PR TITLE
Add event_store_locator option to AsyncHandler

### DIFF
--- a/rails_event_store/lib/rails_event_store/async_handler_helpers.rb
+++ b/rails_event_store/lib/rails_event_store/async_handler_helpers.rb
@@ -6,9 +6,10 @@ module RailsEventStore
       with
     end
 
-    def self.with(event_store: Rails.configuration.event_store, serializer: YAML)
+    def self.with(event_store: Rails.configuration.event_store, event_store_locator: nil, serializer: YAML)
       Module.new do
         define_method :perform do |payload|
+          event_store = event_store_locator.call if event_store_locator
           super(event_store.deserialize(serializer: serializer, **payload.symbolize_keys))
         end
       end


### PR DESCRIPTION
Because eager loading of the event store is not suitable to
legacy applications. Howevery current event_store: option will be
removed only at RES 3.0.