### PR TITLE
Coerce `load_path` to string

### DIFF
--- a/ruby_event_store-browser/lib/ruby_event_store/browser/gem_source.rb
+++ b/ruby_event_store-browser/lib/ruby_event_store/browser/gem_source.rb
@@ -6,7 +6,7 @@ module RubyEventStore
       attr_reader :path
 
       def initialize(load_path)
-        @path = load_path.find { |x| x.match? %r{ruby_event_store-browser(?:-\d\.\d\.\d)?/lib\z} }
+        @path = load_path.find { |x| x.to_s.match? %r{ruby_event_store-browser(?:-\d\.\d\.\d)?/lib\z} }
       end
 
       def version


### PR DESCRIPTION
In my Rails 7 application `$LOAD_PATH` is a `Pathname` instance. Coercing the `load_path` to a string before using `match?` makes it work regardless of the `$LOAD_PATH` type.