### PR TITLE
fix(activerecord): use created_at for fallback in #as_of when valid_a…

### DIFF
--- a/ruby_event_store-active_record/lib/ruby_event_store/active_record/event_repository_reader.rb
+++ b/ruby_event_store-active_record/lib/ruby_event_store/active_record/event_repository_reader.rb
@@ -116,7 +116,7 @@ module RubyEventStore
         when :as_at
           stream.order("#{@event_klass.table_name}.created_at #{order(spec)}")
         when :as_of
-          stream.order("#{@event_klass.table_name}.valid_at #{order(spec)}")
+          stream.order(Arel.sql("COALESCE(#{@event_klass.table_name}.valid_at, #{@event_klass.table_name}.created_at) #{order(spec)}"))
         else
           stream
         end

--- a/ruby_event_store-active_record/spec/event_repository_spec.rb
+++ b/ruby_event_store-active_record/spec/event_repository_spec.rb
@@ -264,7 +264,7 @@ module RubyEventStore
                     2
         expect {
           repository.read(specification.in_batches.as_of.result).to_a
-        }.to match_query /SELECT.*FROM.*event_store_events.*ORDER BY .*event_store_events.*valid_at.*,.*event_store_events.*id.* ASC LIMIT.*.OFFSET.*/,
+        }.to match_query /SELECT.*FROM.*event_store_events.*ORDER BY .*COALESCE(.*event_store_events.*valid_at, .*event_store_events.*created_at.*).*,.*event_store_events.*id.* ASC LIMIT.*.OFFSET.*/,
                     2
       end
 


### PR DESCRIPTION
fix(activerecord): use created_at for fallback in #as_of when valid_at is nil

We encountered an issue when using bi-temporal and non-bi-temporal events with a client reader.

1. Event timestamp: 6.minutes.ago
2. Event timestamp: 3.minute.ago
3. Event valid_at: 5.minutes.ago
4. Event valid_at: 4.minutes.ago


`event_store.read.as_at` gives the expected order (`ORDER BY created_at`): 1, 2, 3, 4

But `event_store.read.as_of`

Expected result: 1, 3, 4, 2
Actual result: 3, 4, 1, 2

Why? Because `valid_at` of non-bi-temporal events 1 and 2 is `NULL` in database, and it only gets `ORDER BY valid_at`, so these events get either prepended or appended in result list.

The fix uses COALESCE, to fall back to `created_at`, when `valid_at` is null.