### PR TITLE
Outbox: automatically retry once on connection errors

### DIFF
--- a/contrib/ruby_event_store-outbox/lib/ruby_event_store/outbox.rb
+++ b/contrib/ruby_event_store-outbox/lib/ruby_event_store/outbox.rb
@@ -2,6 +2,8 @@
 
 module RubyEventStore
   module Outbox
+    Error = Class.new(StandardError)
+    RetriableError = Class.new(Error)
   end
 end
 

--- a/contrib/ruby_event_store-outbox/lib/ruby_event_store/outbox/sidekiq_processor.rb
+++ b/contrib/ruby_event_store-outbox/lib/ruby_event_store/outbox/sidekiq_processor.rb
@@ -22,6 +22,8 @@ module RubyEventStore
         redis.lpush("queue:#{queue}", payload)
 
         @recently_used_queues << queue
+      rescue Redis::TimeoutError
+        raise RetriableError
       end
 
       def after_batch

--- a/contrib/ruby_event_store-outbox/lib/ruby_event_store/outbox/sidekiq_processor.rb
+++ b/contrib/ruby_event_store-outbox/lib/ruby_event_store/outbox/sidekiq_processor.rb
@@ -22,7 +22,7 @@ module RubyEventStore
         redis.lpush("queue:#{queue}", payload)
 
         @recently_used_queues << queue
-      rescue Redis::TimeoutError
+      rescue Redis::TimeoutError, Redis::ConnectionError
         raise RetriableError
       end
 

--- a/contrib/ruby_event_store-outbox/spec/sidekiq_correctness_spec.rb
+++ b/contrib/ruby_event_store-outbox/spec/sidekiq_correctness_spec.rb
@@ -121,6 +121,38 @@ module RubyEventStore
 
         expect(entry_from_outbox).to be_present
       end
+
+      specify "Redis::ConnectionError is retriable" do
+        stub_const("RubyEventStore::Outbox::Consumer::MAXIMUM_BATCH_FETCHES_IN_ONE_LOCK", 1)
+        event =
+          TimeEnrichment.with(
+            Event.new(event_id: "83c3187f-84f6-4da7-8206-73af5aca7cc8"),
+            timestamp: Time.utc(2019, 9, 30)
+          )
+        event_record = RubyEventStore::Mappers::Default.new.event_to_record(event)
+        class ::CorrectAsyncHandler
+          include Sidekiq::Worker
+          def through_outbox?
+            true
+          end
+        end
+
+        SidekiqScheduler.new.call(CorrectAsyncHandler, event_record)
+        consumer = Consumer.new(SecureRandom.uuid, default_configuration, logger: test_logger, metrics: metrics)
+        failed_once = false
+        allow_any_instance_of(Redis).to receive(:lpush).and_wrap_original do |m, *args|
+          if failed_once
+            m.call(*args)
+          else
+            failed_once = true
+            raise Redis::ConnectionError
+          end
+        end
+        consumer.one_loop
+        entry_from_outbox = redis.lindex("queue:default", 0)
+
+        expect(entry_from_outbox).to be_present
+      end
     end
   end
 end


### PR DESCRIPTION
I am well aware that the tests are crap for these, i.e. there are no unit tests covering specific sidekiq processor (mostly because there is only a sidekiq processor and it's hard to abstract). I plan to improve tests later. Currently the behaviour is similar, but accidental: the consumer get the error (like timeout error), logs it, and then process next batch, starting from the same point. That will improve "performance" though, meaning the data won't be unnecessarily fetched again (we don't expect it to change, ever, so it doesn't make sense).