### PR TITLE
Move non aj scheduler handler tests to sidekiq scheduler gem

### DIFF
--- a/contrib/ruby_event_store-sidekiq_scheduler/Gemfile
+++ b/contrib/ruby_event_store-sidekiq_scheduler/Gemfile
@@ -5,3 +5,6 @@ eval_gemfile "../../support/bundler/Gemfile.shared"
 
 gem "sidekiq", "~> 7.0"
 gem "ruby_event_store", path: "../.."
+gem "rails_event_store", path: "../.."
+gem "rails", "7.0.4"
+gem "sqlite3"

--- a/contrib/ruby_event_store-sidekiq_scheduler/Gemfile.lock
+++ b/contrib/ruby_event_store-sidekiq_scheduler/Gemfile.lock
@@ -1,8 +1,27 @@
 PATH
   remote: ../..
   specs:
+    aggregate_root (2.7.0)
+      ruby_event_store (= 2.7.0)
+    rails_event_store (2.7.0)
+      activejob (>= 6.0)
+      activemodel (>= 6.0)
+      activesupport (>= 6.0)
+      aggregate_root (= 2.7.0)
+      arkency-command_bus (>= 0.4)
+      rails_event_store_active_record (= 2.7.0)
+      ruby_event_store (= 2.7.0)
+      ruby_event_store-browser (= 2.7.0)
+    rails_event_store_active_record (2.7.0)
+      ruby_event_store-active_record (= 2.7.0)
     ruby_event_store (2.7.0)
       concurrent-ruby (~> 1.0, >= 1.1.6)
+    ruby_event_store-active_record (2.7.0)
+      activerecord (>= 6.0)
+      ruby_event_store (= 2.7.0)
+    ruby_event_store-browser (2.7.0)
+      rack
+      ruby_event_store (= 2.7.0)
 
 PATH
   remote: .
@@ -18,10 +37,96 @@ GEM
 GEM
   remote: https://rubygems.org/
   specs:
+    actioncable (7.0.4)
+      actionpack (= 7.0.4)
+      activesupport (= 7.0.4)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+    actionmailbox (7.0.4)
+      actionpack (= 7.0.4)
+      activejob (= 7.0.4)
+      activerecord (= 7.0.4)
+      activestorage (= 7.0.4)
+      activesupport (= 7.0.4)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.0.4)
+      actionpack (= 7.0.4)
+      actionview (= 7.0.4)
+      activejob (= 7.0.4)
+      activesupport (= 7.0.4)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.0)
+    actionpack (7.0.4)
+      actionview (= 7.0.4)
+      activesupport (= 7.0.4)
+      rack (~> 2.0, >= 2.2.0)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actiontext (7.0.4)
+      actionpack (= 7.0.4)
+      activerecord (= 7.0.4)
+      activestorage (= 7.0.4)
+      activesupport (= 7.0.4)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (7.0.4)
+      activesupport (= 7.0.4)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    activejob (7.0.4)
+      activesupport (= 7.0.4)
+      globalid (>= 0.3.6)
+    activemodel (7.0.4)
+      activesupport (= 7.0.4)
+    activerecord (7.0.4)
+      activemodel (= 7.0.4)
+      activesupport (= 7.0.4)
+    activestorage (7.0.4)
+      actionpack (= 7.0.4)
+      activejob (= 7.0.4)
+      activerecord (= 7.0.4)
+      activesupport (= 7.0.4)
+      marcel (~> 1.0)
+      mini_mime (>= 1.1.0)
+    activesupport (7.0.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    arkency-command_bus (0.4.1)
+      concurrent-ruby
     ast (2.4.2)
+    builder (3.2.4)
     concurrent-ruby (1.1.10)
     connection_pool (2.3.0)
+    crass (1.0.6)
+    date (3.3.3)
     diff-lcs (1.5.0)
+    erubi (1.11.0)
+    globalid (1.0.0)
+      activesupport (>= 5.0)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
+    loofah (2.19.1)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    mail (2.8.0)
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    marcel (1.0.2)
+    method_source (1.0.0)
+    mini_mime (1.1.2)
     minitest (5.16.3)
     mutant (0.11.17)
       diff-lcs (~> 1.3)
@@ -35,9 +140,54 @@ GEM
     mutant-rspec (0.11.17)
       mutant (= 0.11.17)
       rspec-core (>= 3.8.0, < 4.0.0)
+    net-imap (0.3.2)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.1)
+      timeout
+    net-smtp (0.3.3)
+      net-protocol
+    nio4r (2.5.8)
+    nokogiri (1.13.10-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.10-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.10-x86_64-linux)
+      racc (~> 1.4)
     parser (3.1.3.0)
       ast (~> 2.4.1)
