### PR TITLE
Fix deep stringify keys in serializer for sidekiq scheduler

### DIFF
--- a/contrib/ruby_event_store-sidekiq_scheduler/lib/ruby_event_store/sidekiq_scheduler.rb
+++ b/contrib/ruby_event_store-sidekiq_scheduler/lib/ruby_event_store/sidekiq_scheduler.rb
@@ -1,4 +1,5 @@
 require "sidekiq"
+require "active_support/core_ext/hash/keys"
 
 module RubyEventStore
   class SidekiqScheduler
@@ -7,7 +8,7 @@ module RubyEventStore
     end
 
     def call(klass, record)
-      klass.perform_async(record.serialize(serializer).to_h.transform_keys(&:to_s))
+      klass.perform_async(record.serialize(serializer).to_h.deep_stringify_keys)
     end
 
     def verify(subscriber)

--- a/contrib/ruby_event_store-sidekiq_scheduler/lib/ruby_event_store/sidekiq_scheduler.rb
+++ b/contrib/ruby_event_store-sidekiq_scheduler/lib/ruby_event_store/sidekiq_scheduler.rb
@@ -8,7 +8,7 @@ module RubyEventStore
     end
 
     def call(klass, record)
-      klass.perform_async(record.serialize(serializer).to_h.deep_stringify_keys)
+      klass.perform_async(deep_transform_keys(record.serialize(serializer).to_h, &:to_s))
     end
 
     def verify(subscriber)
@@ -18,5 +18,13 @@ module RubyEventStore
     private
 
     attr_reader :serializer
+
+    def deep_transform_keys(hash, &block)
+      result = {}
+      hash.each do |key, value|
+        result[yield(key)] = value.instance_of?(Hash) ? deep_transform_keys(value, &block) : value
+      end
+      result
+    end
   end
 end


### PR DESCRIPTION
Deep stringify the keys for sidekiq scheduler, so that sidekiq does not complain when using `RubyEventStore::NULL` serializer.