### PR TITLE
batch enumerator optimization

### DIFF
--- a/ruby_event_store-active_record/lib/ruby_event_store/active_record/batch_enumerator.rb
+++ b/ruby_event_store-active_record/lib/ruby_event_store/active_record/batch_enumerator.rb
@@ -17,8 +17,8 @@ module RubyEventStore
           batch_limit = [batch_size, total_limit - batch_offset].min
           results, offset_id = reader.call(offset_id, batch_limit)
 
-          break if results.empty?
-          yield results
+          yield results if results.any?
+          break if results.size < batch_size
         end
       end
 

--- a/ruby_event_store-active_record/spec/batch_enumerator_spec.rb
+++ b/ruby_event_store-active_record/spec/batch_enumerator_spec.rb
@@ -59,6 +59,11 @@ module RubyEventStore
         expect(reader).to receive(:call).with(kind_of(Integer), kind_of(Integer)).and_return([[], nil])
         BatchEnumerator.new(100, Float::INFINITY, reader).to_a
       end
+
+      specify "ensure not fetching next batch if the previous one was smaller than specified batch size" do
+        expect(reader).to receive(:call).exactly(4).times.and_call_original
+        expect(BatchEnumerator.new(3000, Float::INFINITY, reader).to_a)
+      end
     end
   end
 end

--- a/ruby_event_store-active_record/spec/event_repository_spec.rb
+++ b/ruby_event_store-active_record/spec/event_repository_spec.rb
@@ -207,12 +207,10 @@ module RubyEventStore
 
         expect {
           repository.read(specification.in_batches.as_at.result).to_a
-        }.to match_query /SELECT.*FROM.*event_store_events.*ORDER BY .*event_store_events.*created_at.* ASC,.*event_store_events.*id.* ASC LIMIT.*.OFFSET.*/,
-                    2
+        }.to match_query /SELECT.*FROM.*event_store_events.*ORDER BY .*event_store_events.*created_at.* ASC,.*event_store_events.*id.* ASC LIMIT.*.OFFSET.*/
         expect {
           repository.read(specification.in_batches.as_of.result).to_a
-        }.to match_query /SELECT.*FROM.*event_store_events.*ORDER BY .*COALESCE(.*event_store_events.*valid_at.*, .*event_store_events.*created_at.*).* ASC,.*event_store_events.*id.* ASC LIMIT.*.OFFSET.*/,
-                    2
+        }.to match_query /SELECT.*FROM.*event_store_events.*ORDER BY .*COALESCE(.*event_store_events.*valid_at.*, .*event_store_events.*created_at.*).* ASC,.*event_store_events.*id.* ASC LIMIT.*.OFFSET.*/
       end
 
       specify "with batches and non-bi-temporal queries use monotonic ids" do
@@ -239,7 +237,7 @@ module RubyEventStore
         )
 
         expect {
-          repository.read(specification.in_batches.result).to_a
+          repository.read(specification.in_batches(3).result).to_a
         }.to match_query /SELECT.*FROM.*event_store_events.*WHERE.*event_store_events.id >*.*ORDER BY .*event_store_events.*id.* ASC LIMIT.*/
       end
 

--- a/ruby_event_store-active_record/spec/event_repository_spec.rb
+++ b/ruby_event_store-active_record/spec/event_repository_spec.rb
@@ -10,7 +10,6 @@ module RubyEventStore
 
       it_behaves_like :event_repository, mk_repository, helper
 
-      
       let(:repository) { mk_repository.call }
       let(:specification) do
         Specification.new(
@@ -236,9 +235,11 @@ module RubyEventStore
           ExpectedVersion.any
         )
 
-        expect {
-          repository.read(specification.in_batches(3).result).to_a
-        }.to match_query /SELECT.*FROM.*event_store_events.*WHERE.*event_store_events.id >*.*ORDER BY .*event_store_events.*id.* ASC LIMIT.*/
+        expect do
+          expect do
+            repository.read(specification.in_batches(3).result).to_a
+          end.to match_query /SELECT.*FROM .event_store_events. ORDER BY .event_store_events.\..id. ASC LIMIT/
+        end.to match_query /SELECT.*FROM .event_store_events. WHERE .event_store_events\.id >.* ORDER BY .event_store_events.\..id. ASC LIMIT/
       end
 
       specify "produces expected query for position in stream call" do

--- a/ruby_event_store/lib/ruby_event_store/batch_enumerator.rb
+++ b/ruby_event_store/lib/ruby_event_store/batch_enumerator.rb
@@ -15,8 +15,8 @@ module RubyEventStore
         batch_limit = [batch_size, total_limit - batch_offset].min
         result = reader.call(batch_offset, batch_limit)
 
-        break if result.empty?
-        yield result
+        yield result if result.any?
+        break if result.size < batch_size
       end
     end
 

--- a/ruby_event_store/spec/batch_enumerator_spec.rb
+++ b/ruby_event_store/spec/batch_enumerator_spec.rb
@@ -51,5 +51,10 @@ module RubyEventStore
       expect(reader = double(:reader)).to receive(:call).with(kind_of(Numeric), kind_of(Numeric)).and_return([])
       BatchEnumerator.new(100, Float::INFINITY, reader).to_a
     end
+
+    specify "ensure not fetching next batch if the previous one was smaller than specified batch size" do
+      expect(reader).to receive(:call).exactly(4).times.and_call_original
+      expect(BatchEnumerator.new(3000, Float::INFINITY, reader).to_a)
+    end
   end
 end


### PR DESCRIPTION
no need to fetch next batch if the previous one is smaller than specified batch size
(related to #1708)