### PR TITLE
Additional value mapping (Hanami 2 integration)

### DIFF
--- a/contrib/ruby_event_store-rom/Gemfile
+++ b/contrib/ruby_event_store-rom/Gemfile
@@ -7,4 +7,7 @@ gem "mysql2", ">= 0.5.3"
 gem "pg", ">= 1.2.2"
 gem "ruby_event_store", path: "../../ruby_event_store"
 gem "sqlite3", "1.4.2"
-gem "activesupport"
+
+group :test do
+  gem "activesupport"
+end

--- a/contrib/ruby_event_store-rom/lib/ruby_event_store/rom/changesets/create_events.rb
+++ b/contrib/ruby_event_store-rom/lib/ruby_event_store/rom/changesets/create_events.rb
@@ -11,6 +11,8 @@ module RubyEventStore
           rename_keys timestamp: :created_at
           map_value   :created_at, ->(time) { Time.iso8601(time).localtime }
           map_value   :valid_at,   ->(time) { Time.iso8601(time).localtime }
+          map_value   :data, ->(value) { value.class.name == "Hash" ? value.to_json : value }
+          map_value   :metadata, ->(value) { value.class.name == "Hash" ? value.to_json : value }
           accept_keys %i[event_id data metadata event_type created_at valid_at]
         end
 


### PR DESCRIPTION
# Overview

Tweaks for Hanami 2 integration.

# Background

During configuring of Hanami 2 project to work with RES-ROM, I have encountered sequel problem. Command below accepts named arguments, so there is no way to call the command handler directly passing invalid parameters to it.

```ruby
cmd = Crm::RegisterCustomer.new(customer_id: customer_id, name: name)
command_bus.(cmd)
```

However, calling command bus with this command  returns an Sequel Error: Column not found (details below).

I have found that `CreateEvents` changeset receives Hash as a value for JSONB columns (data and metadata) in case of Hanami 2 integration, and String in Rails or tests.

To solve it, I added two additional MAP_VALUE rules.

```
module RubyEventStore
  module ROM
    module Changesets
      class CreateEvents < ::ROM::Changeset::Create
        relation :events

        map(&:to_h)
        map do
          # ...
          map_value   :data, ->(value) { value.class.name == "Hash" ? value.to_json : value }
          map_value   :metadata, ->(value) { value.class.name == "Hash" ? value.to_json : value }
          # ...
        end

        def commit
          relation.multi_insert(to_a)
        end
      end
    end
  end
end
```

It sems to solve the problem, but I am not happy with this as I believe, I did not find the source of the problem. I expect that some kind of value transformation was not triggered.

### Summary

I keep this PR as a monkey patch for now, until the proper fix is found, to make Hanami 2 integration possible. Help welcome!
