### PR TITLE
Rubocop strictly as a linter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,19 +1,19 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
+  SuggestExtensions: false
+  DisabledByDefault: true
+  NewCops: enable
   Exclude:
-    - ruby_event_store-active_record/active_record/lib/ruby_event_store/active_record/generators/templates/*
-    - bounded_context/lib/generators/templates/*
-    - support/helpers/0_18_2_migration_template.rb
-    - contrib/**/*
     - railseventstore.org/**/*
-    - bounded_context/spec/dummy_*/**/*
+    - contrib/**/*
+    - "**/generators/templates/**/*"
     - "**/bin/*"
-    - ruby_event_store-browser/elm/node_modules/**/*
+    - "**/*_spec.rb"
+    - "**/*_test.rb"
+    - "**/*_lint.rb"
 
-Lint/UselessAssignment:
-  Exclude:
-    - ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
-    - "**/spec/*"
+Lint:
+  Enabled: true
 
 Lint/SuppressedException:
   Enabled: false


### PR DESCRIPTION
Some interesting results that make us consider using it.
First step is to resolve existing warnings, or mute them.
Next: add this lint as a step in the CI and Makefile tooling.

https://github.com/RailsEventStore/rails_event_store/issues/630

Co-authored-by: Łukasz Reszke <lukaszreszke93@gmail.com>
Co-authored-by: Szymon Fiedler <szymon.fiedler@gmail.com>
