### PR TITLE
Fix read as of last

### DIFF
--- a/ruby_event_store-active_record/lib/ruby_event_store/active_record/event_repository_reader.rb
+++ b/ruby_event_store-active_record/lib/ruby_event_store/active_record/event_repository_reader.rb
@@ -114,7 +114,11 @@ module RubyEventStore
       end
 
       def as_of(spec)
-        Arel.sql("COALESCE(#{@event_klass.table_name}.valid_at, #{@event_klass.table_name}.created_at) #{order(spec)}")
+        Arel::Nodes::NamedFunction.new(
+          "COALESCE",
+          [@event_klass.arel_table[:valid_at], @event_klass.arel_table[:created_at]]
+        )
+        .public_send("#{order(spec).downcase}")
       end
 
       def as_at(spec)


### PR DESCRIPTION
fixes 
```
:in `block in reverse_sql_order': Order "COALESCE(event_store_events.valid_at, event_store_events.created_at) ASC" cannot be reversed automatically (ActiveRecord::IrreversibleOrderError)
```