### PR TITLE
Support ActiveJob adapters with pre-deserialized events and NULL serializer

### DIFF
--- a/rails_event_store/lib/rails_event_store/async_handler_helpers.rb
+++ b/rails_event_store/lib/rails_event_store/async_handler_helpers.rb
@@ -2,21 +2,32 @@
 
 module RailsEventStore
   module AsyncHandler
-    def self.with_defaults
-      with
-    end
+    class << self
+      def with_defaults
+        with
+      end
 
-    def self.with(event_store: Rails.configuration.event_store, event_store_locator: nil, serializer: RubyEventStore::Serializers::YAML)
-      Module.new do
-        define_method :perform do |payload|
-          event_store = event_store_locator.call if event_store_locator
-          super(event_store.deserialize(serializer: serializer, **payload.symbolize_keys))
+      def with(event_store: Rails.configuration.event_store, event_store_locator: nil, serializer: RubyEventStore::Serializers::YAML)
+        Module.new do
+          define_method :perform do |payload|
+            event_store = event_store_locator.call if event_store_locator
+            record = AsyncHandler.event_from_payload(payload, event_store, serializer)
+            super(record)
+          end
         end
       end
-    end
 
-    def self.prepended(host_class)
-      host_class.prepend with_defaults
+      def prepended(host_class)
+        host_class.prepend with_defaults
+      end
+
+      # @return [Event] an event as deserialized from the payload
+      def event_from_payload(payload, event_store, serializer)
+        return payload if payload.kind_of?(RailsEventStore::Event)
+
+        payload_hash = payload.to_h.symbolize_keys
+        event_store.deserialize(serializer: serializer, **payload_hash)
+      end
     end
   end
 


### PR DESCRIPTION
Depending on the configuration of the ActiveJob backend and the serializer used - i.e. the `NULL` serializer -, it is possible that
the argument to `perform` is already a full `Event` record. In that scenario, it can be used as-is without prior processing.

Closes #1334, even if the approach is different from how I understood the problem at first glance. But when taking a closer look at `Record`, `DeserializedRecord` and the transformation pipeline I understood better the way things are related and decided on a more straightforward solution and just detecting that specific situation.


