### PR TITLE
Fix projections with bi-temporal event stream

### DIFF
--- a/ruby_event_store/lib/ruby_event_store/projection.rb
+++ b/ruby_event_store/lib/ruby_event_store/projection.rb
@@ -76,7 +76,7 @@ module RubyEventStore
     end
 
     def read_scope(event_store, stream, count, start)
-      scope = event_store.read.in_batches(count)
+      scope = event_store.read.in_batches(count).as_of
       scope = scope.of_type(handled_events)
       scope = scope.stream(stream) if stream
       scope = scope.from(start) if start


### PR DESCRIPTION
Projections don't play with bi-temporal event sourcing at all.

I followed the discussions and tickets from RES 3.0 ( #1463 + #1552 + #1561) and I know, that this will become obsolete, when the "Projections redesigned" (https://github.com/RailsEventStore/rails_event_store/pull/1561/commits/f76c43dc4bc0ed1a08446c969dc257dfab16a8e4) is merged.

Then we can finally use:

```ruby
  Projection
    .new(0)
    .on(MoneyDeposited) { |state, event| state += event.data[:amount] }
    .on(MoneyWithdrawn) { |state, event| state -= event.data[:amount] }
    .call(event_store.read.stream(stream_name).from(starting.event_id).in_batches(2).as_of)
```

But for now, I would appreciate this fix, if there is nothing against it. 

Please have a look at the changed specs, as I don't know if we really need `time_sort_by=nil`.

When using non-bi-temporal events (without `valid_at`) the projection is now ordered by `timestamp` (but sadly, this doesn't fix #1550)