### PR TITLE
Browser — drop sinatra dependency

### DIFF
--- a/contrib/distributed_rails_event_store/dres_rails/Gemfile.lock
+++ b/contrib/distributed_rails_event_store/dres_rails/Gemfile.lock
@@ -28,8 +28,8 @@ PATH
   remote: ../../../ruby_event_store-browser
   specs:
     ruby_event_store-browser (2.4.1)
+      rack
       ruby_event_store (= 2.4.1)
-      sinatra
 
 PATH
   remote: ../../../ruby_event_store
@@ -153,8 +153,6 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     minitest (5.15.0)
-    mustermann (1.1.1)
-      ruby2_keywords (~> 0.0.1)
     mutant (0.11.4)
       diff-lcs (~> 1.3)
       parser (~> 3.1.0)
@@ -194,8 +192,6 @@ GEM
     public_suffix (4.0.7)
     racc (1.6.0)
     rack (2.2.3.1)
-    rack-protection (2.2.0)
-      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (7.0.3)
@@ -247,16 +243,9 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.11.0)
-    ruby2_keywords (0.0.5)
-    sinatra (2.2.0)
-      mustermann (~> 1.0)
-      rack (~> 2.2)
-      rack-protection (= 2.2.0)
-      tilt (~> 2.0)
     sorbet-runtime (0.5.10032)
     strscan (3.0.3)
     thor (1.2.1)
-    tilt (2.0.10)
     timecop (0.9.5)
     timeout (0.3.0)
     tzinfo (2.0.4)

--- a/contrib/ruby_event_store-protobuf/Gemfile.lock
+++ b/contrib/ruby_event_store-protobuf/Gemfile.lock
@@ -28,8 +28,8 @@ PATH
   remote: ../../ruby_event_store-browser
   specs:
     ruby_event_store-browser (2.4.1)
+      rack
       ruby_event_store (= 2.4.1)
-      sinatra
 
 PATH
   remote: ../../ruby_event_store
@@ -140,8 +140,6 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
     minitest (5.15.0)
-    mustermann (1.1.1)
-      ruby2_keywords (~> 0.0.1)
     mutant (0.11.4)
       diff-lcs (~> 1.3)
       parser (~> 3.1.0)
@@ -178,8 +176,6 @@ GEM
       google-protobuf
     racc (1.6.0)
     rack (2.2.3.1)
-    rack-protection (2.2.0)
-      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (7.0.3)
@@ -223,16 +219,9 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
-    ruby2_keywords (0.0.5)
-    sinatra (2.2.0)
-      mustermann (~> 1.0)
-      rack (~> 2.2)
-      rack-protection (= 2.2.0)
-      tilt (~> 2.0)
     sorbet-runtime (0.5.10032)
     strscan (3.0.3)
     thor (1.2.1)
-    tilt (2.0.10)
     timeout (0.3.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)

--- a/contrib/ruby_event_store-protobuf/Gemfile.rails_6_0.lock
+++ b/contrib/ruby_event_store-protobuf/Gemfile.rails_6_0.lock
@@ -28,8 +28,8 @@ PATH
   remote: ../../ruby_event_store-browser
   specs:
     ruby_event_store-browser (2.4.1)
+      rack
       ruby_event_store (= 2.4.1)
-      sinatra
 
 PATH
   remote: ../../ruby_event_store
@@ -129,8 +129,6 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
     minitest (5.15.0)
-    mustermann (1.1.1)
-      ruby2_keywords (~> 0.0.1)
     mutant (0.11.4)
       diff-lcs (~> 1.3)
       parser (~> 3.1.0)
@@ -153,8 +151,6 @@ GEM
       google-protobuf
     racc (1.6.0)
     rack (2.2.3.1)
-    rack-protection (2.2.0)
-      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.0.5)
@@ -198,12 +194,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
-    ruby2_keywords (0.0.5)
-    sinatra (2.2.0)
-      mustermann (~> 1.0)
-      rack (~> 2.2)
-      rack-protection (= 2.2.0)
-      tilt (~> 2.0)
     sorbet-runtime (0.5.10032)
     sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
@@ -214,7 +204,6 @@ GEM
       sprockets (>= 3.0.0)
     thor (1.2.1)
     thread_safe (0.3.6)
-    tilt (2.0.10)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
     unparser (0.6.5)

