### PR TITLE
fix(activerecord): #as_of filter by time

### DIFF
--- a/ruby_event_store-active_record/lib/ruby_event_store/active_record/event_repository_reader.rb
+++ b/ruby_event_store-active_record/lib/ruby_event_store/active_record/event_repository_reader.rb
@@ -163,20 +163,28 @@ module RubyEventStore
         )
       end
 
+      def time_comparison_field(specification)
+        if specification.time_sort_by_as_of?
+          "COALESCE(#{@event_klass.table_name}.valid_at, #{@event_klass.table_name}.created_at)"
+        else
+          "#{@event_klass.table_name}.created_at"
+        end
+      end
+
       def older_than_condition(specification)
-        ["#{@event_klass.table_name}.created_at < ?", specification.older_than]
+        ["#{time_comparison_field(specification)} < ?", specification.older_than]
       end
 
       def older_than_or_equal_condition(specification)
-        ["#{@event_klass.table_name}.created_at <= ?", specification.older_than_or_equal]
+        ["#{time_comparison_field(specification)} <= ?", specification.older_than_or_equal]
       end
 
       def newer_than_condition(specification)
-        ["#{@event_klass.table_name}.created_at > ?", specification.newer_than]
+        ["#{time_comparison_field(specification)} > ?", specification.newer_than]
       end
 
       def newer_than_or_equal_condition(specification)
-        ["#{@event_klass.table_name}.created_at >= ?", specification.newer_than_or_equal]
+        ["#{time_comparison_field(specification)} >= ?", specification.newer_than_or_equal]
       end
 
       def order(spec)


### PR DESCRIPTION
Using bi-temporal event sourcing with `valid_at` the order of the stream when using `#as_of` was fixed with https://github.com/RailsEventStore/rails_event_store/pull/1518 

I encountered another bug when using `#as_of` in combination with time filtering e.g. `older_than(time)`

`event_store.read.stream('stream').as_of.older_than(time).backward.limit(1).first`

Expected: Get the **valid** event before a given point in time.
Actual: The last event _created_ before that time.

Why? The following methods in `event_repository_reader.rb` use only `created_at` for filtering by time:

`older_than(time)`
`older_than_or_equal(time)`
`newer_than(time)`
`newer_than_or_equal(time)`

This fix uses `COALESCE(valid_at, created_at)` when filtering by time using `#as_of`.