### PR TITLE
Extend profile to work for mysql

### DIFF
--- a/APP_TEMPLATE
+++ b/APP_TEMPLATE
@@ -7,11 +7,21 @@ class Profile
   private attr_reader :options, :location
 
   def client
-    postgres? ? "RailsEventStore::JSONClient.new" : "RailsEventStore::Client.new"
+    if postgres? || mysql?
+      "RailsEventStore::JSONClient.new"
+    else
+      "RailsEventStore::Client.new"
+    end
   end
 
   def data_type
-    postgres? ? "jsonb" : "binary"
+    if postgres?
+      "jsonb"
+    elsif mysql?
+      "json"
+    else
+      "binary"
+    end
   end
 
   def for_existing_app
@@ -22,6 +32,10 @@ class Profile
 
   def existing_app?
     !!location
+  end
+
+  def mysql?
+    database.downcase.eql?("mysql2") || database.downcase.eql?("mysql")
   end
 
   def postgres?

--- a/APP_TEMPLATE
+++ b/APP_TEMPLATE
@@ -35,7 +35,7 @@ class Profile
   end
 
   def mysql?
-    database.downcase.eql?("mysql2") || database.downcase.eql?("mysql")
+    %w[mysql2 mysql trilogy].include?(database.downcase)
   end
 
   def postgres?

--- a/APP_TEMPLATE
+++ b/APP_TEMPLATE
@@ -85,9 +85,7 @@ CODE
 
 route "mount RailsEventStore::Browser => '/res' if Rails.env.development?"
 
-profile.for_existing_app do
-  run_bundle unless run "bundle check"
-end
+profile.for_existing_app { run_bundle unless run "bundle check" }
 
 after_bundle do
   rails_command "db:create"
@@ -95,6 +93,4 @@ after_bundle do
   rails_command "db:migrate"
 end
 
-profile.for_existing_app do
-  run_after_bundle_callbacks
-end
+profile.for_existing_app { run_after_bundle_callbacks }


### PR DESCRIPTION
Since mysql supports json format now, profile should take that into consideration and generate JSONClient instead of regular one.

Should be merged once we agree that JSONClient is a good default for MySQL with json columns