### PR TITLE
same behavior of adapters when reading from or to non existent event 

### DIFF
--- a/ruby_event_store-active_record/lib/ruby_event_store/active_record/event_repository_reader.rb
+++ b/ruby_event_store-active_record/lib/ruby_event_store/active_record/event_repository_reader.rb
@@ -140,7 +140,7 @@ module RubyEventStore
           @stream_klass.table_name
         )
       rescue ::ActiveRecord::RecordNotFound
-        raise RubyEventStore::EventNotFoundInStream.new(specification.start)
+        raise EventNotFoundInStream
       end
 
       def stop_condition(specification)
@@ -150,7 +150,7 @@ module RubyEventStore
           @stream_klass.table_name
         )
       rescue ::ActiveRecord::RecordNotFound
-        raise RubyEventStore::EventNotFoundInStream.new(specification.stop)
+        raise EventNotFoundInStream
       end
 
       def start_condition_in_global_stream(specification)
@@ -160,7 +160,7 @@ module RubyEventStore
           @event_klass.table_name
         )
       rescue ::ActiveRecord::RecordNotFound
-        raise RubyEventStore::EventNotFound.new(specification.start)
+        raise EventNotFound.new(specification.start)
       end
 
       def stop_condition_in_global_stream(specification)
@@ -170,7 +170,7 @@ module RubyEventStore
           @event_klass.table_name
         )
       rescue ::ActiveRecord::RecordNotFound
-        raise RubyEventStore::EventNotFound.new(specification.stop)
+        raise EventNotFound.new(specification.stop)
       end
 
       def coalesce(*exprs)

--- a/ruby_event_store-active_record/lib/ruby_event_store/active_record/event_repository_reader.rb
+++ b/ruby_event_store-active_record/lib/ruby_event_store/active_record/event_repository_reader.rb
@@ -140,7 +140,7 @@ module RubyEventStore
           @stream_klass.table_name
         )
       rescue ::ActiveRecord::RecordNotFound
-        raise EventNotFoundInStream
+        raise EventNotFound.new(specification.start)
       end
 
       def stop_condition(specification)
@@ -150,7 +150,7 @@ module RubyEventStore
           @stream_klass.table_name
         )
       rescue ::ActiveRecord::RecordNotFound
-        raise EventNotFoundInStream
+        raise EventNotFound.new(specification.stop)
       end
 
       def start_condition_in_global_stream(specification)

--- a/ruby_event_store-active_record/lib/ruby_event_store/active_record/event_repository_reader.rb
+++ b/ruby_event_store-active_record/lib/ruby_event_store/active_record/event_repository_reader.rb
@@ -139,6 +139,8 @@ module RubyEventStore
           @stream_klass.find_by!(event_id: specification.start, stream: specification.stream.name),
           @stream_klass.table_name
         )
+      rescue ::ActiveRecord::RecordNotFound
+        raise RubyEventStore::EventNotFoundInStream.new(specification.start)
       end
 
       def stop_condition(specification)
@@ -147,6 +149,8 @@ module RubyEventStore
           @stream_klass.find_by!(event_id: specification.stop, stream: specification.stream.name),
           @stream_klass.table_name
         )
+      rescue ::ActiveRecord::RecordNotFound
+        raise RubyEventStore::EventNotFoundInStream.new(specification.stop)
       end
 
       def start_condition_in_global_stream(specification)
@@ -155,6 +159,8 @@ module RubyEventStore
           @event_klass.find_by!(event_id: specification.start),
           @event_klass.table_name
         )
+      rescue ::ActiveRecord::RecordNotFound
+        raise RubyEventStore::EventNotFound.new(specification.start)
       end
 
       def stop_condition_in_global_stream(specification)
@@ -163,6 +169,8 @@ module RubyEventStore
           @event_klass.find_by!(event_id: specification.stop),
           @event_klass.table_name
         )
+      rescue ::ActiveRecord::RecordNotFound
+        raise RubyEventStore::EventNotFound.new(specification.stop)
       end
 
       def coalesce(*exprs)

--- a/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
+++ b/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
@@ -150,12 +150,8 @@ module RubyEventStore
       serialized_records = serialized_records.select { |e| spec.with_types.any? { |x| x.eql?(e.event_type) } } if spec
         .with_types?
       serialized_records = serialized_records.reverse if spec.backward?
-      begin
-        serialized_records = serialized_records.drop(index_of(serialized_records, spec.start) + 1) if spec.start
-        serialized_records = serialized_records.take(index_of(serialized_records, spec.stop)) if spec.stop
-      rescue EventNotFound => e
-        raise spec.stream.global? ? e : EventNotFoundInStream
-      end
+      serialized_records = serialized_records.drop(index_of(serialized_records, spec.start) + 1) if spec.start
+      serialized_records = serialized_records.take(index_of(serialized_records, spec.stop)) if spec.stop
       serialized_records = serialized_records.take(spec.limit) if spec.limit?
       serialized_records = serialized_records.select { |sr| Time.iso8601(time_comparison_field(spec, sr)) < spec.older_than } if spec
         .older_than