-    rack (3.0.2)
+    racc (1.6.1)
+    rack (2.2.4)
+    rack-test (2.0.2)
+      rack (>= 1.3)
+    rails (7.0.4)
+      actioncable (= 7.0.4)
+      actionmailbox (= 7.0.4)
+      actionmailer (= 7.0.4)
+      actionpack (= 7.0.4)
+      actiontext (= 7.0.4)
+      actionview (= 7.0.4)
+      activejob (= 7.0.4)
+      activemodel (= 7.0.4)
+      activerecord (= 7.0.4)
+      activestorage (= 7.0.4)
+      activesupport (= 7.0.4)
+      bundler (>= 1.15.0)
+      railties (= 7.0.4)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.4.4)
+      loofah (~> 2.19, >= 2.19.1)
+    railties (7.0.4)
+      actionpack (= 7.0.4)
+      activesupport (= 7.0.4)
+      method_source
+      rake (>= 12.2)
+      thor (~> 1.0)
+      zeitwerk (~> 2.5)
     rake (13.0.6)
     redis-client (0.11.2)
       connection_pool
@@ -61,11 +211,23 @@ GEM
       rack (>= 2.2.4)
       redis-client (>= 0.11.0)
     sorbet-runtime (0.5.10588)
+    sqlite3 (1.5.4-arm64-darwin)
+    sqlite3 (1.5.4-x86_64-darwin)
+    sqlite3 (1.5.4-x86_64-linux)
+    thor (1.2.1)
+    timeout (0.3.1)
+    tzinfo (2.0.5)
+      concurrent-ruby (~> 1.0)
     unparser (0.6.5)
       diff-lcs (~> 1.3)
       parser (>= 3.1.0)
+    websocket-driver (0.7.5)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    zeitwerk (2.6.6)
 
 PLATFORMS
+  arm64-darwin-21
   arm64-darwin-22
   x86_64-darwin-22
   x86_64-linux
@@ -75,11 +237,14 @@ DEPENDENCIES
   mutant-license!
   mutant-minitest (= 0.11.17)
   mutant-rspec (= 0.11.17)
+  rails (= 7.0.4)
+  rails_event_store!
   rake (>= 10.0)
   rspec (~> 3.6)
   ruby_event_store!
   ruby_event_store-sidekiq_scheduler!
   sidekiq (~> 7.0)
+  sqlite3
 
 BUNDLED WITH
    2.3.26

--- a/contrib/ruby_event_store-sidekiq_scheduler/Gemfile.sidekiq_5
+++ b/contrib/ruby_event_store-sidekiq_scheduler/Gemfile.sidekiq_5
@@ -5,3 +5,6 @@ eval_gemfile "../../support/bundler/Gemfile.shared"
 
 gem "sidekiq", "~> 5.0"
 gem "ruby_event_store", path: "../.."
+gem "rails_event_store", path: "../.."
+gem "rails", "7.0.4"
+gem "sqlite3"

--- a/contrib/ruby_event_store-sidekiq_scheduler/Gemfile.sidekiq_5.lock
+++ b/contrib/ruby_event_store-sidekiq_scheduler/Gemfile.sidekiq_5.lock
@@ -1,8 +1,27 @@
 PATH
   remote: ../..
   specs:
+    aggregate_root (2.7.0)
+      ruby_event_store (= 2.7.0)
+    rails_event_store (2.7.0)
+      activejob (>= 6.0)
+      activemodel (>= 6.0)
+      activesupport (>= 6.0)
+      aggregate_root (= 2.7.0)
+      arkency-command_bus (>= 0.4)
+      rails_event_store_active_record (= 2.7.0)
+      ruby_event_store (= 2.7.0)
+      ruby_event_store-browser (= 2.7.0)
+    rails_event_store_active_record (2.7.0)
+      ruby_event_store-active_record (= 2.7.0)
     ruby_event_store (2.7.0)
       concurrent-ruby (~> 1.0, >= 1.1.6)
