### PR TITLE
Self-hosted full mutant coverage jobs

### DIFF
--- a/.github/workflows/aggregate_root_coverage.yml
+++ b/.github/workflows/aggregate_root_coverage.yml
@@ -19,7 +19,7 @@ on:
       - "support/**"
 jobs:
   coverage:
-    runs-on: ubuntu-20.04
+    runs-on: mutant
     timeout-minutes: 120
     env:
       BUNDLE_GEMFILE: Gemfile

--- a/.github/workflows/minitest-ruby_event_store_coverage.yml
+++ b/.github/workflows/minitest-ruby_event_store_coverage.yml
@@ -19,7 +19,8 @@ on:
       - "support/**"
 jobs:
   coverage:
-    runs-on: ubuntu-20.04
+    runs-on: mutant
+    timeout-minutes: 120
     env:
       WORKING_DIRECTORY: contrib/minitest-ruby_event_store
       BUNDLE_GEMFILE: Gemfile

--- a/.github/workflows/rails_event_store_coverage.yml
+++ b/.github/workflows/rails_event_store_coverage.yml
@@ -19,7 +19,7 @@ on:
       - "support/**"
 jobs:
   coverage:
-    runs-on: ubuntu-20.04
+    runs-on: mutant
     timeout-minutes: 120
     env:
       BUNDLE_GEMFILE: Gemfile

--- a/.github/workflows/ruby_event_store-active_record_coverage.yml
+++ b/.github/workflows/ruby_event_store-active_record_coverage.yml
@@ -19,7 +19,7 @@ on:
       - "support/**"
 jobs:
   coverage:
-    runs-on: ubuntu-20.04
+    runs-on: mutant
     timeout-minutes: 120
     env:
       BUNDLE_GEMFILE: Gemfile

--- a/.github/workflows/ruby_event_store-browser_coverage.yml
+++ b/.github/workflows/ruby_event_store-browser_coverage.yml
@@ -19,7 +19,7 @@ on:
       - "support/**"
 jobs:
   coverage:
-    runs-on: ubuntu-20.04
+    runs-on: mutant
     timeout-minutes: 120
     env:
       BUNDLE_GEMFILE: Gemfile

--- a/.github/workflows/ruby_event_store-flipper_coverage.yml
+++ b/.github/workflows/ruby_event_store-flipper_coverage.yml
@@ -19,7 +19,7 @@ on:
       - "support/**"
 jobs:
   coverage:
-    runs-on: ubuntu-20.04
+    runs-on: mutant
     timeout-minutes: 120
     env:
       WORKING_DIRECTORY: contrib/ruby_event_store-flipper

--- a/.github/workflows/ruby_event_store-newrelic_coverage.yml
+++ b/.github/workflows/ruby_event_store-newrelic_coverage.yml
@@ -18,8 +18,9 @@ on:
       - ".github/workflows/ruby_event_store-newrelic_coverage.yml"
       - "support/**"
 jobs:
-  mutate:
-    runs-on: ubuntu-20.04
+  coverage:
+    runs-on: mutant
+    timeout-minutes: 120
     env:
       WORKING_DIRECTORY: contrib/ruby_event_store-newrelic
       BUNDLE_GEMFILE: Gemfile

--- a/.github/workflows/ruby_event_store-outbox_coverage.yml
+++ b/.github/workflows/ruby_event_store-outbox_coverage.yml
@@ -18,8 +18,9 @@ on:
       - ".github/workflows/ruby_event_store-outbox_coverage.yml"
       - "support/**"
 jobs:
-  mutate:
-    runs-on: ubuntu-20.04
+  coverage:
+    runs-on: mutant
+    timeout-minutes: 120
     env:
       WORKING_DIRECTORY: contrib/ruby_event_store-outbox
       BUNDLE_GEMFILE: Gemfile

--- a/.github/workflows/ruby_event_store-profiler_coverage.yml
+++ b/.github/workflows/ruby_event_store-profiler_coverage.yml
@@ -18,8 +18,9 @@ on:
       - ".github/workflows/ruby_event_store-profiler_coverage.yml"
       - "support/**"
 jobs:
-  mutate:
-    runs-on: ubuntu-20.04
+  coverage:
+    runs-on: mutant
+    timeout-minutes: 120
     env:
       WORKING_DIRECTORY: contrib/ruby_event_store-profiler
       BUNDLE_GEMFILE: Gemfile

--- a/.github/workflows/ruby_event_store-protobuf_coverage.yml
+++ b/.github/workflows/ruby_event_store-protobuf_coverage.yml
@@ -18,8 +18,9 @@ on:
       - ".github/workflows/ruby_event_store-protobuf_coverage.yml"
       - "support/**"
 jobs:
-  mutate:
-    runs-on: ubuntu-20.04
+  coverage:
+    runs-on: mutant
+    timeout-minutes: 120
     env:
       WORKING_DIRECTORY: contrib/ruby_event_store-protobuf
       BUNDLE_GEMFILE: Gemfile

--- a/.github/workflows/ruby_event_store-rom_coverage.yml
+++ b/.github/workflows/ruby_event_store-rom_coverage.yml
@@ -18,8 +18,9 @@ on:
       - ".github/workflows/ruby_event_store-rom_coverage.yml"
       - "support/**"
 jobs:
-  mutate:
-    runs-on: ubuntu-20.04
+  coverage:
+    runs-on: mutant
+    timeout-minutes: 120
     env:
       WORKING_DIRECTORY: contrib/ruby_event_store-rom
       BUNDLE_GEMFILE: Gemfile

--- a/.github/workflows/ruby_event_store-rspec_coverage.yml
+++ b/.github/workflows/ruby_event_store-rspec_coverage.yml
@@ -19,7 +19,7 @@ on:
       - "support/**"
 jobs:
   coverage:
-    runs-on: ubuntu-20.04
+    runs-on: mutant
     timeout-minutes: 120
     env:
       BUNDLE_GEMFILE: Gemfile

--- a/.github/workflows/ruby_event_store-sidekiq_scheduler_coverage.yml
+++ b/.github/workflows/ruby_event_store-sidekiq_scheduler_coverage.yml
@@ -19,7 +19,7 @@ on:
       - "support/**"
 jobs:
   coverage:
-    runs-on: ubuntu-20.04
+    runs-on: mutant
     timeout-minutes: 120
     env:
       WORKING_DIRECTORY: contrib/ruby_event_store-sidekiq_scheduler

--- a/.github/workflows/ruby_event_store-transformations_coverage.yml
+++ b/.github/workflows/ruby_event_store-transformations_coverage.yml
@@ -18,8 +18,9 @@ on:
       - ".github/workflows/ruby_event_store-transformations_coverage.yml"
       - "support/**"
 jobs:
-  mutate:
-    runs-on: ubuntu-20.04
+  coverage:
+    runs-on: mutant
+    timeout-minutes: 120
     env:
       WORKING_DIRECTORY: contrib/ruby_event_store-transformations
       BUNDLE_GEMFILE: Gemfile

--- a/.github/workflows/ruby_event_store_coverage.yml
+++ b/.github/workflows/ruby_event_store_coverage.yml
@@ -19,7 +19,7 @@ on:
       - "support/**"
 jobs:
   coverage:
-    runs-on: ubuntu-20.04
+    runs-on: mutant
     timeout-minutes: 120
     env:
       BUNDLE_GEMFILE: Gemfile


### PR DESCRIPTION
Running full `mutatnt` coverage on hexacore machine with 64GB RAM — in addtion to github-hosted `test` and `mutate-changes`

There are 2 runners on that machine.