--- a/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
@@ -1055,6 +1055,36 @@ module RubyEventStore
       expect(repository.read(specification.to(events[4].event_id).backward.read_last.result)).to be_nil
     end
 
+    specify do
+      event = SRecord.new
+      repository.append_to_stream([event], Stream.new('dummy'), ExpectedVersion.any)
+      expect do
+        repository.read(specification.stream('another').from(event.event_id).result).to_a
+      end.to raise_error(RubyEventStore::EventNotFoundInStream)
+    end
+
+    specify do
+      event = SRecord.new
+      repository.append_to_stream([event], Stream.new('dummy'), ExpectedVersion.any)
+      expect do
+        repository.read(specification.stream('another').to(event.event_id).result).to_a
+      end.to raise_error(RubyEventStore::EventNotFoundInStream)
+    end
+
+    specify do
+      not_existing_uuid = SecureRandom.uuid
+      expect do
+        repository.read(specification.from(not_existing_uuid).result).to_a
+      end.to raise_error(RubyEventStore::EventNotFound)
+    end
+
+    specify do
+      not_existing_uuid = SecureRandom.uuid
+      expect do
+        repository.read(specification.to(not_existing_uuid).result).to_a
+      end.to raise_error(RubyEventStore::EventNotFound)
+    end
+
     context "#update_messages" do
       specify "changes events" do
         skip unless helper.supports_upsert?

--- a/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
@@ -1060,7 +1060,7 @@ module RubyEventStore
       repository.append_to_stream([event], Stream.new('dummy'), ExpectedVersion.any)
       expect do
         repository.read(specification.stream('another').from(event.event_id).result).to_a
-      end.to raise_error(RubyEventStore::EventNotFoundInStream)
+      end.to raise_error(RubyEventStore::EventNotFound, "Event not found: #{event.event_id}")
     end
 
     specify do
@@ -1068,7 +1068,7 @@ module RubyEventStore
       repository.append_to_stream([event], Stream.new('dummy'), ExpectedVersion.any)
       expect do
         repository.read(specification.stream('another').to(event.event_id).result).to_a
-      end.to raise_error(RubyEventStore::EventNotFoundInStream)
+      end.to raise_error(RubyEventStore::EventNotFound, "Event not found: #{event.event_id}")
     end
 
     specify do

--- a/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
@@ -1075,14 +1075,14 @@ module RubyEventStore
       not_existing_uuid = SecureRandom.uuid
       expect do
         repository.read(specification.from(not_existing_uuid).result).to_a
-      end.to raise_error(RubyEventStore::EventNotFound)
+      end.to raise_error(RubyEventStore::EventNotFound, "Event not found: #{not_existing_uuid}")
     end
 
     specify do
       not_existing_uuid = SecureRandom.uuid
       expect do
         repository.read(specification.to(not_existing_uuid).result).to_a
-      end.to raise_error(RubyEventStore::EventNotFound)
+      end.to raise_error(RubyEventStore::EventNotFound, "Event not found: #{not_existing_uuid}")
     end
 
     context "#update_messages" do

--- a/ruby_event_store/lib/ruby_event_store/specification.rb
+++ b/ruby_event_store/lib/ruby_event_store/specification.rb
@@ -28,7 +28,6 @@ module RubyEventStore
     # @return [Specification]
     def from(start)
       raise InvalidPageStart if start.nil? || start.empty?
-      raise EventNotFound.new(start) unless reader.has_event?(start)
       Specification.new(reader, result.dup { |r| r.start = start })
     end
 
@@ -39,7 +38,6 @@ module RubyEventStore
     # @return [Specification]
     def to(stop)
       raise InvalidPageStop if stop.nil? || stop.empty?
-      raise EventNotFound.new(stop) unless reader.has_event?(stop)
       Specification.new(reader, result.dup { |r| r.stop = stop })
     end
 

--- a/ruby_event_store/lib/ruby_event_store/specification_reader.rb
+++ b/ruby_event_store/lib/ruby_event_store/specification_reader.rb
@@ -29,12 +29,6 @@ module RubyEventStore
       repository.count(specification_result)
     end
 
-    # @api private
-    # @private
-    def has_event?(event_id)
-      repository.has_event?(event_id)
-    end
-
     private
 
     attr_reader :repository, :mapper

--- a/ruby_event_store/spec/client_spec.rb
+++ b/ruby_event_store/spec/client_spec.rb
@@ -341,19 +341,6 @@ module RubyEventStore
       expect { client.read.backward.stream("").limit(100).to_a }.to raise_error(IncorrectStreamData)
     end
 