+    ruby_event_store-active_record (2.7.0)
+      activerecord (>= 6.0)
+      ruby_event_store (= 2.7.0)
+    ruby_event_store-browser (2.7.0)
+      rack
+      ruby_event_store (= 2.7.0)
 
 PATH
   remote: .
@@ -18,10 +37,96 @@ GEM
 GEM
   remote: https://rubygems.org/
   specs:
+    actioncable (7.0.4)
+      actionpack (= 7.0.4)
+      activesupport (= 7.0.4)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+    actionmailbox (7.0.4)
+      actionpack (= 7.0.4)
+      activejob (= 7.0.4)
+      activerecord (= 7.0.4)
+      activestorage (= 7.0.4)
+      activesupport (= 7.0.4)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.0.4)
+      actionpack (= 7.0.4)
+      actionview (= 7.0.4)
+      activejob (= 7.0.4)
+      activesupport (= 7.0.4)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.0)
+    actionpack (7.0.4)
+      actionview (= 7.0.4)
+      activesupport (= 7.0.4)
+      rack (~> 2.0, >= 2.2.0)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actiontext (7.0.4)
+      actionpack (= 7.0.4)
+      activerecord (= 7.0.4)
+      activestorage (= 7.0.4)
+      activesupport (= 7.0.4)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (7.0.4)
+      activesupport (= 7.0.4)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    activejob (7.0.4)
+      activesupport (= 7.0.4)
+      globalid (>= 0.3.6)
+    activemodel (7.0.4)
+      activesupport (= 7.0.4)
+    activerecord (7.0.4)
+      activemodel (= 7.0.4)
+      activesupport (= 7.0.4)
+    activestorage (7.0.4)
+      actionpack (= 7.0.4)
+      activejob (= 7.0.4)
+      activerecord (= 7.0.4)
+      activesupport (= 7.0.4)
+      marcel (~> 1.0)
+      mini_mime (>= 1.1.0)
+    activesupport (7.0.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    arkency-command_bus (0.4.1)
+      concurrent-ruby
     ast (2.4.2)
+    builder (3.2.4)
     concurrent-ruby (1.1.10)
     connection_pool (2.3.0)
+    crass (1.0.6)
+    date (3.3.3)
     diff-lcs (1.5.0)
+    erubi (1.11.0)
+    globalid (1.0.0)
+      activesupport (>= 5.0)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
+    loofah (2.19.1)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    mail (2.8.0)
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    marcel (1.0.2)
+    method_source (1.0.0)
+    mini_mime (1.1.2)
     minitest (5.16.3)
     mutant (0.11.17)
       diff-lcs (~> 1.3)
@@ -35,11 +140,56 @@ GEM
     mutant-rspec (0.11.17)
       mutant (= 0.11.17)
       rspec-core (>= 3.8.0, < 4.0.0)
+    net-imap (0.3.2)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.1)
+      timeout
+    net-smtp (0.3.3)
+      net-protocol
+    nio4r (2.5.8)
+    nokogiri (1.13.10-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.10-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.10-x86_64-linux)
+      racc (~> 1.4)
     parser (3.1.3.0)
       ast (~> 2.4.1)
+    racc (1.6.1)
     rack (2.2.4)
     rack-protection (3.0.4)
       rack
+    rack-test (2.0.2)
+      rack (>= 1.3)
+    rails (7.0.4)
+      actioncable (= 7.0.4)
+      actionmailbox (= 7.0.4)
+      actionmailer (= 7.0.4)
+      actionpack (= 7.0.4)
+      actiontext (= 7.0.4)
+      actionview (= 7.0.4)
+      activejob (= 7.0.4)
+      activemodel (= 7.0.4)
+      activerecord (= 7.0.4)
+      activestorage (= 7.0.4)
+      activesupport (= 7.0.4)
+      bundler (>= 1.15.0)
+      railties (= 7.0.4)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.4.4)
+      loofah (~> 2.19, >= 2.19.1)
+    railties (7.0.4)
+      actionpack (= 7.0.4)
+      activesupport (= 7.0.4)
+      method_source
+      rake (>= 12.2)
+      thor (~> 1.0)
+      zeitwerk (~> 2.5)
     rake (13.0.6)
     redis (4.5.1)
     regexp_parser (2.6.1)
@@ -62,11 +212,23 @@ GEM
       rack-protection (>= 1.5.0)
       redis (~> 4.5, < 4.6.0)
     sorbet-runtime (0.5.10588)
