### PR TITLE
chore: resolve sidekiq json-unsafe warning

### DIFF
--- a/contrib/ruby_event_store-sidekiq_scheduler/lib/ruby_event_store/sidekiq_scheduler.rb
+++ b/contrib/ruby_event_store-sidekiq_scheduler/lib/ruby_event_store/sidekiq_scheduler.rb
@@ -7,7 +7,7 @@ module RubyEventStore
     end
 
     def call(klass, record)
-      klass.perform_async(record.serialize(serializer).to_h)
+      klass.perform_async(record.serialize(serializer).to_h.transform_keys!(&:to_s))
     end
 
     def verify(subscriber)


### PR DESCRIPTION
Sidekiq 6.4 has started to log warnings
(https://github.com/mperham/sidekiq/pull/5071) if the job arguments are
not strictly JSON-safe i.e. serializing to JSON and deserializing from
JSON yield consistent outputs. To what it means, we cannot use a hash
with symbol keys since doing the JSON rountrip will change them all to
string keys.

This fix will transform the hash argument with symbol keys to string
keys so Sidekiq won't complain it (and break it starting version 7.0).

#### Before

<img width="946" alt="image" src="https://user-images.githubusercontent.com/1403932/153738131-ede95975-65e7-4aba-80e5-12a2b10dc8e3.png">


#### After

<img width="829" alt="image" src="https://user-images.githubusercontent.com/1403932/153738123-7cf97c99-e2a9-43c1-b14b-6b5e8c25e11b.png">
