### PR TITLE
possibly a dead code

### DIFF
--- a/rails_event_store/lib/rails_event_store/after_commit_async_dispatcher.rb
+++ b/rails_event_store/lib/rails_event_store/after_commit_async_dispatcher.rb
@@ -21,7 +21,7 @@ module RailsEventStore
     end
 
     def async_record(schedule_proc)
-      AsyncRecord.new(self, schedule_proc)
+      AsyncRecord.new(schedule_proc)
     end
 
     def verify(subscriber)
@@ -29,8 +29,7 @@ module RailsEventStore
     end
 
     class AsyncRecord
-      def initialize(dispatcher, schedule_proc)
-        @dispatcher = dispatcher
+      def initialize(schedule_proc)
         @schedule_proc = schedule_proc
       end
 
@@ -42,13 +41,9 @@ module RailsEventStore
 
       def before_committed!; end
 
-      def add_to_transaction
-        dispatcher.run(&schedule_proc)
-      end
-
       def trigger_transactional_callbacks?; end
 
-      attr_reader :schedule_proc, :dispatcher
+      attr_reader :schedule_proc
     end
   end
 end


### PR DESCRIPTION
dead code

originally needed:
https://github.com/RailsEventStore/rails_event_store/commit/3feb47d938907a289e90ce51e2fb5a0d541972d1

and since we require ActiveRecord >= 6 it is no longer needed:
https://github.com/rails/rails/commit/9030b7c7751ba8375697baaee461b1a6435ad5fe