--- a/contrib/ruby_event_store-protobuf/Gemfile.rails_6_1.lock
+++ b/contrib/ruby_event_store-protobuf/Gemfile.rails_6_1.lock
@@ -28,8 +28,8 @@ PATH
   remote: ../../ruby_event_store-browser
   specs:
     ruby_event_store-browser (2.4.1)
+      rack
       ruby_event_store (= 2.4.1)
-      sinatra
 
 PATH
   remote: ../../ruby_event_store
@@ -133,8 +133,6 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
     minitest (5.15.0)
-    mustermann (1.1.1)
-      ruby2_keywords (~> 0.0.1)
     mutant (0.11.4)
       diff-lcs (~> 1.3)
       parser (~> 3.1.0)
@@ -157,8 +155,6 @@ GEM
       google-protobuf
     racc (1.6.0)
     rack (2.2.3.1)
-    rack-protection (2.2.0)
-      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.1.6)
@@ -202,12 +198,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
-    ruby2_keywords (0.0.5)
-    sinatra (2.2.0)
-      mustermann (~> 1.0)
-      rack (~> 2.2)
-      rack-protection (= 2.2.0)
-      tilt (~> 2.0)
     sorbet-runtime (0.5.10032)
     sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
@@ -217,7 +207,6 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     thor (1.2.1)
-    tilt (2.0.10)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unparser (0.6.5)

--- a/rails_event_store/Gemfile.lock
+++ b/rails_event_store/Gemfile.lock
@@ -15,8 +15,8 @@ PATH
   remote: ../ruby_event_store-browser
   specs:
     ruby_event_store-browser (2.4.1)
+      rack
       ruby_event_store (= 2.4.1)
-      sinatra
 
 PATH
   remote: ../ruby_event_store
@@ -134,8 +134,6 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
     minitest (5.15.0)
-    mustermann (1.1.1)
-      ruby2_keywords (~> 0.0.1)
     mutant (0.11.4)
       diff-lcs (~> 1.3)
       parser (~> 3.1.0)
@@ -170,8 +168,6 @@ GEM
       ast (~> 2.4.1)
     racc (1.6.0)
     rack (2.2.3.1)
-    rack-protection (2.2.0)
-      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (7.0.3)
@@ -216,21 +212,14 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
-    ruby2_keywords (0.0.5)
     sidekiq (6.4.2)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
-    sinatra (2.2.0)
-      mustermann (~> 1.0)
-      rack (~> 2.2)
-      rack-protection (= 2.2.0)
-      tilt (~> 2.0)
     sorbet-runtime (0.5.10032)
     sqlite3 (1.4.2)
     strscan (3.0.3)
     thor (1.2.1)
-    tilt (2.0.10)
     timeout (0.3.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)

--- a/rails_event_store/Gemfile.rails_6_0.lock
+++ b/rails_event_store/Gemfile.rails_6_0.lock
@@ -15,8 +15,8 @@ PATH
   remote: ../ruby_event_store-browser
   specs:
     ruby_event_store-browser (2.4.1)
+      rack
       ruby_event_store (= 2.4.1)
-      sinatra
 
 PATH
   remote: ../ruby_event_store
@@ -123,8 +123,6 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
     minitest (5.15.0)
-    mustermann (1.1.1)
-      ruby2_keywords (~> 0.0.1)
     mutant (0.11.4)
       diff-lcs (~> 1.3)
       parser (~> 3.1.0)
@@ -145,8 +143,6 @@ GEM
       ast (~> 2.4.1)
     racc (1.6.0)
     rack (2.2.3.1)
-    rack-protection (2.2.0)
-      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.0.5)
@@ -191,16 +187,10 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
-    ruby2_keywords (0.0.5)
     sidekiq (6.4.2)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
-    sinatra (2.2.0)
-      mustermann (~> 1.0)
-      rack (~> 2.2)
-      rack-protection (= 2.2.0)
-      tilt (~> 2.0)
     sorbet-runtime (0.5.10032)
     sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
@@ -212,7 +202,6 @@ GEM
     sqlite3 (1.4.2)
     thor (1.2.1)
     thread_safe (0.3.6)
-    tilt (2.0.10)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
     unparser (0.6.5)

--- a/rails_event_store/Gemfile.rails_6_1.lock
+++ b/rails_event_store/Gemfile.rails_6_1.lock
@@ -15,8 +15,8 @@ PATH
   remote: ../ruby_event_store-browser
   specs:
     ruby_event_store-browser (2.4.1)
+      rack
       ruby_event_store (= 2.4.1)
