### PR TITLE
Changing facade API behaviour reverted

### DIFF
--- a/ruby_event_store/lib/ruby_event_store/client.rb
+++ b/ruby_event_store/lib/ruby_event_store/client.rb
@@ -339,16 +339,12 @@ module RubyEventStore
     end
 
     def enrich_events_metadata(events)
-      raise ArgumentError, "Event cannot be `nil`" if events.nil?
-
       events = Array(events)
       events.each { |event| enrich_event_metadata(event) }
       events
     end
 
     def enrich_event_metadata(event)
-      raise ArgumentError, "Event cannot be `nil`" if event.nil?
-
       metadata.each { |key, value| event.metadata[key] ||= value }
       event.metadata[:timestamp] ||= clock.call
       event.metadata[:valid_at] ||= event.metadata.fetch(:timestamp)

--- a/ruby_event_store/lib/ruby_event_store/client.rb
+++ b/ruby_event_store/lib/ruby_event_store/client.rb
@@ -28,8 +28,6 @@ module RubyEventStore
     # @param expected_version [:any, :auto, :none, Integer] controls optimistic locking strategy. {http://railseventstore.org/docs/expected_version/ Read more}
     # @return [self]
     def publish(events, stream_name: GLOBAL_STREAM, expected_version: :any)
-      assert_nil_events(events)
-
       enriched_events = enrich_events_metadata(events)
       records = transform(enriched_events)
       append_records_to_stream(records, stream_name: stream_name, expected_version: expected_version)
@@ -46,8 +44,6 @@ module RubyEventStore
     # @param (see #publish)
     # @return [self]
     def append(events, stream_name: GLOBAL_STREAM, expected_version: :any)
-      assert_nil_events(events)
-
       append_records_to_stream(
         transform(enrich_events_metadata(events)),
         stream_name: stream_name,
@@ -338,23 +334,21 @@ module RubyEventStore
 
     private
 
-    def assert_nil_events(events)
-      raise ArgumentError, "Event cannot be `nil`" if events.nil?
-      events = Array(events)
-      raise ArgumentError, "Event cannot be `nil`" if events.any?(&:nil?)
-    end
-
     def transform(events)
       events.map { |ev| mapper.event_to_record(ev) }
     end
 
     def enrich_events_metadata(events)
+      raise ArgumentError, "Event cannot be `nil`" if events.nil?
+
       events = Array(events)
       events.each { |event| enrich_event_metadata(event) }
       events
     end
 
     def enrich_event_metadata(event)
+      raise ArgumentError, "Event cannot be `nil`" if event.nil?
+
       metadata.each { |key, value| event.metadata[key] ||= value }
       event.metadata[:timestamp] ||= clock.call
       event.metadata[:valid_at] ||= event.metadata.fetch(:timestamp)

--- a/ruby_event_store/lib/ruby_event_store/client.rb
+++ b/ruby_event_store/lib/ruby_event_store/client.rb
@@ -64,8 +64,6 @@ module RubyEventStore
     # @param expected_version (see #publish)
     # @return [self]
     def link(event_ids, stream_name:, expected_version: :any)
-      assert_nil_events(event_ids)
-
       repository.link_to_stream(Array(event_ids), Stream.new(stream_name), ExpectedVersion.new(expected_version))
       self
     end

--- a/ruby_event_store/spec/client_spec.rb
+++ b/ruby_event_store/spec/client_spec.rb
@@ -20,7 +20,7 @@ module RubyEventStore
     end
 
     specify "publish with no events, fail if nil" do
-      client.publish([], stream_name: stream)
+      client.append([], stream_name: stream)
 
       expect {
         client.publish(nil, stream_name: stream)
@@ -35,20 +35,6 @@ module RubyEventStore
 
     specify "append returns client when success" do
       expect(client.append(TestEvent.new, stream_name: stream)).to eq(client)
-    end
-
-    specify "append with no events, fail if nil" do
-      client.append([], stream_name: stream)
-
-      expect {
-        client.append(nil, stream_name: stream)
-      }.to raise_error(ArgumentError, "Event cannot be `nil`")
-
-      expect {
-        client.append([nil], stream_name: stream)
-      }.to raise_error(ArgumentError, "Event cannot be `nil`")
-
-      expect(client.read.stream(stream).to_a).to be_empty
     end
 
     specify "append to default stream when not specified" do

--- a/ruby_event_store/spec/client_spec.rb
+++ b/ruby_event_store/spec/client_spec.rb
@@ -19,20 +19,6 @@ module RubyEventStore
       expect(client.publish(TestEvent.new)).to eq(client)
     end
 
-    specify "publish with no events, fail if nil" do
-      client.append([], stream_name: stream)
-
-      expect {
-        client.publish(nil, stream_name: stream)
-      }.to raise_error(ArgumentError, "Event cannot be `nil`")
-
-      expect {
-        client.publish([nil], stream_name: stream)
-      }.to raise_error(ArgumentError, "Event cannot be `nil`")
-
-      expect(client.read.stream(stream).to_a).to be_empty
-    end
-
     specify "append returns client when success" do
       expect(client.append(TestEvent.new, stream_name: stream)).to eq(client)
     end
@@ -212,7 +198,7 @@ module RubyEventStore
       expect(published[2].metadata[:valid_at]).to be_a Time
     end
 
-    specify "event's metadata takes precedence over with_metadata" do
+    specify "event's  metadata takes precedence over with_metadata" do
       client.with_metadata(request_ip: "127.0.0.1") do
         client.publish(@event = TestEvent.new(metadata: { request_ip: "1.2.3.4" }))
       end

--- a/ruby_event_store/spec/client_spec.rb
+++ b/ruby_event_store/spec/client_spec.rb
@@ -51,25 +51,6 @@ module RubyEventStore
       expect(client.read.stream(stream).to_a).to be_empty
     end
 
-    specify "link returns self when success" do
-      client.append(event = TestEvent.new)
-      expect(client.link(event.event_id, stream_name: stream)).to eq(client)
-    end
-
-    specify "link with no events, fail if nil" do
-      client.link([], stream_name: stream)
-
-      expect {
-        client.link(nil, stream_name: stream)
-      }.to raise_error(ArgumentError, "Event cannot be `nil`")
-
-      expect {
-        client.link([nil], stream_name: stream)
-      }.to raise_error(ArgumentError, "Event cannot be `nil`")
-
-      expect(client.read.stream(stream).to_a).to be_empty
-    end
-
     specify "append to default stream when not specified" do
       expect(client.append(test_event = TestEvent.new)).to eq(client)
       expect(client.read.limit(100).to_a).to eq([test_event])


### PR DESCRIPTION
- Revert "Assert nil when linking events"
- Revert "Extract assertion to separate method and call it asap"
- Revert "Raise ArgumentError when trying to publish nil as event"
