### PR TITLE
Fix initialization for ROM

### DIFF
--- a/contrib/ruby_event_store-rom/lib/ruby_event_store/rom.rb
+++ b/contrib/ruby_event_store-rom/lib/ruby_event_store/rom.rb
@@ -31,8 +31,6 @@ module RubyEventStore
         end
       end
 
-      private
-
       def rom_container(adapter_name, database_uri, &block)
         if adapter_name.is_a?(::ROM::Configuration)
           ::ROM.container(adapter_name.tap(&block), &block)

--- a/contrib/ruby_event_store-rom/lib/ruby_event_store/rom/tasks/migration_tasks.rake
+++ b/contrib/ruby_event_store-rom/lib/ruby_event_store/rom/tasks/migration_tasks.rake
@@ -7,7 +7,7 @@ MIGRATIONS_PATH = "db/migrate".freeze
 desc "Setup ROM EventRespository environment"
 task "db:setup" do
   Dir.chdir(Dir.pwd)
-  ROM::SQL::RakeSupport.env = ::RubyEventStore::ROM.configure(:sql).rom_container
+  ROM::SQL::RakeSupport.env = ::RubyEventStore::ROM.rom_container(:sql, ENV['DATABASE_URL'])
 end
 
 desc "Copy RubyEventStore SQL migrations to db/migrate"
@@ -15,7 +15,7 @@ task "db:migrations:copy" => "db:setup" do
   # Optional data type for `data` and `metadata`
   data_type = ENV["DATA_TYPE"]
 
-  Dir[File.join(File.dirname(__FILE__), "../../../../../../", MIGRATIONS_PATH, "/*.rb")].each do |input|
+  Dir[File.join(File.dirname(__FILE__), "../../../../", MIGRATIONS_PATH, "/*.rb")].each do |input|
     contents = File.read(input)
     name     = File.basename(input, ".*").sub(/\d+_/, "")
 
@@ -27,7 +27,7 @@ task "db:migrations:copy" => "db:setup" do
       name    += "_with_#{data_type}"
     end
 
-    output = ROM::SQL::RakeSupport.create_migration(name, path: File.join(Dir.pwd, MIGRATIONS_PATH))
+    output = ROM::SQL::RakeSupport.create_migration(name)
 
     File.write output, contents
 

--- a/railseventstore.org/source/docs/v2/without_rails.html.md
+++ b/railseventstore.org/source/docs/v2/without_rails.html.md
@@ -39,7 +39,7 @@ Add the tasks to your `Rakefile` to import them into your project:
 
 ```ruby
 # In your project Rakefile
-require 'ruby_event_store/rom/adapters/sql/rake_task'
+require 'ruby_event_store/rom/rake_task'
 ```
 
 Then run Rake tasks to get your database setup:


### PR DESCRIPTION
Currently initialization for ROM does not work because of number of things:

* `::RubyEventStore::ROM.configure` having been removed - I replaced it with a call to `::RubyEventStore::ROM.rom_container`, which I made public, but maybe a public proxy `.configure` would be better
* Wrong source migration path
* `ROM::SQL::RakeSupport.create_migration` trying to create output migration in a really weird path (in Ruby 3): 
```
rake aborted!
Errno::ENOENT: No such file or directory @ rb_sysopen - db/migrate/{:path=>"/Users/katafrakt/dev/palaver/db/migrate"}_create_ruby_event_store_tables.rb
/Users/katafrakt/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/rom-sql-3.5.0/lib/rom/sql/migration/migrator.rb:54:in `write'
```
* Non-existing require path in instructions

This PR fixes all four, making it possible to create migrations for ROM setup.