-      sinatra
 
 PATH
   remote: ../ruby_event_store
@@ -127,8 +127,6 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
     minitest (5.15.0)
-    mustermann (1.1.1)
-      ruby2_keywords (~> 0.0.1)
     mutant (0.11.4)
       diff-lcs (~> 1.3)
       parser (~> 3.1.0)
@@ -149,8 +147,6 @@ GEM
       ast (~> 2.4.1)
     racc (1.6.0)
     rack (2.2.3.1)
-    rack-protection (2.2.0)
-      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.1.6)
@@ -195,16 +191,10 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
-    ruby2_keywords (0.0.5)
     sidekiq (6.4.2)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
-    sinatra (2.2.0)
-      mustermann (~> 1.0)
-      rack (~> 2.2)
-      rack-protection (= 2.2.0)
-      tilt (~> 2.0)
     sorbet-runtime (0.5.10032)
     sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
@@ -215,7 +205,6 @@ GEM
       sprockets (>= 3.0.0)
     sqlite3 (1.4.2)
     thor (1.2.1)
-    tilt (2.0.10)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unparser (0.6.5)

--- a/rails_event_store/spec/dummy_6_0/Gemfile.lock
+++ b/rails_event_store/spec/dummy_6_0/Gemfile.lock
@@ -15,8 +15,8 @@ PATH
   remote: ../../../ruby_event_store-browser
   specs:
     ruby_event_store-browser (2.4.1)
+      rack
       ruby_event_store (= 2.4.1)
-      sinatra
 
 PATH
   remote: ../../../ruby_event_store
@@ -119,16 +119,12 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
     minitest (5.15.0)
-    mustermann (1.1.1)
-      ruby2_keywords (~> 0.0.1)
     nio4r (2.5.8)
     nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     racc (1.6.0)
     rack (2.2.3.1)
-    rack-protection (2.2.0)
-      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.1.6)
@@ -158,12 +154,6 @@ GEM
       rake (>= 12.2)
       thor (~> 1.0)
     rake (13.0.6)
-    ruby2_keywords (0.0.5)
-    sinatra (2.2.0)
-      mustermann (~> 1.0)
-      rack (~> 2.2)
-      rack-protection (= 2.2.0)
-      tilt (~> 2.0)
     sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -172,7 +162,6 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     thor (1.2.1)
-    tilt (2.0.10)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     websocket-driver (0.7.5)

--- a/rails_event_store/spec/dummy_6_1/Gemfile.lock
+++ b/rails_event_store/spec/dummy_6_1/Gemfile.lock
@@ -15,8 +15,8 @@ PATH
   remote: ../../../ruby_event_store-browser
   specs:
     ruby_event_store-browser (2.4.1)
+      rack
       ruby_event_store (= 2.4.1)
-      sinatra
 
 PATH
   remote: ../../../ruby_event_store
@@ -119,16 +119,12 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
     minitest (5.15.0)
-    mustermann (1.1.1)
-      ruby2_keywords (~> 0.0.1)
     nio4r (2.5.8)
     nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     racc (1.6.0)
     rack (2.2.3.1)
-    rack-protection (2.2.0)
-      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.1.6)
@@ -158,12 +154,6 @@ GEM
       rake (>= 12.2)
       thor (~> 1.0)
     rake (13.0.6)
-    ruby2_keywords (0.0.5)
-    sinatra (2.2.0)
-      mustermann (~> 1.0)
-      rack (~> 2.2)
-      rack-protection (= 2.2.0)
-      tilt (~> 2.0)
     sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -172,7 +162,6 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     thor (1.2.1)
-    tilt (2.0.10)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     websocket-driver (0.7.5)

--- a/rails_event_store/spec/dummy_7_0/Gemfile.lock
+++ b/rails_event_store/spec/dummy_7_0/Gemfile.lock
@@ -15,8 +15,8 @@ PATH
   remote: ../../../ruby_event_store-browser
   specs:
     ruby_event_store-browser (2.4.1)
+      rack
       ruby_event_store (= 2.4.1)
-      sinatra
 
 PATH
   remote: ../../../ruby_event_store
@@ -126,8 +126,6 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
     minitest (5.15.0)
-    mustermann (1.1.1)
-      ruby2_keywords (~> 0.0.1)
     net-imap (0.2.3)
       digest
       net-protocol
@@ -148,8 +146,6 @@ GEM
       racc (~> 1.4)
     racc (1.6.0)
     rack (2.2.3.1)