+    sqlite3 (1.5.4-arm64-darwin)
+    sqlite3 (1.5.4-x86_64-darwin)
+    sqlite3 (1.5.4-x86_64-linux)
+    thor (1.2.1)
+    timeout (0.3.1)
+    tzinfo (2.0.5)
+      concurrent-ruby (~> 1.0)
     unparser (0.6.5)
       diff-lcs (~> 1.3)
       parser (>= 3.1.0)
+    websocket-driver (0.7.5)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    zeitwerk (2.6.6)
 
 PLATFORMS
+  arm64-darwin-21
   arm64-darwin-22
   x86_64-darwin-22
   x86_64-linux
@@ -76,11 +238,14 @@ DEPENDENCIES
   mutant-license!
   mutant-minitest (= 0.11.17)
   mutant-rspec (= 0.11.17)
+  rails (= 7.0.4)
+  rails_event_store!
   rake (>= 10.0)
   rspec (~> 3.6)
   ruby_event_store!
   ruby_event_store-sidekiq_scheduler!
   sidekiq (~> 5.0)
+  sqlite3
 
 BUNDLED WITH
    2.3.26

--- a/contrib/ruby_event_store-sidekiq_scheduler/Gemfile.sidekiq_6
+++ b/contrib/ruby_event_store-sidekiq_scheduler/Gemfile.sidekiq_6
@@ -5,3 +5,6 @@ eval_gemfile "../../support/bundler/Gemfile.shared"
 
 gem "sidekiq", "~> 6.4"
 gem "ruby_event_store", path: "../.."
+gem "rails_event_store", path: "../.."
+gem "rails", "7.0.4"
+gem "sqlite3"

--- a/contrib/ruby_event_store-sidekiq_scheduler/Gemfile.sidekiq_6.lock
+++ b/contrib/ruby_event_store-sidekiq_scheduler/Gemfile.sidekiq_6.lock
@@ -1,8 +1,27 @@
 PATH
   remote: ../..
   specs:
+    aggregate_root (2.7.0)
+      ruby_event_store (= 2.7.0)
+    rails_event_store (2.7.0)
+      activejob (>= 6.0)
+      activemodel (>= 6.0)
+      activesupport (>= 6.0)
+      aggregate_root (= 2.7.0)
+      arkency-command_bus (>= 0.4)
+      rails_event_store_active_record (= 2.7.0)
+      ruby_event_store (= 2.7.0)
+      ruby_event_store-browser (= 2.7.0)
+    rails_event_store_active_record (2.7.0)
+      ruby_event_store-active_record (= 2.7.0)
     ruby_event_store (2.7.0)
       concurrent-ruby (~> 1.0, >= 1.1.6)
+    ruby_event_store-active_record (2.7.0)
+      activerecord (>= 6.0)
+      ruby_event_store (= 2.7.0)
+    ruby_event_store-browser (2.7.0)
+      rack
+      ruby_event_store (= 2.7.0)
 
 PATH
   remote: .
@@ -18,10 +37,96 @@ GEM
 GEM
   remote: https://rubygems.org/
   specs:
+    actioncable (7.0.4)
+      actionpack (= 7.0.4)
+      activesupport (= 7.0.4)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+    actionmailbox (7.0.4)
+      actionpack (= 7.0.4)
+      activejob (= 7.0.4)
+      activerecord (= 7.0.4)
+      activestorage (= 7.0.4)
+      activesupport (= 7.0.4)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.0.4)
+      actionpack (= 7.0.4)
+      actionview (= 7.0.4)
+      activejob (= 7.0.4)
+      activesupport (= 7.0.4)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.0)
+    actionpack (7.0.4)
+      actionview (= 7.0.4)
+      activesupport (= 7.0.4)
+      rack (~> 2.0, >= 2.2.0)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actiontext (7.0.4)
+      actionpack (= 7.0.4)
+      activerecord (= 7.0.4)
+      activestorage (= 7.0.4)
+      activesupport (= 7.0.4)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (7.0.4)
+      activesupport (= 7.0.4)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    activejob (7.0.4)
+      activesupport (= 7.0.4)
+      globalid (>= 0.3.6)
+    activemodel (7.0.4)
+      activesupport (= 7.0.4)
+    activerecord (7.0.4)
+      activemodel (= 7.0.4)
+      activesupport (= 7.0.4)
+    activestorage (7.0.4)
+      actionpack (= 7.0.4)
+      activejob (= 7.0.4)
+      activerecord (= 7.0.4)
+      activesupport (= 7.0.4)
+      marcel (~> 1.0)
+      mini_mime (>= 1.1.0)
+    activesupport (7.0.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    arkency-command_bus (0.4.1)
+      concurrent-ruby
     ast (2.4.2)
+    builder (3.2.4)
     concurrent-ruby (1.1.10)
     connection_pool (2.3.0)
+    crass (1.0.6)
+    date (3.3.3)
     diff-lcs (1.5.0)
+    erubi (1.11.0)
+    globalid (1.0.0)
+      activesupport (>= 5.0)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
+    loofah (2.19.1)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    mail (2.8.0)
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    marcel (1.0.2)
+    method_source (1.0.0)
+    mini_mime (1.1.2)
     minitest (5.16.3)
     mutant (0.11.17)
       diff-lcs (~> 1.3)
@@ -35,9 +140,54 @@ GEM
     mutant-rspec (0.11.17)
       mutant (= 0.11.17)
       rspec-core (>= 3.8.0, < 4.0.0)
+    net-imap (0.3.2)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.1)
+      timeout
+    net-smtp (0.3.3)
+      net-protocol
+    nio4r (2.5.8)
+    nokogiri (1.13.10-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.10-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.10-x86_64-linux)
+      racc (~> 1.4)
     parser (3.1.3.0)
       ast (~> 2.4.1)
+    racc (1.6.1)
     rack (2.2.4)
+    rack-test (2.0.2)
+      rack (>= 1.3)
+    rails (7.0.4)
+      actioncable (= 7.0.4)
+      actionmailbox (= 7.0.4)
+      actionmailer (= 7.0.4)
+      actionpack (= 7.0.4)
+      actiontext (= 7.0.4)
+      actionview (= 7.0.4)
+      activejob (= 7.0.4)
+      activemodel (= 7.0.4)
+      activerecord (= 7.0.4)
+      activestorage (= 7.0.4)
+      activesupport (= 7.0.4)
+      bundler (>= 1.15.0)
+      railties (= 7.0.4)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.4.4)
+      loofah (~> 2.19, >= 2.19.1)
+    railties (7.0.4)
+      actionpack (= 7.0.4)
+      activesupport (= 7.0.4)
+      method_source
+      rake (>= 12.2)
+      thor (~> 1.0)
+      zeitwerk (~> 2.5)
     rake (13.0.6)
     redis (4.8.0)
     regexp_parser (2.6.1)
@@ -59,11 +209,23 @@ GEM
       rack (~> 2.0)
       redis (>= 4.5.0, < 5)
     sorbet-runtime (0.5.10588)
+    sqlite3 (1.5.4-arm64-darwin)
+    sqlite3 (1.5.4-x86_64-darwin)
+    sqlite3 (1.5.4-x86_64-linux)
+    thor (1.2.1)
+    timeout (0.3.1)
+    tzinfo (2.0.5)
+      concurrent-ruby (~> 1.0)
     unparser (0.6.5)
       diff-lcs (~> 1.3)
       parser (>= 3.1.0)
+    websocket-driver (0.7.5)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    zeitwerk (2.6.6)
 
 PLATFORMS
+  arm64-darwin-21
   arm64-darwin-22
   x86_64-darwin-22
   x86_64-linux
@@ -73,11 +235,14 @@ DEPENDENCIES
   mutant-license!
   mutant-minitest (= 0.11.17)
   mutant-rspec (= 0.11.17)
+  rails (= 7.0.4)
+  rails_event_store!
   rake (>= 10.0)
   rspec (~> 3.6)
   ruby_event_store!
   ruby_event_store-sidekiq_scheduler!
   sidekiq (~> 6.4)
+  sqlite3
 
 BUNDLED WITH
    2.3.26

--- a/contrib/ruby_event_store-sidekiq_scheduler/Makefile
+++ b/contrib/ruby_event_store-sidekiq_scheduler/Makefile
@@ -1,6 +1,7 @@
 GEM_VERSION  = $(shell cat lib/ruby_event_store/sidekiq_scheduler/version.rb | grep VERSION | egrep -o '[0-9]+\.[0-9]+\.[0-9]+')
 GEM_NAME     = ruby_event_store-sidekiq_scheduler
 DATABASE_URL ?= sqlite3::memory:
+DATA_TYPE    ?= binary
 
 include ../../support/make/install.mk
 include ../../support/make/test.mk

--- a/contrib/ruby_event_store-sidekiq_scheduler/spec/after_commit_async_dispatcher_spec.rb
+++ b/contrib/ruby_event_store-sidekiq_scheduler/spec/after_commit_async_dispatcher_spec.rb
@@ -1,0 +1,241 @@
+require "spec_helper"
+require "ruby_event_store/spec/dispatcher_lint"
+require "ruby_event_store/spec/scheduler_lint"
+require "rails_event_store"
+
+module RubyEventStore
+  ::RSpec.describe RailsEventStore::AfterCommitAsyncDispatcher do
+    around(:each) do |example|
+      ::ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+      m =
+        Migrator.new(
+          File.expand_path(
+            "../../../ruby_event_store-active_record/lib/ruby_event_store/active_record/generators/templates",
+            __dir__
+          )
+        )
+      SilenceStdout.silence_stdout { m.run_migration("create_event_store_events") }
+
+      example.run
+    end
+
+    DummyError = Class.new(StandardError)
+
+    class DummyRecord < ::ActiveRecord::Base
+      self.table_name = "dummy_records"
+      after_commit -> { raise DummyError }
+    end
+
+    it_behaves_like :scheduler, SidekiqScheduler.new(serializer: RubyEventStore::Serializers::YAML)
+
+    it_behaves_like :dispatcher, RailsEventStore::AfterCommitAsyncDispatcher.new(scheduler: SidekiqScheduler.new(serializer: RubyEventStore::Serializers::YAML))
+
+    let(:event) { TimeEnrichment.with(RailsEventStore::Event.new(event_id: "83c3187f-84f6-4da7-8206-73af5aca7cc8")) }
+    let(:record) { RubyEventStore::Mappers::Default.new.event_to_record(event) }
+    let(:serialized_record) { record.serialize(YAML).to_h.transform_keys(&:to_s) }
+
+    let(:dispatcher) { RailsEventStore::AfterCommitAsyncDispatcher.new(scheduler: SidekiqScheduler.new(serializer: RubyEventStore::Serializers::YAML)) }
+
+    before(:each) { TestAsyncHandler.reset }
+
+    it "dispatch job immediately when no transaction is open" do
+      expect_to_have_enqueued_job(TestAsyncHandler) { dispatcher.call(TestAsyncHandler, event, record) }
+      expect(TestAsyncHandler.received).to be_nil
+      TestAsyncHandler.perform_enqueued_jobs
+      expect(TestAsyncHandler.received).to eq(serialized_record)
+    end
+
+    it "dispatch job only after transaction commit" do
+      expect_to_have_enqueued_job(TestAsyncHandler) do
+        ::ActiveRecord::Base.transaction do
+          expect_no_enqueued_job(TestAsyncHandler) { dispatcher.call(TestAsyncHandler, event, record) }
+        end
+      end
+      expect(TestAsyncHandler.received).to be_nil
+      TestAsyncHandler.perform_enqueued_jobs
+      expect(TestAsyncHandler.received).to eq(serialized_record)
+    end
+
+    context "when transaction is rolledback" do
+      it "does not dispatch job" do
+        expect_no_enqueued_job(TestAsyncHandler) do
+          ::ActiveRecord::Base.transaction do
+            dispatcher.call(TestAsyncHandler, event, record)
+            raise ::ActiveRecord::Rollback
+          end
+        end
+        TestAsyncHandler.perform_enqueued_jobs
+        expect(TestAsyncHandler.received).to be_nil
+      end
+
+      context "when raise_in_transactional_callbacks is enabled" do
+        around { |example| with_raise_in_transactional_callbacks { example.run } }
+
+        it "does not dispatch job" do
+          expect_no_enqueued_job(TestAsyncHandler) do
+            ::ActiveRecord::Base.transaction do
+              dispatcher.call(TestAsyncHandler, event, record)
+              raise ::ActiveRecord::Rollback
+            end
+          end
+          TestAsyncHandler.perform_enqueued_jobs
+          expect(TestAsyncHandler.received).to be_nil
+        end
+      end
+    end
+
+    it "dispatch job only after top-level transaction (nested is not new) commit" do
+      expect_to_have_enqueued_job(TestAsyncHandler) do
+        ::ActiveRecord::Base.transaction do
+          expect_no_enqueued_job(TestAsyncHandler) do
+            ::ActiveRecord::Base.transaction(requires_new: false) { dispatcher.call(TestAsyncHandler, event, record) }
+          end
+        end
+      end
+      expect(TestAsyncHandler.received).to be_nil
+      TestAsyncHandler.perform_enqueued_jobs
+      expect(TestAsyncHandler.received).to eq(serialized_record)
+    end
+
+    it "dispatch job only after top-level transaction commit" do
+      expect_to_have_enqueued_job(TestAsyncHandler) do
+        ::ActiveRecord::Base.transaction do
+          expect_no_enqueued_job(TestAsyncHandler) do
+            ::ActiveRecord::Base.transaction(requires_new: true) { dispatcher.call(TestAsyncHandler, event, record) }
+          end
+        end
+      end
+      expect(TestAsyncHandler.received).to be_nil
+      TestAsyncHandler.perform_enqueued_jobs
+      expect(TestAsyncHandler.received).to eq(serialized_record)
+    end
+
+    it "does not dispatch job after nested transaction rollback" do
+      expect_no_enqueued_job(TestAsyncHandler) do
+        ::ActiveRecord::Base.transaction do
+          expect_no_enqueued_job(TestAsyncHandler) do
+            ::ActiveRecord::Base.transaction(requires_new: true) do
+              dispatcher.call(TestAsyncHandler, event, record)
+              raise ::ActiveRecord::Rollback
+            end
+          end
+        end
+      end
+      TestAsyncHandler.perform_enqueued_jobs
+      expect(TestAsyncHandler.received).to be_nil
+    end
+
+    context "when an exception is raised within after commit callback" do
+      before { ::ActiveRecord::Schema.define { create_table(:dummy_records) } }
+
+      it "dispatches the job after commit" do
+        expect_to_have_enqueued_job(TestAsyncHandler) do
+          begin
+            ::ActiveRecord::Base.transaction do
+              DummyRecord.new.save!
+              expect_no_enqueued_job(TestAsyncHandler) { dispatcher.call(TestAsyncHandler, event, record) }
+            end
+          rescue DummyError
+          end
+        end
+        expect(DummyRecord.count).to eq(1)
+        expect(TestAsyncHandler.received).to be_nil
+
+        TestAsyncHandler.perform_enqueued_jobs
+        expect(TestAsyncHandler.received).to eq(serialized_record)
+      end
+
+      context "when raise_in_transactional_callbacks is enabled" do
+        around { |example| with_raise_in_transactional_callbacks { example.run } }
+
+        it "dispatches the job after commit" do
+          expect_to_have_enqueued_job(TestAsyncHandler) do
+            begin
+              ::ActiveRecord::Base.transaction do
+                DummyRecord.new.save!
+                expect_no_enqueued_job(TestAsyncHandler) { dispatcher.call(TestAsyncHandler, event, record) }
+              end
+            rescue DummyError
+            end
+          end
+          expect(DummyRecord.count).to eq(1)
+          expect(TestAsyncHandler.received).to be_nil
+
+          TestAsyncHandler.perform_enqueued_jobs
+          expect(TestAsyncHandler.received).to eq(serialized_record)
+        end
+      end
+    end
+
+    context "within a non-joinable transaction" do
+      around { |example| ::ActiveRecord::Base.transaction(joinable: false) { example.run } }
+
+      it "dispatches the job" do
+        expect_to_have_enqueued_job(TestAsyncHandler) { dispatcher.call(TestAsyncHandler, event, record) }
+      end
+
+      it "dispatches the job after a nested transaction commits" do
+        expect_to_have_enqueued_job(TestAsyncHandler) do
+          ::ActiveRecord::Base.transaction do
+            expect_no_enqueued_job(TestAsyncHandler) { dispatcher.call(TestAsyncHandler, event, record) }
+          end
+        end
+      end
+    end
+
+    describe "#verify" do
+      specify { expect(dispatcher.verify(TestAsyncHandler)).to eq(true) }
+    end
+
+    def expect_no_enqueued_job(job)
+      raise unless block_given?
+      yield
+      expect(job.queued).to be_nil
+    end
+
+    def expect_to_have_enqueued_job(job)
+      raise unless block_given?
+      yield
+      expect(job.queued).not_to be_nil
+    end
+
+    def with_raise_in_transactional_callbacks
+      skip unless ::ActiveRecord::Base.respond_to?(:raise_in_transactional_callbacks)
+
+      old_transaction_config = ::ActiveRecord::Base.raise_in_transactional_callbacks
+      ::ActiveRecord::Base.raise_in_transactional_callbacks = true
+
+      yield
+
+      ::ActiveRecord::Base.raise_in_transactional_callbacks = old_transaction_config
+    end
+
+    private
+
+    class TestAsyncHandler
+      include ::Sidekiq::Worker
+
+      @@received = nil
+      @@queued = nil
+      def self.reset
+        @@received = nil
+        @@queued = nil
+      end
+      def self.queued
+        @@queued
+
+      end
+      def self.received
+        @@received
+
+      end
+      def self.perform_enqueued_jobs
+        @@received = @@queued
+
+      end
+      def self.perform_async(event)
+        @@queued = event
+      end
+    end
+  end
+end

