### PR TITLE
Bump RubyEventStore::ActiveRecord migration version to 5

### DIFF
--- a/rails_event_store/spec/rails_migration_generator_spec.rb
+++ b/rails_event_store/spec/rails_migration_generator_spec.rb
@@ -23,7 +23,7 @@ module RailsEventStore
     end
 
     it "uses particular migration version" do
-      expect(subject).to match(/ActiveRecord::Migration\[4\.2\]$/)
+      expect(subject).to match(/ActiveRecord::Migration\[5\.0\]$/)
     end
 
     it "uses binary data type for metadata" do

--- a/ruby_event_store-active_record/lib/ruby_event_store/active_record/generators/rails_migration_generator.rb
+++ b/ruby_event_store-active_record/lib/ruby_event_store/active_record/generators/rails_migration_generator.rb
@@ -43,7 +43,7 @@ module RubyEventStore
       end
 
       def migration_version
-        "[4.2]"
+        "[5.0]"
       end
 
       def timestamp

--- a/ruby_event_store-active_record/lib/ruby_event_store/active_record/generators/templates/create_event_store_events_template.erb
+++ b/ruby_event_store-active_record/lib/ruby_event_store/active_record/generators/templates/create_event_store_events_template.erb
@@ -8,7 +8,7 @@ class CreateEventStoreEvents < ActiveRecord::Migration<%= migration_version %>
       create_table(:event_store_events_in_streams, id: :bigserial, force: false) do |t|
         t.string      :stream,      null: false
         t.integer     :position,    null: true
-        t.references  :event,       null: false, type: :uuid
+        t.references  :event,       null: false, type: :uuid, index: false
         t.datetime    :created_at,  null: false
       end
       add_index :event_store_events_in_streams, [:stream, :position], unique: true
@@ -16,7 +16,7 @@ class CreateEventStoreEvents < ActiveRecord::Migration<%= migration_version %>
       add_index :event_store_events_in_streams, [:stream, :event_id], unique: true
 
       create_table(:event_store_events, id: :bigserial, force: false) do |t|
-        t.references  :event,       null: false, type: :uuid
+        t.references  :event,       null: false, type: :uuid, index: false
         t.string      :event_type,  null: false
         t.<%= data_type %>      :metadata
         t.<%= data_type %>      :data, null: false

--- a/ruby_event_store-active_record/lib/ruby_event_store/active_record/generators/templates/create_event_store_events_template.erb
+++ b/ruby_event_store-active_record/lib/ruby_event_store/active_record/generators/templates/create_event_store_events_template.erb
@@ -31,7 +31,7 @@ class CreateEventStoreEvents < ActiveRecord::Migration<%= migration_version %>
       create_table(:event_store_events_in_streams, force: false) do |t|
         t.string      :stream,      null: false
         t.integer     :position,    null: true
-        t.references  :event,       null: false, type: :string, limit: 36
+        t.references  :event,       null: false, type: :string, limit: 36, index: false
         t.datetime    :created_at,  null: false, precision: 6
       end
       add_index :event_store_events_in_streams, [:stream, :position], unique: true
@@ -39,7 +39,7 @@ class CreateEventStoreEvents < ActiveRecord::Migration<%= migration_version %>
       add_index :event_store_events_in_streams, [:stream, :event_id], unique: true
 
       create_table(:event_store_events, force: false) do |t|
-        t.references  :event,       null: false, type: :string, limit: 36
+        t.references  :event,       null: false, type: :string, limit: 36, index: false
         t.string      :event_type,  null: false
         t.binary      :metadata
         t.binary      :data,        null: false

--- a/ruby_event_store-active_record/spec/migration_test_spec.rb
+++ b/ruby_event_store-active_record/spec/migration_test_spec.rb
@@ -13,48 +13,99 @@ module RubyEventStore
 
         load_database_schema
 