-    rack-protection (2.2.0)
-      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (7.0.3)
@@ -179,15 +175,8 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rake (13.0.6)
-    ruby2_keywords (0.0.5)
-    sinatra (2.2.0)
-      mustermann (~> 1.0)
-      rack (~> 2.2)
-      rack-protection (= 2.2.0)
-      tilt (~> 2.0)
     strscan (3.0.3)
     thor (1.2.1)
-    tilt (2.0.10)
     timeout (0.3.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)

--- a/ruby_event_store-browser/Gemfile.lock
+++ b/ruby_event_store-browser/Gemfile.lock
@@ -8,8 +8,8 @@ PATH
   remote: .
   specs:
     ruby_event_store-browser (2.4.1)
+      rack
       ruby_event_store (= 2.4.1)
-      sinatra
 
 GEM
   remote: https://oss:7AXfeZdAfCqL1PvHm2nvDJO6Zd9UW8IK@gem.mutant.dev/
@@ -41,8 +41,6 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
     minitest (5.15.0)
-    mustermann (1.1.1)
-      ruby2_keywords (~> 0.0.1)
     mutant (0.11.4)
       diff-lcs (~> 1.3)
       parser (~> 3.1.0)
@@ -63,8 +61,6 @@ GEM
     public_suffix (4.0.7)
     racc (1.6.0)
     rack (2.2.3.1)
-    rack-protection (2.2.0)
-      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rake (13.0.6)
@@ -82,18 +78,11 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
-    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sinatra (2.2.0)
-      mustermann (~> 1.0)
-      rack (~> 2.2)
-      rack-protection (= 2.2.0)
-      tilt (~> 2.0)
     sorbet-runtime (0.5.10032)
-    tilt (2.0.10)
     unparser (0.6.5)
       diff-lcs (~> 1.3)
       parser (>= 3.1.0)

--- a/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
+++ b/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
@@ -63,8 +63,7 @@ module RubyEventStore
                  page: request.params["page"]
                )
         in "GET", %r{/(events/.*|streams/.*)?}
-          render_html(
-            ERB.new(<<~HTML).result_with_hash(path: routing.root_path, browser_settings: browser_settings(routing))
+          erb <<~HTML, path: routing.root_path, browser_settings: browser_settings(routing)
               <!DOCTYPE html>
               <html>
                 <head>
@@ -77,7 +76,6 @@ module RubyEventStore
                 </body>
               </html>
           HTML
-          )
         else
           not_found
         end
@@ -97,8 +95,8 @@ module RubyEventStore
         [200, { "Content-Type" => "application/vnd.api+json" }, [JSON.dump(body.to_h)]]
       end
 
-      def render_html(html)
-        [200, { "Content-Type" => "text/html;charset=utf-8" }, [html]]
+      def erb(template, **locals)
+        [200, { "Content-Type" => "text/html;charset=utf-8" }, [ERB.new(template).result_with_hash(locals)]]
       end
 
       def browser_settings(routing)

--- a/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
+++ b/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
@@ -34,7 +34,7 @@ module RubyEventStore
         private
 
         def regexp
-          %r/\A#{pattern.gsub(NAMED_SEGMENTS_PATTERN, '/\1(?<\2>[^$/]+)')}\Z/
+          /\A#{pattern.gsub(NAMED_SEGMENTS_PATTERN, '/\1(?<\2>[^$/]+)')}\Z/
         end
 
         attr_reader :request_method, :pattern, :handler
@@ -133,21 +133,14 @@ module RubyEventStore
           "/api/events/:event_id",
           ->(params) { json Event.new(event_store: event_store, event_id: params["event_id"]) }
         )
-        router.add_route(
-          "GET",
-          "/",
-          ->(*) { erb template, path: routing.root_path, browser_settings: browser_settings(routing) }
-        )
-        router.add_route(
-          "GET",
-          "/events/:event_id",
-          ->(*) { erb template, path: routing.root_path, browser_settings: browser_settings(routing) }
-        )
-        router.add_route(
-          "GET",
-          "/streams/:stream_name",
-          ->(*) { erb template, path: routing.root_path, browser_settings: browser_settings(routing) }
-        )
+
+        %w[/ /events/:event_id /streams/:stream_name].each do |starting_route|
+          router.add_route(
+            "GET",
+            starting_route,
+            ->(*) { erb template, path: routing.root_path, browser_settings: browser_settings(routing) }
+          )
+        end
         router.handle(request)
       rescue RubyEventStore::EventNotFound, Router::NoMatch
         not_found