--- a/contrib/ruby_event_store-sidekiq_scheduler/spec/async_handler_helpers_spec.rb
+++ b/contrib/ruby_event_store-sidekiq_scheduler/spec/async_handler_helpers_spec.rb
@@ -1,0 +1,81 @@
+require "spec_helper"
+require "ruby_event_store/active_record"
+require "rails_event_store"
+require "rails"
+require_relative "../../../support/helpers/silence_stdout"
+require_relative "../../../support/helpers/migrator"
+
+SilenceStdout.silence_stdout { require "sidekiq/testing" }
+
+module RubyEventStore
+  class SidekiqHandlerWithHelper
+    include Sidekiq::Worker
+
+    def perform(event)
+      $queue.push(event)
+    end
+  end
+
+  ::RSpec.describe RailsEventStore::AsyncHandler do
+    let(:event_store) { RailsEventStore::Client.new }
+    let(:application) { instance_double(Rails::Application) }
+    let(:config) { FakeConfiguration.new }
+
+    around(:each) do |example|
+      ::ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+      m =
+        Migrator.new(
+          File.expand_path(
+            "../../../ruby_event_store-active_record/lib/ruby_event_store/active_record/generators/templates",
+            __dir__
+          )
+        )
+      SilenceStdout.silence_stdout { m.run_migration("create_event_store_events") }
+
+      Timeout.timeout(2) { example.run }
+    end
+
+    before do
+      allow(Rails).to receive(:application).and_return(application)
+      allow(application).to receive(:config).and_return(config)
+      Rails.configuration.event_store = event_store
+      ActiveJob::Base.queue_adapter = :async
+      $queue = Queue.new
+    end
+
+    specify "Sidekiq::Worker without ActiveJob that requires serialization" do
+      event_store =
+        RailsEventStore::Client.new(
+          dispatcher: ImmediateAsyncDispatcher.new(scheduler: SidekiqScheduler.new(serializer: YAML))
+        )
+      ev = RailsEventStore::Event.new
+      Sidekiq::Testing.fake! do
+        SidekiqHandlerWithHelper.prepend RailsEventStore::AsyncHandler.with(
+          event_store: event_store,
+          serializer: YAML
+        )
+        event_store.subscribe_to_all_events(SidekiqHandlerWithHelper)
+        event_store.publish(ev)
+        Thread.new { Sidekiq::Worker.drain_all }.join
+      end
+      expect($queue.pop).to eq(ev)
+    end
+  end
+
+  private
+
+  class FakeConfiguration
+    def initialize
+      @options = {}
+    end
+
+    private
+
+    def method_missing(name, *args, &blk)
+      if name.to_s =~ /=$/
+        @options[$`.to_sym] = args.first
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
mainly: 
* moved non-ActiveJobScheduler test cases of `async_handler_helpers_spec.rb` into contrib/sidekiq-scheduler (which results in dev dependency on `rails_event_store` and `rails`)
* duplicated `after_commit_async_dispatcher_spec.rb` test, with a change of scheduler to be SidekiqScheduler, in contrib/sidekiq-scheduler

Additional dependencies in sidekiq-scheduler are a tradeoff we have to make if we want to move the Non-ActiveJobScheduler tests out of `rails_event_store`. The good thing is that those still show usage and are closer to the gem that the user might be interested in.