### PR TITLE
Ensure RubyEventStore::Projection yield events in order when using multiple stream names

### DIFF
--- a/ruby_event_store/lib/ruby_event_store/projection.rb
+++ b/ruby_event_store/lib/ruby_event_store/projection.rb
@@ -65,9 +65,45 @@ module RubyEventStore
       raise ArgumentError.new("Start must be an array with event ids") unless valid_starting_point?(start)
       streams
         .zip(start_events(start))
-        .reduce(initial_state) do |state, (stream_name, start_event_id)|
-          read_scope(event_store, stream_name, count, start_event_id).reduce(state, &method(:transition))
+        .map { |stream_name, start_event_id|
+          read_scope(event_store, stream_name, count, start_event_id)
+        }
+        .then(&method(:enumerate_events_in_order_from_streams))
+        .reduce(initial_state, &method(:transition))
+    end
+
+    def enumerate_events_in_order_from_streams(scopes)
+      enumerators = scopes.map.with_index { |c, i| [i, c.to_enum] }.to_h
+      # keep track of which enumerators are active
+      active_enumerators = enumerators.map { true }
+
+      Enumerator.new do |y|
+        # Load initial candicdate values of the enumerator
+        memo = enumerators.map do |i, enumerator|
+          enumerator.next
+        rescue StopIteration
+          active_enumerators[i] = false
         end
+
+        while active_enumerators.any? do
+          value_index = begin
+            memo
+              .map.with_index { |e, i| [e, i] } # keep track of index
+              .select { |_, i| active_enumerators[i] } # ignore memo position of stopped enumerators
+              .map { |e, i| [e&.timestamp, i] } # yield the value we want to sort by
+              .sort_by(&:first) # sort by that value
+              .first.last # get the first result after sorting, and return the index
+          end
+
+          y.yield(memo[value_index])
+
+          begin
+            memo[value_index] = enumerators[value_index].next
+          rescue StopIteration
+            active_enumerators[value_index] = false
+          end
+        end
+      end
     end
 
     def reduce_from_all_streams(event_store, start, count)

--- a/ruby_event_store/spec/projection_spec.rb
+++ b/ruby_event_store/spec/projection_spec.rb
@@ -48,28 +48,27 @@ module RubyEventStore
       expect(account_balance).to eq(total: 5)
     end
 
-    specify "reduce events from many streams in order" do
-      event_store.with_metadata(timestamp: Time.utc(2018, 1, 1, 1, 1, 1)) {
-        event_store.append(MoneyDeposited.new(data: { order: 1 }), stream_name: "Customer$1")
-      }
-      event_store.with_metadata(timestamp: Time.utc(2018, 1, 1, 1, 1, 2)) {
-        event_store.append(MoneyDeposited.new(data: { order: 2 }), stream_name: "Customer$1")
-      }
-      event_store.with_metadata(timestamp: Time.utc(2018, 1, 1, 1, 1, 3)) {
-        event_store.append(MoneyDeposited.new(data: { order: 3 }), stream_name: "Customer$2")
-      }
+specify "reduce events from many streams in order" do
+  event_store.with_metadata(timestamp: Time.utc(2018, 1, 1, 1, 1, 1)) {
+    event_store.append(MoneyDeposited.new(data: { order: 1 }), stream_name: "Customer$1")
+  }
+  event_store.with_metadata(timestamp: Time.utc(2018, 1, 1, 1, 1, 2)) {
+    event_store.append(MoneyDeposited.new(data: { order: 2 }), stream_name: "Customer$1")
+  }
+  event_store.with_metadata(timestamp: Time.utc(2018, 1, 1, 1, 1, 3)) {
+    event_store.append(MoneyDeposited.new(data: { order: 3 }), stream_name: "Customer$2")
+  }
 
-      account_balance =
-        Projection
-          .from_stream(%w[Customer$2 Customer$1])
-          .init(-> { { order: nil } })
-          .when(MoneyDeposited, ->(state, event) {
-            puts event.timestamp
-            state[:order] = event.data[:order]
-          })
-          .run(event_store)
-      expect(account_balance).to eq(order: 3)
-    end
+  account_balance =
+    Projection
+      .from_stream(%w[Customer$2 Customer$1])
+      .init(-> { { order: nil } })
+      .when(MoneyDeposited, ->(state, event) {
+        state[:order] = event.data[:order]
+      })
+      .run(event_store)
+  expect(account_balance).to eq(order: 3)
+end
 
     specify "raises proper errors when wrong argument were passed (stream mode)" do
       projection =