--- a/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
+++ b/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
@@ -47,23 +47,23 @@ module RubyEventStore
         event_store = event_store_locator.call
 
         case [request.request_method, request.path]
-        in "GET", %r{/api/events/([^/]+)}
+        in "GET", %r{/api/events/([^/]+)$}
           render_json_api(Event.new(event_store: event_store, event_id: URI.decode_www_form_component($1)))
-        in "GET", %r{/api/streams/([^/]+)/relationships/events}
+        in "GET", %r{/api/streams/([^/]+)$}
+          render_json_api(
+            GetStream.new(
+              stream_name: URI.decode_www_form_component($1),
+              routing: routing,
+              related_streams_query: @related_streams_query
+            )
+          )
+        in "GET", %r{/api/streams/([^/]+)/relationships/events$}
           render_json_api(
             GetEventsFromStream.new(
               event_store: event_store,
               routing: routing,
               stream_name: URI.decode_www_form_component($1),
               page: request.params["page"]
-            )
-          )
-        in "GET", %r{/api/streams/([^/]+)}
-          render_json_api(
-            GetStream.new(
-              stream_name: URI.decode_www_form_component($1),
-              routing: routing,
-              related_streams_query: @related_streams_query
             )
           )
         in "GET", %r{/(events/.*|streams/.*)?}

--- a/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
+++ b/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
@@ -47,9 +47,9 @@ module RubyEventStore
         event_store = event_store_locator.call
 
         case [request.request_method, request.path]
-        in "GET", %r{/api/events/(.+)}
+        in "GET", %r{/api/events/([^/]+)}
           render_json_api(Event.new(event_store: event_store, event_id: URI.decode_www_form_component($1)))
-        in "GET", %r{/api/streams/(.+)/relationships/events}
+        in "GET", %r{/api/streams/([^/]+)/relationships/events}
           render_json_api(
             GetEventsFromStream.new(
               event_store: event_store,
@@ -58,7 +58,7 @@ module RubyEventStore
               page: request.params["page"]
             )
           )