-    specify "raise exception if event_id does not exist" do
-      expect { client.read.stream("stream_name").from("0").limit(100).to_a }.to raise_error(
-        EventNotFound,
-        /Event not found: 0/
-      )
-      expect { client.read.backward.stream("stream_name").from("0").limit(100).to_a }.to raise_error(EventNotFound, /0/)
-    end
-
-    specify "raise exception if event_id is not given or invalid" do
-      expect { client.read.stream("stream_name").from(nil).limit(100).to_a }.to raise_error(InvalidPageStart)
-      expect { client.read.backward.stream("stream_name").from(:invalid).limit(100).to_a }.to raise_error(EventNotFound)
-    end
-
     specify "fails when page size is invalid" do
       expect { client.read.stream("stream_name").limit(0).to_a }.to raise_error(InvalidPageSize)
       expect { client.read.backward.stream("stream_name").limit(0).to_a }.to raise_error(InvalidPageSize)
@@ -410,9 +397,11 @@ module RubyEventStore
         client.publish(event, stream_name: "stream_name")
       end
 
-      expect { client.read.stream("stream_name").from(SecureRandom.uuid).limit(100).to_a }.to raise_error(EventNotFound)
+      expect { client.read.stream("stream_name").from(SecureRandom.uuid).limit(100).to_a }.to raise_error(
+        EventNotFoundInStream
+      )
       expect { client.read.backward.stream("stream_name").from(SecureRandom.uuid).limit(100).to_a }.to raise_error(
-        EventNotFound
+        EventNotFoundInStream
       )
     end
 

--- a/ruby_event_store/spec/client_spec.rb
+++ b/ruby_event_store/spec/client_spec.rb
@@ -398,10 +398,10 @@ module RubyEventStore
       end
 
       expect { client.read.stream("stream_name").from(SecureRandom.uuid).limit(100).to_a }.to raise_error(
-        EventNotFoundInStream
+        EventNotFound
       )
       expect { client.read.backward.stream("stream_name").from(SecureRandom.uuid).limit(100).to_a }.to raise_error(
-        EventNotFoundInStream
+        EventNotFound
       )
     end
 

--- a/ruby_event_store/spec/specification_spec.rb
+++ b/ruby_event_store/spec/specification_spec.rb
@@ -40,11 +40,19 @@ module RubyEventStore
     specify { expect { specification.from("") }.to raise_error(InvalidPageStart) }
     specify { expect { specification.from(:dummy) }.to raise_error(EventNotFound, /dummy/) }
     specify { expect { specification.from(none_such_id) }.to raise_error(EventNotFound, /#{none_such_id}/) }
+    specify do
+      repository.append_to_stream([test_record(event_id)], Stream.new("Dummy"), ExpectedVersion.none)
+      expect { specification.stream('Another').from(event_id) }.not_to raise_error
+    end
 
     specify { expect { specification.to(nil) }.to raise_error(InvalidPageStop) }
     specify { expect { specification.to("") }.to raise_error(InvalidPageStop) }
     specify { expect { specification.to(:dummy) }.to raise_error(EventNotFound, /dummy/) }
     specify { expect { specification.to(none_such_id) }.to raise_error(EventNotFound, /#{none_such_id}/) }
+    specify do
+      repository.append_to_stream([test_record(event_id)], Stream.new("Dummy"), ExpectedVersion.none)
+      expect { specification.stream('Another').to(event_id) }.not_to raise_error
+    end
 
     specify { expect { specification.older_than(nil) }.to raise_error(ArgumentError) }
     specify { expect { specification.older_than("") }.to raise_error(ArgumentError) }

--- a/ruby_event_store/spec/specification_spec.rb
+++ b/ruby_event_store/spec/specification_spec.rb
@@ -38,8 +38,6 @@ module RubyEventStore
 
     specify { expect { specification.from(nil) }.to raise_error(InvalidPageStart) }
     specify { expect { specification.from("") }.to raise_error(InvalidPageStart) }
-    specify { expect { specification.from(:dummy) }.to raise_error(EventNotFound, /dummy/) }
-    specify { expect { specification.from(none_such_id) }.to raise_error(EventNotFound, /#{none_such_id}/) }
     specify do
       repository.append_to_stream([test_record(event_id)], Stream.new("Dummy"), ExpectedVersion.none)
       expect { specification.stream('Another').from(event_id) }.not_to raise_error
@@ -47,12 +45,6 @@ module RubyEventStore
 
     specify { expect { specification.to(nil) }.to raise_error(InvalidPageStop) }
     specify { expect { specification.to("") }.to raise_error(InvalidPageStop) }
-    specify { expect { specification.to(:dummy) }.to raise_error(EventNotFound, /dummy/) }
-    specify { expect { specification.to(none_such_id) }.to raise_error(EventNotFound, /#{none_such_id}/) }
-    specify do
-      repository.append_to_stream([test_record(event_id)], Stream.new("Dummy"), ExpectedVersion.none)
-      expect { specification.stream('Another').to(event_id) }.not_to raise_error
-    end
 
     specify { expect { specification.older_than(nil) }.to raise_error(ArgumentError) }
     specify { expect { specification.older_than("") }.to raise_error(ArgumentError) }


### PR DESCRIPTION
- cover current behaviour with a test
- same behavior of adapters when reading from or to non-existent event
- improve mutant coverage
- Validate starting and ending specification events only on execution