--- a/ruby_event_store/spec/projection_spec.rb
+++ b/ruby_event_store/spec/projection_spec.rb
@@ -48,27 +48,27 @@ module RubyEventStore
       expect(account_balance).to eq(total: 5)
     end
 
-specify "reduce events from many streams in order" do
-  event_store.with_metadata(timestamp: Time.utc(2018, 1, 1, 1, 1, 1)) {
-    event_store.append(MoneyDeposited.new(data: { order: 1 }), stream_name: "Customer$1")
-  }
-  event_store.with_metadata(timestamp: Time.utc(2018, 1, 1, 1, 1, 2)) {
-    event_store.append(MoneyDeposited.new(data: { order: 2 }), stream_name: "Customer$1")
-  }
-  event_store.with_metadata(timestamp: Time.utc(2018, 1, 1, 1, 1, 3)) {
-    event_store.append(MoneyDeposited.new(data: { order: 3 }), stream_name: "Customer$2")
-  }
+    specify "reduce events from many streams in order" do
+      event_store.with_metadata(timestamp: Time.utc(2018, 1, 1, 1, 1, 1)) {
+        event_store.append(MoneyDeposited.new(data: { order: 1 }), stream_name: "Customer$1")
+      }
+      event_store.with_metadata(timestamp: Time.utc(2018, 1, 1, 1, 1, 2)) {
+        event_store.append(MoneyDeposited.new(data: { order: 2 }), stream_name: "Customer$1")
+      }
+      event_store.with_metadata(timestamp: Time.utc(2018, 1, 1, 1, 1, 3)) {
+        event_store.append(MoneyDeposited.new(data: { order: 3 }), stream_name: "Customer$2")
+      }
 
-  account_balance =
-    Projection
-      .from_stream(%w[Customer$2 Customer$1])
-      .init(-> { { order: nil } })
-      .when(MoneyDeposited, ->(state, event) {
-        state[:order] = event.data[:order]
-      })
-      .run(event_store)
-  expect(account_balance).to eq(order: 3)
-end
+      account_balance =
+        Projection
+          .from_stream(%w[Customer$2 Customer$1])
+          .init(-> { { order: nil } })
+          .when(MoneyDeposited, ->(state, event) {
+            state[:order] = event.data[:order]
+          })
+          .run(event_store)
+      expect(account_balance).to eq(order: 3)
+    end
 
     specify "raises proper errors when wrong argument were passed (stream mode)" do
       projection =

--- a/ruby_event_store/spec/projection_spec.rb
+++ b/ruby_event_store/spec/projection_spec.rb
@@ -48,6 +48,29 @@ module RubyEventStore
       expect(account_balance).to eq(total: 5)
     end
 
+    specify "reduce events from many streams in order" do
+      event_store.with_metadata(timestamp: Time.utc(2018, 1, 1, 1, 1, 1)) {
+        event_store.append(MoneyDeposited.new(data: { order: 1 }), stream_name: "Customer$1")
+      }
+      event_store.with_metadata(timestamp: Time.utc(2018, 1, 1, 1, 1, 2)) {
+        event_store.append(MoneyDeposited.new(data: { order: 2 }), stream_name: "Customer$1")
+      }
+      event_store.with_metadata(timestamp: Time.utc(2018, 1, 1, 1, 1, 3)) {
+        event_store.append(MoneyDeposited.new(data: { order: 3 }), stream_name: "Customer$2")
+      }
+
+      account_balance =
+        Projection
+          .from_stream(%w[Customer$2 Customer$1])
+          .init(-> { { order: nil } })
+          .when(MoneyDeposited, ->(state, event) {
+            puts event.timestamp
+            state[:order] = event.data[:order]
+          })
+          .run(event_store)
+      expect(account_balance).to eq(order: 3)
+    end
+
     specify "raises proper errors when wrong argument were passed (stream mode)" do
       projection =
         Projection


### PR DESCRIPTION
This is a fix for #1550 

In this solution we convert the streams into enumerators, yielding each time the value with the smaller timestamp until each stream is fully consumed.

This makes some assumptions:

* All events respond to timestamp
* Streams always return an event (no nil values can be returned)
* Streams can be converted to enumerators using `to_enum`

Happy to take further feedback.