### PR TITLE
sub transactions

### DIFF
--- a/ruby_event_store-active_record/lib/ruby_event_store/active_record/event_repository.rb
+++ b/ruby_event_store-active_record/lib/ruby_event_store/active_record/event_repository.rb
@@ -157,7 +157,7 @@ module RubyEventStore
       end
 
       def start_transaction(&block)
-        @event_klass.transaction(requires_new: true, &block)
+        @event_klass.transaction(requires_new: $use_savepoint, &block)
       end
     end
   end

--- a/ruby_event_store-active_record/lib/ruby_event_store/active_record/event_repository.rb
+++ b/ruby_event_store-active_record/lib/ruby_event_store/active_record/event_repository.rb
@@ -157,7 +157,7 @@ module RubyEventStore
       end
 
       def start_transaction(&block)
-        @event_klass.transaction(requires_new: $use_savepoint, &block)
+        @event_klass.transaction(requires_new: $use_savepoint || true, &block)
       end
     end
   end

--- a/ruby_event_store-active_record/poc.rb
+++ b/ruby_event_store-active_record/poc.rb
@@ -30,7 +30,16 @@ event_store =
   )
 
 mk_event =
-  lambda { RubyEventStore::Event.new(metadata: { event_type: "whatever" }) }
+  lambda do
+    RubyEventStore::Event.new(
+      data: {
+        kaka: "dudu"
+      },
+      metadata: {
+        event_type: "whatever"
+      }
+    )
+  end
 
 logged_keywords = %w[COMMIT BEGIN SAVEPOINT RELEASE].freeze
 
@@ -44,7 +53,12 @@ log_transaction =
 perform_100_appends_in_outer_transaction =
   lambda do
     ActiveRecord::Base.transaction do
-      100.times { event_store.append(mk_event.call) }
+      100.times do
+        event_store.append(
+          100.times.map { mk_event.call },
+          stream_name: "benchmark"
+        )
+      end
     end
   end
 

--- a/ruby_event_store-active_record/poc.rb
+++ b/ruby_event_store-active_record/poc.rb
@@ -1,0 +1,47 @@
+require "bundler/inline"
+
+gemfile do
+  source "https://rubygems.org"
+  gem "ruby_event_store", path: ".."
+  gem "ruby_event_store-active_record", path: "."
+  gem "pg"
+  gem "childprocess"
+  gem "benchmark-ips"
+end
+
+require "ruby_event_store"
+require "ruby_event_store/active_record"
+
+require_relative "../support/helpers/migrator"
+require_relative "../support/helpers/schema_helper"
+
+include SchemaHelper
+establish_database_connection
+drop_database
+load_database_schema
+
+event_store =
+  RubyEventStore::Client.new(
+    repository:
+      RubyEventStore::ActiveRecord::EventRepository.new(
+        serializer: RubyEventStore::NULL
+      )
+  )
+
+mk_event =
+  lambda { RubyEventStore::Event.new(metadata: { event_type: "whatever" }) }
+
+logged_keywords = %w[COMMIT BEGIN SAVEPOINT RELEASE].freeze
+
+log_transaction =
+  lambda do |name, started, finished, unique_id, payload|
+    if logged_keywords.any? { |keyword| payload[:sql].start_with? keyword }
+      puts payload[:sql]
+    end
+  end
+
+ActiveSupport::Notifications.subscribed(log_transaction, /sql/) do
+  ActiveRecord::Base.transaction do
+    100.times { event_store.append(mk_event.call) }
+  end
+end

--- a/ruby_event_store-active_record/transactions.rb
+++ b/ruby_event_store-active_record/transactions.rb
@@ -1,0 +1,86 @@
+require "bundler/inline"
+
+gemfile do
+  source "https://rubygems.org"
+  gem "activerecord"
+  gem "pg"
+end
+
+require "active_record"
+
+ActiveRecord::Base.establish_connection(ENV.fetch("DATABASE_URL"))
+ActiveRecord::Schema.define do
+  create_table :transactions, force: true do |t|
+    t.string :label
+    t.integer :amount
+  end
+
+  create_table :events, force: true do |t|
+    t.string :name
+    t.string :event_id
+  end
+
+  add_index :events, :event_id, unique: true
+end
+
+Event = Class.new(ActiveRecord::Base)
+Transaction = Class.new(ActiveRecord::Base)
+
+ActiveRecord::Base.logger =
+  Logger
+    .new(STDOUT)
+    .tap do |l|
+      l.formatter = proc { |severity, datetime, progname, msg| "#{msg}\n" }
+    end
+
+raise unless Transaction.count == 0
+raise unless Event.count == 0
+
+puts "first"
+begin
+  ActiveRecord::Base.transaction do
+    Transaction.create(label: "kaka", amount: 100)
+
+    event_id = SecureRandom.uuid
+    Event.create(name: "deposited", event_id: event_id)
+    raise ActiveRecord::Rollback
+    # Event.create(name: "deposited", event_id: event_id)
+  end
+rescue ActiveRecord::RecordNotUnique, ActiveRecord::Rollback
+end
+raise unless Transaction.count == 0
+raise unless Event.count == 0
+
+puts "second"
+begin
+  ActiveRecord::Base.transaction do
+    Transaction.create(label: "kaka", amount: 100)
+
+    ActiveRecord::Base.transaction do
+      event_id = SecureRandom.uuid
+      Event.create(name: "deposited", event_id: event_id)
+      raise ActiveRecord::Rollback
+      # Event.create(name: "deposited", event_id: event_id)
+    end
+  end
+rescue ActiveRecord::RecordNotUnique, ActiveRecord::Rollback
+end
+raise unless Transaction.count == 1
+raise unless Event.count == 1
+
+puts "third"
+begin
+  ActiveRecord::Base.transaction do
+    Transaction.create(label: "kaka", amount: 100)
+
+    ActiveRecord::Base.transaction(requires_new: true) do
+      event_id = SecureRandom.uuid
+      Event.create(name: "deposited", event_id: event_id)
+      raise ActiveRecord::Rollback
+      # Event.create(name: "deposited", event_id: event_id)
+    end
+  end
+rescue ActiveRecord::RecordNotUnique, ActiveRecord::Rollback
+end
+raise unless Transaction.count == 2
+raise unless Event.count == 1


### PR DESCRIPTION
- POC code to show savepoints from subsequent appends in transaction
- First iteration of benchmark
- When benchmarking, add more events and ones making sure both tables are exercised
- Fallback to previous default if not messhing with benchmarks
- Sample unrelated to benchmarks but worth persisting