-        expect(dump_schema.strip).to eq <<~SCHEMA.strip
-          # This file is auto-generated from the current state of the database. Instead
-          # of editing this file, please use the migrations feature of Active Record to
-          # incrementally modify your database, and then regenerate this schema definition.
-          #
-          # This file is the source Rails uses to define your schema when running `bin/rails
-          # db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
-          # be faster and is potentially less error prone than running all of your
-          # migrations from scratch. Old migrations may fail to apply correctly if those
-          # migrations use external dependencies or application code.
-          #
-          # It's strongly recommended that you check this file into your version control system.
-
-          ActiveRecord::Schema[7.0].define(version: 0) do
-            create_table \"event_store_events\", force: :cascade do |t|
-              t.string \"event_id\", limit: 36, null: false
-              t.string \"event_type\", null: false
-              t.binary \"metadata\"
-              t.binary \"data\", null: false
-              t.datetime \"created_at\", null: false
-              t.datetime \"valid_at\"
-              t.index [\"created_at\"], name: \"index_event_store_events_on_created_at\"
-              t.index [\"event_id\"], name: \"index_event_store_events_on_event_id\", unique: true
-              t.index [\"event_type\"], name: \"index_event_store_events_on_event_type\"
-              t.index [\"valid_at\"], name: \"index_event_store_events_on_valid_at\"
-            end
-
-            create_table \"event_store_events_in_streams\", force: :cascade do |t|
-              t.string \"stream\", null: false
-              t.integer \"position\"
-              t.string \"event_id\", limit: 36, null: false
-              t.datetime \"created_at\", null: false
-              t.index [\"created_at\"], name: \"index_event_store_events_in_streams_on_created_at\"
-              t.index [\"stream\", \"event_id\"], name: \"index_event_store_events_in_streams_on_stream_and_event_id\", unique: true
-              t.index [\"stream\", \"position\"], name: \"index_event_store_events_in_streams_on_stream_and_position\", unique: true
-            end
-
-          end
-        SCHEMA
+        expect(dump_schema.strip).to eq expected_schema
       ensure
         drop_database
         close_database_connection
+      end
+
+      private
+
+      def expected_schema
+        if ENV["DATABASE_URL"].include?("postgres")
+          <<~SCHEMA.strip
+            # This file is auto-generated from the current state of the database. Instead
+            # of editing this file, please use the migrations feature of Active Record to
+            # incrementally modify your database, and then regenerate this schema definition.
+            #
+            # This file is the source Rails uses to define your schema when running `bin/rails
+            # db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+            # be faster and is potentially less error prone than running all of your
+            # migrations from scratch. Old migrations may fail to apply correctly if those
+            # migrations use external dependencies or application code.
+            #
+            # It's strongly recommended that you check this file into your version control system.
+
+            ActiveRecord::Schema[7.0].define(version: 2022_12_08_155138) do
+              # These are extensions that must be enabled in order to support this database
+              enable_extension \"plpgsql\"
+
+              create_table \"event_store_events\", force: :cascade do |t|
+                t.uuid \"event_id\", null: false
+                t.string \"event_type\", null: false
+                t.binary \"metadata\"
+                t.binary \"data\", null: false
+                t.datetime \"created_at\", precision: nil, null: false
+                t.datetime \"valid_at\", precision: nil
+                t.index [\"created_at\"], name: \"index_event_store_events_on_created_at\"
+                t.index [\"event_id\"], name: \"index_event_store_events_on_event_id\", unique: true
+                t.index [\"event_type\"], name: \"index_event_store_events_on_event_type\"
+                t.index [\"valid_at\"], name: \"index_event_store_events_on_valid_at\"
+              end
+
+              create_table \"event_store_events_in_streams\", force: :cascade do |t|
+                t.string \"stream\", null: false
+                t.integer \"position\"
+                t.uuid \"event_id\", null: false
+                t.datetime \"created_at\", precision: nil, null: false
+                t.index [\"created_at\"], name: \"index_event_store_events_in_streams_on_created_at\"
+                t.index [\"stream\", \"event_id\"], name: \"index_event_store_events_in_streams_on_stream_and_event_id\", unique: true
+                t.index [\"stream\", \"position\"], name: \"index_event_store_events_in_streams_on_stream_and_position\", unique: true
+              end
+
+            end
+          SCHEMA
+        else
+          <<~SCHEMA.strip
+            # This file is auto-generated from the current state of the database. Instead
+            # of editing this file, please use the migrations feature of Active Record to
+            # incrementally modify your database, and then regenerate this schema definition.
+            #
+            # This file is the source Rails uses to define your schema when running `bin/rails
+            # db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+            # be faster and is potentially less error prone than running all of your
+            # migrations from scratch. Old migrations may fail to apply correctly if those
+            # migrations use external dependencies or application code.
+            #
+            # It's strongly recommended that you check this file into your version control system.
+
+            ActiveRecord::Schema[7.0].define(version: 0) do
+              create_table \"event_store_events\", force: :cascade do |t|
+                t.string \"event_id\", limit: 36, null: false
+                t.string \"event_type\", null: false
+                t.binary \"metadata\"
+                t.binary \"data\", null: false
+                t.datetime \"created_at\", null: false
+                t.datetime \"valid_at\"
+                t.index [\"created_at\"], name: \"index_event_store_events_on_created_at\"
+                t.index [\"event_id\"], name: \"index_event_store_events_on_event_id\", unique: true
+                t.index [\"event_type\"], name: \"index_event_store_events_on_event_type\"
+                t.index [\"valid_at\"], name: \"index_event_store_events_on_valid_at\"
+              end
+
+              create_table \"event_store_events_in_streams\", force: :cascade do |t|
+                t.string \"stream\", null: false
+                t.integer \"position\"
+                t.string \"event_id\", limit: 36, null: false
+                t.datetime \"created_at\", null: false
+                t.index [\"created_at\"], name: \"index_event_store_events_in_streams_on_created_at\"
+                t.index [\"stream\", \"event_id\"], name: \"index_event_store_events_in_streams_on_stream_and_event_id\", unique: true
+                t.index [\"stream\", \"position\"], name: \"index_event_store_events_in_streams_on_stream_and_position\", unique: true
+              end
+
+            end
+          SCHEMA
+        end
       end
     end
   end

--- a/ruby_event_store-active_record/spec/migration_test_spec.rb
+++ b/ruby_event_store-active_record/spec/migration_test_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module RubyEventStore
+  module ActiveRecord
+    ::RSpec.describe "Gold master test for schema" do
+      include SchemaHelper
+
+      specify do
+        establish_database_connection
+        drop_database
+
+        load_database_schema
+
+        expect(dump_schema.strip).to eq <<~SCHEMA.strip
+          # This file is auto-generated from the current state of the database. Instead
+          # of editing this file, please use the migrations feature of Active Record to
+          # incrementally modify your database, and then regenerate this schema definition.
+          #
+          # This file is the source Rails uses to define your schema when running `bin/rails
+          # db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+          # be faster and is potentially less error prone than running all of your
+          # migrations from scratch. Old migrations may fail to apply correctly if those
+          # migrations use external dependencies or application code.
+          #
+          # It's strongly recommended that you check this file into your version control system.
+
+          ActiveRecord::Schema[7.0].define(version: 0) do
+            create_table \"event_store_events\", force: :cascade do |t|
+              t.string \"event_id\", limit: 36, null: false
+              t.string \"event_type\", null: false
+              t.binary \"metadata\"
+              t.binary \"data\", null: false
+              t.datetime \"created_at\", null: false
+              t.datetime \"valid_at\"
+              t.index [\"created_at\"], name: \"index_event_store_events_on_created_at\"
+              t.index [\"event_id\"], name: \"index_event_store_events_on_event_id\", unique: true
+              t.index [\"event_type\"], name: \"index_event_store_events_on_event_type\"
+              t.index [\"valid_at\"], name: \"index_event_store_events_on_valid_at\"
+            end
+
+            create_table \"event_store_events_in_streams\", force: :cascade do |t|
+              t.string \"stream\", null: false
+              t.integer \"position\"
+              t.string \"event_id\", limit: 36, null: false
+              t.datetime \"created_at\", null: false
+              t.index [\"created_at\"], name: \"index_event_store_events_in_streams_on_created_at\"
+              t.index [\"stream\", \"event_id\"], name: \"index_event_store_events_in_streams_on_stream_and_event_id\", unique: true
+              t.index [\"stream\", \"position\"], name: \"index_event_store_events_in_streams_on_stream_and_position\", unique: true
+            end
+
+          end
+        SCHEMA
+      end
+    end
+  end
+end

--- a/ruby_event_store-active_record/spec/migration_test_spec.rb
+++ b/ruby_event_store-active_record/spec/migration_test_spec.rb
@@ -52,6 +52,9 @@ module RubyEventStore
 
           end
         SCHEMA
+      ensure
+        drop_database
+        close_database_connection
       end
     end
   end

--- a/ruby_event_store-active_record/spec/migration_test_spec.rb
+++ b/ruby_event_store-active_record/spec/migration_test_spec.rb
@@ -56,8 +56,12 @@ module RubyEventStore
             end
           SCHEMA
         elsif ENV["DATABASE_URL"].include?("mysql")
+          my_sql_major_version = ::ActiveRecord::Base.connection.select_value("SELECT VERSION();").to_i
+          collation = my_sql_major_version == 8 ? "collation: \"utf8mb4_0900_ai_ci\", " : ""
+          charset = my_sql_major_version == 8 ? "utf8mb4" : "latin1"
+
           <<~SCHEMA.strip
-              create_table "event_store_events", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+              create_table "event_store_events", id: :integer, charset: "#{charset}", #{collation}force: :cascade do |t|
                 t.string "event_id", limit: 36, null: false
                 t.string "event_type", null: false
                 t.binary "metadata"
@@ -70,7 +74,7 @@ module RubyEventStore
                 t.index ["valid_at"], name: "index_event_store_events_on_valid_at"
               end
 
-              create_table "event_store_events_in_streams", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+              create_table "event_store_events_in_streams", id: :integer, charset: "#{charset}", #{collation}force: :cascade do |t|
                 t.string "stream", null: false
                 t.integer "position"
                 t.string "event_id", limit: 36, null: false

--- a/ruby_event_store-active_record/spec/migration_test_spec.rb
+++ b/ruby_event_store-active_record/spec/migration_test_spec.rb
@@ -23,6 +23,7 @@ module RubyEventStore
 
       def expected_schema
         if ENV["DATABASE_URL"].include?("postgres")
+          data_type = ENV["DATA_TYPE"]
           <<~SCHEMA.strip
             # This file is auto-generated from the current state of the database. Instead
             # of editing this file, please use the migrations feature of Active Record to
@@ -43,8 +44,8 @@ module RubyEventStore
               create_table \"event_store_events\", force: :cascade do |t|
                 t.uuid \"event_id\", null: false
                 t.string \"event_type\", null: false
-                t.binary \"metadata\"
-                t.binary \"data\", null: false
+                t.#{data_type} \"metadata\"
+                t.#{data_type} \"data\", null: false
                 t.datetime \"created_at\", precision: nil, null: false
                 t.datetime \"valid_at\", precision: nil
                 t.index [\"created_at\"], name: \"index_event_store_events_on_created_at\"

--- a/ruby_event_store-active_record/spec/migration_test_spec.rb
+++ b/ruby_event_store-active_record/spec/migration_test_spec.rb
@@ -65,6 +65,46 @@ module RubyEventStore
 
             end
           SCHEMA
+        elsif ENV["DATABASE_URL"].include?("mysql")
+          <<~SCHEMA.strip
+            # This file is auto-generated from the current state of the database. Instead
+            # of editing this file, please use the migrations feature of Active Record to
+            # incrementally modify your database, and then regenerate this schema definition.
+            #
+            # This file is the source Rails uses to define your schema when running `bin/rails
+            # db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+            # be faster and is potentially less error prone than running all of your
+            # migrations from scratch. Old migrations may fail to apply correctly if those
+            # migrations use external dependencies or application code.
+            #
+            # It's strongly recommended that you check this file into your version control system.
+
+            ActiveRecord::Schema[7.0].define(version: 0) do
+              create_table "event_store_events", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+                t.string "event_id", limit: 36, null: false
+                t.string "event_type", null: false
+                t.binary "metadata"
+                t.binary "data", null: false
+                t.datetime "created_at", null: false
+                t.datetime "valid_at"
+                t.index ["created_at"], name: "index_event_store_events_on_created_at"
+                t.index ["event_id"], name: "index_event_store_events_on_event_id", unique: true
+                t.index ["event_type"], name: "index_event_store_events_on_event_type"
+                t.index ["valid_at"], name: "index_event_store_events_on_valid_at"
+              end
+
+              create_table "event_store_events_in_streams", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+                t.string "stream", null: false
+                t.integer "position"
+                t.string "event_id", limit: 36, null: false
+                t.datetime "created_at", null: false
+                t.index ["created_at"], name: "index_event_store_events_in_streams_on_created_at"
+                t.index ["stream", "event_id"], name: "index_event_store_events_in_streams_on_stream_and_event_id", unique: true
+                t.index ["stream", "position"], name: "index_event_store_events_in_streams_on_stream_and_position", unique: true
+              end
+
+            end
+          SCHEMA
         else
           <<~SCHEMA.strip
             # This file is auto-generated from the current state of the database. Instead

--- a/ruby_event_store-active_record/spec/migration_test_spec.rb
+++ b/ruby_event_store-active_record/spec/migration_test_spec.rb
@@ -13,7 +13,7 @@ module RubyEventStore
 
         load_database_schema
 
-        expect(dump_schema.strip).to eq expected_schema
+        expect(table_schema).to eq expected_schema
       ensure
         drop_database
         close_database_connection
@@ -21,26 +21,15 @@ module RubyEventStore
 
       private
 
+      def table_schema
+        schema = dump_schema
+        schema[schema.index("create_table")..schema.length - 1].strip
+      end
+
       def expected_schema
         if ENV["DATABASE_URL"].include?("postgres")
           data_type = ENV["DATA_TYPE"]
           <<~SCHEMA.strip
-            # This file is auto-generated from the current state of the database. Instead
-            # of editing this file, please use the migrations feature of Active Record to
-            # incrementally modify your database, and then regenerate this schema definition.
-            #
-            # This file is the source Rails uses to define your schema when running `bin/rails
-            # db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
-            # be faster and is potentially less error prone than running all of your
-            # migrations from scratch. Old migrations may fail to apply correctly if those
-            # migrations use external dependencies or application code.
-            #
-            # It's strongly recommended that you check this file into your version control system.
-
-            ActiveRecord::Schema[7.0].define(version: 2022_12_08_155138) do
-              # These are extensions that must be enabled in order to support this database
-              enable_extension \"plpgsql\"
-
               create_table \"event_store_events\", force: :cascade do |t|
                 t.uuid \"event_id\", null: false
                 t.string \"event_type\", null: false
@@ -68,19 +57,6 @@ module RubyEventStore
           SCHEMA
         elsif ENV["DATABASE_URL"].include?("mysql")
           <<~SCHEMA.strip
-            # This file is auto-generated from the current state of the database. Instead
-            # of editing this file, please use the migrations feature of Active Record to
-            # incrementally modify your database, and then regenerate this schema definition.
-            #
-            # This file is the source Rails uses to define your schema when running `bin/rails
-            # db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
-            # be faster and is potentially less error prone than running all of your
-            # migrations from scratch. Old migrations may fail to apply correctly if those
-            # migrations use external dependencies or application code.
-            #
-            # It's strongly recommended that you check this file into your version control system.
-
-            ActiveRecord::Schema[7.0].define(version: 0) do
               create_table "event_store_events", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
                 t.string "event_id", limit: 36, null: false
                 t.string "event_type", null: false
@@ -108,19 +84,6 @@ module RubyEventStore
           SCHEMA
         else
           <<~SCHEMA.strip
-            # This file is auto-generated from the current state of the database. Instead
-            # of editing this file, please use the migrations feature of Active Record to
-            # incrementally modify your database, and then regenerate this schema definition.
-            #
-            # This file is the source Rails uses to define your schema when running `bin/rails
-            # db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
-            # be faster and is potentially less error prone than running all of your
-            # migrations from scratch. Old migrations may fail to apply correctly if those
-            # migrations use external dependencies or application code.
-            #
-            # It's strongly recommended that you check this file into your version control system.
-
-            ActiveRecord::Schema[7.0].define(version: 0) do
               create_table \"event_store_events\", force: :cascade do |t|
                 t.string \"event_id\", limit: 36, null: false
                 t.string \"event_type\", null: false

--- a/support/helpers/migrator.rb
+++ b/support/helpers/migrator.rb
@@ -37,7 +37,7 @@ class Migrator
   end
 
   def migration_version
-    "[4.2]"
+    "[5.0]"
   end
 
   def migration_template(name)


### PR DESCRIPTION
* Generated reference schema dumps for sqlite, postgres, mysql5 and mysql8
* The schema dump is used for assertions
* Bumped defaults of RES::AR templates with the goal that the output schema stays the same
* Didn't touch contrib 
* I don't like the way the test is shaped. However, the reason for that is the fact that we're testing multiple configurations which output differs. Willing to take any advice to refactor this part.