### PR TITLE
Bring back rails_event_store_active_record:migration

### DIFF
--- a/rails_event_store/spec/migration_spec.rb
+++ b/rails_event_store/spec/migration_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module RailsEventStore
+  RSpec.describe "Migration" do
+    specify do
+      expect(Rails::Generators.public_namespaces).to include("rails_event_store_active_record:migration")
+    end
+  end
+end

--- a/ruby_event_store-active_record/lib/ruby_event_store/active_record.rb
+++ b/ruby_event_store-active_record/lib/ruby_event_store/active_record.rb
@@ -10,3 +10,4 @@ require_relative "active_record/event_repository_reader"
 require_relative "active_record/index_violation_detector"
 require_relative "active_record/pg_linearized_event_repository"
 require_relative "active_record/version"
+require_relative "active_record/railtie" if defined?(Rails::Engine)

--- a/ruby_event_store-active_record/lib/ruby_event_store/active_record/generators/migration_generator.rb
+++ b/ruby_event_store-active_record/lib/ruby_event_store/active_record/generators/migration_generator.rb
@@ -13,6 +13,8 @@ module RubyEventStore
 
       DATA_TYPES = %w[binary json jsonb].freeze
 
+      namespace "rails_event_store_active_record:migration"
+
       source_root File.expand_path(File.join(File.dirname(__FILE__), "../generators/templates"))
       class_option(
         :data_type,

--- a/ruby_event_store-active_record/lib/ruby_event_store/active_record/railtie.rb
+++ b/ruby_event_store-active_record/lib/ruby_event_store/active_record/railtie.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module RubyEventStore
+  module ActiveRecord
+    Railtie = Class.new(::Rails::Railtie)
+  end
+end


### PR DESCRIPTION
- Failing test case for broken public API
- Resurrect old migration generator name to maintain stable public API