-        in "GET", %r{/api/streams/(.+)}
+        in "GET", %r{/api/streams/([^/]+)}
           render_json_api(
             GetStream.new(
               stream_name: URI.decode_www_form_component($1),

--- a/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
+++ b/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
@@ -83,17 +83,17 @@ module RubyEventStore
           HTML
           )
         else
-          render_404
+          not_found
         end
       rescue RubyEventStore::EventNotFound
-        render_404
+        not_found
       end
 
       private
 
       attr_reader :event_store_locator, :related_streams_query, :host, :root_path, :api_url
 
-      def render_404
+      def not_found
         [404, {}, []]
       end
 

--- a/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
+++ b/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
@@ -48,24 +48,20 @@ module RubyEventStore
 
         case [request.request_method, request.path]
         in "GET", %r{/api/events/([^/]+)$}
-          json(Event.new(event_store: event_store, event_id: URI.decode_www_form_component($1)))
+          json Event.new(event_store: event_store, event_id: URI.decode_www_form_component($1))
         in "GET", %r{/api/streams/([^/]+)$}
-          json(
-            GetStream.new(
-              stream_name: URI.decode_www_form_component($1),
-              routing: routing,
-              related_streams_query: @related_streams_query
-            )
-          )
+          json GetStream.new(
+                 stream_name: URI.decode_www_form_component($1),
+                 routing: routing,
+                 related_streams_query: @related_streams_query
+               )
         in "GET", %r{/api/streams/([^/]+)/relationships/events$}
-          json(
-            GetEventsFromStream.new(
-              event_store: event_store,
-              routing: routing,
-              stream_name: URI.decode_www_form_component($1),
-              page: request.params["page"]
-            )
-          )
+          json GetEventsFromStream.new(
+                 event_store: event_store,
+                 routing: routing,
+                 stream_name: URI.decode_www_form_component($1),
+                 page: request.params["page"]
+               )
         in "GET", %r{/(events/.*|streams/.*)?}
           render_html(
             ERB.new(<<~HTML).result_with_hash(path: routing.root_path, browser_settings: browser_settings(routing))

--- a/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
+++ b/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
@@ -140,12 +140,12 @@ module RubyEventStore
         )
         router.add_route(
           "GET",
-          "/events/:whatever",
+          "/events/:event_id",
           ->(*) { erb template, path: routing.root_path, browser_settings: browser_settings(routing) }
         )
         router.add_route(
           "GET",
-          "/streams/:whatever",
+          "/streams/:stream_name",
           ->(*) { erb template, path: routing.root_path, browser_settings: browser_settings(routing) }
         )
         router.handle(request)

--- a/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
+++ b/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
@@ -46,23 +46,23 @@ module RubyEventStore
         routing = Routing.new(host || request.base_url, root_path || request.script_name)
         event_store = event_store_locator.call
 
-        case [request.request_method, request.path]
-        in "GET", %r{/api/events/([^/]+)$}
+        case [request.request_method, File.join("/", request.path_info)]
+        in "GET", %r{\A/api/events/([^/]+)\Z}
           json Event.new(event_store: event_store, event_id: URI.decode_www_form_component($1))
-        in "GET", %r{/api/streams/([^/]+)$}
+        in "GET", %r{\A/api/streams/([^/]+)\Z}
           json GetStream.new(
                  stream_name: URI.decode_www_form_component($1),
                  routing: routing,
                  related_streams_query: @related_streams_query
                )
-        in "GET", %r{/api/streams/([^/]+)/relationships/events$}
+        in "GET", %r{\A/api/streams/([^/]+)/relationships/events\Z}
           json GetEventsFromStream.new(
                  event_store: event_store,
                  routing: routing,
                  stream_name: URI.decode_www_form_component($1),
                  page: request.params["page"]
                )
-        in "GET", %r{/(events/.*|streams/.*)?}
+        in "GET", %r{\A/(events/.*|streams/.*)?\Z}
           erb <<~HTML, path: routing.root_path, browser_settings: browser_settings(routing)
               <!DOCTYPE html>
               <html>

--- a/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
+++ b/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
@@ -1,98 +1,122 @@
 # frozen_string_literal: true
 
 require_relative "../browser"
-require "sinatra/base"
+require "rack"
+require "erb"
+require "json"
 
 module RubyEventStore
   module Browser
-    class App < Sinatra::Base
+    class App
       def self.for(
         event_store_locator:,
         host: nil,
         path: nil,
         api_url: nil,
-        environment: :production,
+        environment: nil,
         related_streams_query: DEFAULT_RELATED_STREAMS_QUERY
       )
-        self.tap do |app|
-          app.settings.instance_exec do
-            set :event_store_locator, event_store_locator
-            set :related_streams_query, -> { related_streams_query }
-            set :host, host
-            set :root_path, path
-            set :api_url, api_url
-            set :environment, environment
-          end
+        Rack::Builder.new do
+          use Rack::Static,
+              urls: {
+                "/ruby_event_store_browser.js" => "ruby_event_store_browser.js",
+                "/bootstrap.js" => "bootstrap.js"
+              },
+              root: "#{__dir__}/../../../public"
+          run App.new(
+                event_store_locator: event_store_locator,
+                related_streams_query: related_streams_query,
+                host: host,
+                root_path: path,
+                api_url: api_url
+              )
         end
       end
 
-      use Rack::Static,
-          urls: {
-            "/ruby_event_store_browser.js" => "ruby_event_store_browser.js",
-            "/bootstrap.js" => "bootstrap.js"
-          },
-          root: "#{__dir__}/../../../public"
-
-      configure { set :protection, except: :path_traversal }
-
-      get "/api/events/:id" do
-        json Event.new(event_store: settings.event_store_locator, event_id: params["id"])
-      rescue RubyEventStore::EventNotFound
-        404
+      def initialize(event_store_locator:, related_streams_query:, host:, root_path:, api_url:)
+        @event_store_locator = event_store_locator
+        @related_streams_query = related_streams_query
+        @host = host
+        @root_path = root_path
+        @api_url = api_url
       end
 
-      get "/api/streams/:stream_name" do
-        json GetStream.new(
-               stream_name: params["stream_name"],
-               routing: routing,
-               related_streams_query: settings.related_streams_query
-             )
-      end
+      def call(env)
+        request = Rack::Request.new(env)
+        routing = Routing.new(host || request.base_url, root_path || request.script_name)
+        event_store = event_store_locator.call
 
-      get "/api/streams/:stream_name/relationships/events" do
-        json GetEventsFromStream.new(
-               event_store: settings.event_store_locator,
-               stream_name: params["stream_name"],
-               page: params["page"],
-               routing: routing
-             )
-      end
-
-      get %r{/(events/.*|streams/.*)?} do
-        erb(<<~ERB, locals: { path: settings.root_path || request.script_name })
-          <!DOCTYPE html>
-          <html>
-            <head>
-              <title>RubyEventStore::Browser</title>
-              <meta name="ruby-event-store-browser-settings" content='<%= browser_settings %>'>
-            </head>
-            <body>
-              <script type="text/javascript" src="<%= path %>/ruby_event_store_browser.js"></script>
-              <script type="text/javascript" src="<%= path %>/bootstrap.js"></script>
-            </body>
-          </html>
-        ERB
-      end
-
-      helpers do
-        def routing
-          Routing.new(settings.host || request.base_url, settings.root_path || request.script_name)
-        end
-
-        def browser_settings
-          JSON.dump(
-            {
-              rootUrl: routing.root_url,
-              apiUrl: settings.api_url || routing.api_url,
-              resVersion: RubyEventStore::VERSION
-            }
+        case [request.request_method, request.path]
+        in "GET", %r{/api/events/(.+)}
+          render_json_api(Event.new(event_store: event_store, event_id: URI.decode_www_form_component($1)))
+        in "GET", %r{/api/streams/(.+)/relationships/events}
+          render_json_api(
+            GetEventsFromStream.new(
+              event_store: event_store,
+              routing: routing,
+              stream_name: URI.decode_www_form_component($1),
+              page: request.params["page"]
+            )
           )
+        in "GET", %r{/api/streams/(.+)}
+          render_json_api(
+            GetStream.new(
+              stream_name: URI.decode_www_form_component($1),
+              routing: routing,
+              related_streams_query: @related_streams_query
+            )
+          )
+        in "GET", %r{/(events/.*|streams/.*)?}
+          render_html(
+            ERB.new(<<~HTML).result_with_hash(path: routing.root_path, browser_settings: browser_settings(routing))
+              <!DOCTYPE html>
+              <html>
+                <head>
+                  <title>RubyEventStore::Browser</title>
+                  <meta name="ruby-event-store-browser-settings" content='<%= browser_settings %>'>
+                </head>
+                <body>
+                  <script type="text/javascript" src="<%= path %>/ruby_event_store_browser.js"></script>
+                  <script type="text/javascript" src="<%= path %>/bootstrap.js"></script>
+                </body>
+              </html>
+          HTML
+          )
+        else
+          render_404
         end
+      rescue RubyEventStore::EventNotFound
+        render_404
+      end
 
-        def json(data)
-          content_type "application/vnd.api+json"
-          JSON.dump data.to_h
-        end
+      private
+
+      attr_reader :event_store_locator, :related_streams_query, :host, :root_path, :api_url
+
+      def render_404
+        [404, {}, []]
+      end
+
+      def render_html(html)
+        [200, html_content_type, [html]]
+      end
+
+      def render_json_api(body)
+        [200, json_api_content_type, [JSON.dump(body.to_h)]]
+      end
+
+      def html_content_type
+        { "Content-Type" => "text/html;charset=utf-8" }
+      end
+
+      def json_api_content_type
+        { "Content-Type" => "application/vnd.api+json" }
+      end
+
+      def browser_settings(routing)
+        JSON.dump(
+          { rootUrl: routing.root_url, apiUrl: api_url || routing.api_url, resVersion: RubyEventStore::VERSION }
+        )
       end
     end
   end

--- a/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
+++ b/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
@@ -63,19 +63,7 @@ module RubyEventStore
                  page: request.params["page"]
                )
         in "GET", %r{\A/(events/.*|streams/.*)?\Z}
-          erb <<~HTML, path: routing.root_path, browser_settings: browser_settings(routing)
-              <!DOCTYPE html>
-              <html>
-                <head>
-                  <title>RubyEventStore::Browser</title>
-                  <meta name="ruby-event-store-browser-settings" content='<%= browser_settings %>'>
-                </head>
-                <body>
-                  <script type="text/javascript" src="<%= path %>/ruby_event_store_browser.js"></script>
-                  <script type="text/javascript" src="<%= path %>/bootstrap.js"></script>
-                </body>
-              </html>
-          HTML
+          erb template, path: routing.root_path, browser_settings: browser_settings(routing)
         else
           not_found
         end
@@ -86,6 +74,22 @@ module RubyEventStore
       private
 
       attr_reader :event_store_locator, :related_streams_query, :host, :root_path, :api_url
+
+      def template
+        <<~HTML
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <title>RubyEventStore::Browser</title>
+            <meta name="ruby-event-store-browser-settings" content='<%= browser_settings %>'>
+          </head>
+          <body>
+            <script type="text/javascript" src="<%= path %>/ruby_event_store_browser.js"></script>
+            <script type="text/javascript" src="<%= path %>/bootstrap.js"></script>
+          </body>
+        </html>
+        HTML
+      end
 
       def not_found
         [404, {}, []]

--- a/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
+++ b/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
@@ -48,9 +48,9 @@ module RubyEventStore
 
         case [request.request_method, request.path]
         in "GET", %r{/api/events/([^/]+)$}
-          render_json_api(Event.new(event_store: event_store, event_id: URI.decode_www_form_component($1)))
+          json(Event.new(event_store: event_store, event_id: URI.decode_www_form_component($1)))
         in "GET", %r{/api/streams/([^/]+)$}
-          render_json_api(
+          json(
             GetStream.new(
               stream_name: URI.decode_www_form_component($1),
               routing: routing,
@@ -58,7 +58,7 @@ module RubyEventStore
             )
           )
         in "GET", %r{/api/streams/([^/]+)/relationships/events$}
-          render_json_api(
+          json(
             GetEventsFromStream.new(
               event_store: event_store,
               routing: routing,
@@ -97,12 +97,12 @@ module RubyEventStore
         [404, {}, []]
       end
 
-      def render_html(html)
-        [200, { "Content-Type" => "text/html;charset=utf-8" }, [html]]
+      def json(body)
+        [200, { "Content-Type" => "application/vnd.api+json" }, [JSON.dump(body.to_h)]]
       end
 
-      def render_json_api(body)
-        [200, { "Content-Type" => "application/vnd.api+json" }, [JSON.dump(body.to_h)]]
+      def render_html(html)
+        [200, { "Content-Type" => "text/html;charset=utf-8" }, [html]]
       end
 
       def browser_settings(routing)

--- a/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
+++ b/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
@@ -98,19 +98,11 @@ module RubyEventStore
       end
 
       def render_html(html)
-        [200, html_content_type, [html]]
+        [200, { "Content-Type" => "text/html;charset=utf-8" }, [html]]
       end
 
       def render_json_api(body)
-        [200, json_api_content_type, [JSON.dump(body.to_h)]]
-      end
-
-      def html_content_type
-        { "Content-Type" => "text/html;charset=utf-8" }
-      end
-
-      def json_api_content_type
-        { "Content-Type" => "application/vnd.api+json" }
+        [200, { "Content-Type" => "application/vnd.api+json" }, [JSON.dump(body.to_h)]]
       end
 
       def browser_settings(routing)

--- a/ruby_event_store-browser/lib/ruby_event_store/browser/routing.rb
+++ b/ruby_event_store-browser/lib/ruby_event_store/browser/routing.rb
@@ -1,6 +1,8 @@
 module RubyEventStore
   module Browser
     class Routing
+      attr_reader :host, :root_path
+
       def initialize(host, root_path)
         @host = host
         @root_path = root_path
@@ -37,8 +39,6 @@ module RubyEventStore
       end
 
       private
-
-      attr_reader :host, :root_path
 
       def base_url
         [host, root_path].join

--- a/ruby_event_store-browser/ruby_event_store-browser.gemspec
+++ b/ruby_event_store-browser/ruby_event_store-browser.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.7"
 
   spec.add_dependency "ruby_event_store", "= 2.4.1"
-  spec.add_dependency "sinatra"
+  spec.add_dependency "rack"
 end


### PR DESCRIPTION
https://github.com/RailsEventStore/rails_event_store/issues/958

* Rack::Static to serve compiled JS from public path
* Rack::Request for nice facade over Rack env
* lacking Rack::Protection, which can be re-added if neeeded
* case pattern matching seems simple and sufficient for such a tiny app that Browser is,
  good thing that it uses === and that plays nicely with Regexp,
* one drawback is that it is also quite verbose without that fancy DSL for regex-matching
  URL patterns behind the scenes
* a few rough edges like unnamed and a bit too wide (thus order dependent) regexes,
  decoding params and endless string-vs-symbol whack-a-mole

Examples of router implementation:
https://github.com/pjb3/rack-router
https://github.com/mperham/sidekiq/commit/9ea167db16bf7f4cc9ee94967d0ea0b4dee6a7c5
