### PR TITLE
Cleanup only up to limit

### DIFF
--- a/contrib/ruby_event_store-outbox/lib/ruby_event_store/outbox/cleanup_strategies/clean_old_enqueued.rb
+++ b/contrib/ruby_event_store-outbox/lib/ruby_event_store/outbox/cleanup_strategies/clean_old_enqueued.rb
@@ -2,17 +2,18 @@ module RubyEventStore
   module Outbox
     module CleanupStrategies
       class CleanOldEnqueued
-        def initialize(repository, duration)
+        def initialize(repository, duration, limit)
           @repository = repository
           @duration = duration
+          @limit = limit
         end
 
         def call(fetch_specification)
-          repository.delete_enqueued_older_than(fetch_specification, duration)
+          repository.delete_enqueued_older_than(fetch_specification, duration, limit)
         end
 
         private
-        attr_reader :repository, :duration
+        attr_reader :repository, :duration, :limit
       end
     end
   end

--- a/contrib/ruby_event_store-outbox/lib/ruby_event_store/outbox/cli.rb
+++ b/contrib/ruby_event_store-outbox/lib/ruby_event_store/outbox/cli.rb
@@ -15,6 +15,7 @@ module RubyEventStore
         batch_size: 100,
         metrics_url: nil,
         cleanup_strategy: :none,
+        cleanup_limit: :all,
         sleep_on_empty: 0.5
       }
       Options = Struct.new(*DEFAULTS.keys)
@@ -55,6 +56,10 @@ module RubyEventStore
 
             option_parser.on("--cleanup=STRATEGY", "A strategy for cleaning old records. One of: none or iso8601 duration format how old enqueued records should be removed. Default: none") do |cleanup_strategy|
               options.cleanup_strategy = cleanup_strategy
+            end
+
+            option_parser.on("--cleanup-limit=LIMIT", "Amount of records removed in single cleanup run. One of: all or number of records that should be removed. Default: all") do |cleanup_limit|
+              options.cleanup_limit = cleanup_limit
             end
 
             option_parser.on("--sleep-on-empty=SLEEP_TIME", Float, "How long to sleep before next check when there was nothing to do. Default: 0.5") do |sleep_on_empty|

--- a/contrib/ruby_event_store-outbox/lib/ruby_event_store/outbox/consumer.rb
+++ b/contrib/ruby_event_store-outbox/lib/ruby_event_store/outbox/consumer.rb
@@ -21,6 +21,7 @@ module RubyEventStore
           database_url:,
           redis_url:,
           cleanup:,
+          cleanup_limit:,
           sleep_on_empty:
         )
           @split_keys = split_keys
@@ -29,6 +30,7 @@ module RubyEventStore
           @database_url = database_url
           @redis_url = redis_url
           @cleanup = cleanup
+          @cleanup_limit = cleanup_limit
           @sleep_on_empty = sleep_on_empty
           freeze
         end
@@ -41,11 +43,12 @@ module RubyEventStore
             database_url: overriden_options.fetch(:database_url, database_url),
             redis_url: overriden_options.fetch(:redis_url, redis_url),
             cleanup: overriden_options.fetch(:cleanup, cleanup),
+            cleanup_limit: overriden_options.fetch(:cleanup_limit, cleanup_limit),
             sleep_on_empty: overriden_options.fetch(:sleep_on_empty, sleep_on_empty)
           )
         end
 
-        attr_reader :split_keys, :message_format, :batch_size, :database_url, :redis_url, :cleanup, :sleep_on_empty
+        attr_reader :split_keys, :message_format, :batch_size, :database_url, :redis_url, :cleanup, :cleanup_limit, :sleep_on_empty
       end
 
       def initialize(consumer_uuid, configuration, clock: Time, logger:, metrics:)
@@ -68,7 +71,7 @@ module RubyEventStore
         when :none
           CleanupStrategies::None.new
         else
-          CleanupStrategies::CleanOldEnqueued.new(repository, ActiveSupport::Duration.parse(configuration.cleanup))
+          CleanupStrategies::CleanOldEnqueued.new(repository, ActiveSupport::Duration.parse(configuration.cleanup), configuration.cleanup_limit)
         end
       end
 

--- a/contrib/ruby_event_store-outbox/lib/ruby_event_store/outbox/repository.rb
+++ b/contrib/ruby_event_store-outbox/lib/ruby_event_store/outbox/repository.rb
@@ -142,11 +142,12 @@ module RubyEventStore
         record.update_column(:enqueued_at, now)
       end
 
-      def delete_enqueued_older_than(fetch_specification, duration)
-        Record
+      def delete_enqueued_older_than(fetch_specification, duration, limit)
+        scope = Record
           .for_fetch_specification(fetch_specification)
           .where("enqueued_at < ?", duration.ago)
-          .delete_all
+        scope = scope.limit(limit) unless limit == :all
+        scope.delete_all
         :ok
       rescue ActiveRecord::Deadlocked
         :deadlocked

--- a/contrib/ruby_event_store-outbox/spec/sidekiq_correctness_spec.rb
+++ b/contrib/ruby_event_store-outbox/spec/sidekiq_correctness_spec.rb
@@ -9,7 +9,7 @@ module RubyEventStore
       let(:database_url) { ENV["DATABASE_URL"] }
       let(:redis) { Redis.new(url: redis_url) }
       let(:test_logger) { Logger.new(StringIO.new) }
-      let(:default_configuration) { Consumer::Configuration.new(database_url: database_url, redis_url: redis_url, split_keys: ["default"], message_format: SIDEKIQ5_FORMAT, batch_size: 100, cleanup: :none, sleep_on_empty: 1) }
+      let(:default_configuration) { Consumer::Configuration.new(database_url: database_url, redis_url: redis_url, split_keys: ["default"], message_format: SIDEKIQ5_FORMAT, batch_size: 100, cleanup: :none, cleanup_limit: :all, sleep_on_empty: 1) }
       let(:metrics) { Metrics::Null.new }
 
       before(:each) do |example|


### PR DESCRIPTION
Sometimes cleanup of old entries could be time consuming because of numbers of records already stored in database. The limit (if set) will allow to make sure cleanup operation will finish in reasonable amount of time, leaving records over the limit for the next cleanup run.