### PR TITLE
Remove dependency on base64 gem

### DIFF
--- a/aggregate_root/Gemfile.lock
+++ b/aggregate_root/Gemfile.lock
@@ -8,7 +8,6 @@ PATH
   remote: .
   specs:
     aggregate_root (2.14.0)
-      base64
       ruby_event_store (= 2.14.0)
 
 GEM
@@ -25,7 +24,6 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     ast (2.4.2)
-    base64 (0.2.0)
     concurrent-ruby (1.2.2)
     diff-lcs (1.5.0)
     i18n (1.14.1)

--- a/aggregate_root/aggregate_root.gemspec
+++ b/aggregate_root/aggregate_root.gemspec
@@ -24,5 +24,4 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.7"
 
   spec.add_dependency "ruby_event_store", "= 2.14.0"
-  spec.add_dependency "base64"
 end

--- a/aggregate_root/lib/aggregate_root/snapshot_repository.rb
+++ b/aggregate_root/lib/aggregate_root/snapshot_repository.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'base64'
 require 'ruby_event_store/event'
 
 module AggregateRoot

--- a/contrib/dres_rails/Gemfile.lock
+++ b/contrib/dres_rails/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: ../..
   specs:
     aggregate_root (2.14.0)
-      base64
       ruby_event_store (= 2.14.0)
     rails_event_store (2.14.0)
       activejob (>= 6.0)
@@ -110,7 +109,6 @@ GEM
     arkency-command_bus (0.4.1)
       concurrent-ruby
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     capybara (3.39.2)
       addressable

--- a/contrib/minitest-ruby_event_store/Gemfile.lock
+++ b/contrib/minitest-ruby_event_store/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: ../..
   specs:
     aggregate_root (2.14.0)
-      base64
       ruby_event_store (= 2.14.0)
     ruby_event_store (2.14.0)
       concurrent-ruby (~> 1.0, >= 1.1.6)
@@ -34,7 +33,6 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     ast (2.4.2)
-    base64 (0.2.0)
     concurrent-ruby (1.2.2)
     diff-lcs (1.5.0)
     i18n (1.14.1)

--- a/contrib/ruby_event_store-profiler/Gemfile.lock
+++ b/contrib/ruby_event_store-profiler/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: ../..
   specs:
     aggregate_root (2.14.0)
-      base64
       ruby_event_store (= 2.14.0)
     ruby_event_store (2.14.0)
       concurrent-ruby (~> 1.0, >= 1.1.6)
@@ -27,7 +26,6 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     ast (2.4.2)
-    base64 (0.2.0)
     concurrent-ruby (1.2.2)
     diff-lcs (1.5.0)
     i18n (1.14.1)

--- a/contrib/ruby_event_store-protobuf/Gemfile.lock
+++ b/contrib/ruby_event_store-protobuf/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: ../..
   specs:
     aggregate_root (2.14.0)
-      base64
       ruby_event_store (= 2.14.0)
     rails_event_store (2.14.0)
       activejob (>= 6.0)

--- a/contrib/ruby_event_store-protobuf/Gemfile.rails_6_0.lock
+++ b/contrib/ruby_event_store-protobuf/Gemfile.rails_6_0.lock
@@ -2,7 +2,6 @@ PATH
   remote: ../..
   specs:
     aggregate_root (2.14.0)
-      base64
       ruby_event_store (= 2.14.0)
     rails_event_store (2.14.0)
       activejob (>= 6.0)
@@ -96,7 +95,6 @@ GEM
     arkency-command_bus (0.4.1)
       concurrent-ruby
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     concurrent-ruby (1.2.2)
     crass (1.0.6)

--- a/contrib/ruby_event_store-protobuf/Gemfile.rails_6_1.lock
+++ b/contrib/ruby_event_store-protobuf/Gemfile.rails_6_1.lock
@@ -2,7 +2,6 @@ PATH
   remote: ../..
   specs:
     aggregate_root (2.14.0)
-      base64
       ruby_event_store (= 2.14.0)
     rails_event_store (2.14.0)
       activejob (>= 6.0)
@@ -100,7 +99,6 @@ GEM
     arkency-command_bus (0.4.1)
       concurrent-ruby
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     concurrent-ruby (1.2.2)
     crass (1.0.6)

--- a/contrib/ruby_event_store-protobuf/Gemfile.rails_7_0.lock
+++ b/contrib/ruby_event_store-protobuf/Gemfile.rails_7_0.lock
@@ -2,7 +2,6 @@ PATH
   remote: ../..
   specs:
     aggregate_root (2.14.0)
-      base64
       ruby_event_store (= 2.14.0)
     rails_event_store (2.14.0)
       activejob (>= 6.0)
@@ -106,7 +105,6 @@ GEM
     arkency-command_bus (0.4.1)
       concurrent-ruby
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     concurrent-ruby (1.2.2)
     crass (1.0.6)

--- a/contrib/ruby_event_store-sidekiq_scheduler/Gemfile.lock
+++ b/contrib/ruby_event_store-sidekiq_scheduler/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: ../..
   specs:
     aggregate_root (2.14.0)
-      base64
       ruby_event_store (= 2.14.0)
     rails_event_store (2.14.0)
       activejob (>= 6.0)
@@ -106,7 +105,6 @@ GEM
     arkency-command_bus (0.4.1)
       concurrent-ruby
     ast (2.4.2)
-    base64 (0.2.0)
     bigdecimal (3.1.5)
     builder (3.2.4)
     concurrent-ruby (1.2.2)

--- a/contrib/ruby_event_store-sidekiq_scheduler/Gemfile.sidekiq_5_2.lock
+++ b/contrib/ruby_event_store-sidekiq_scheduler/Gemfile.sidekiq_5_2.lock
@@ -2,7 +2,6 @@ PATH
   remote: ../..
   specs:
     aggregate_root (2.14.0)
-      base64
       ruby_event_store (= 2.14.0)
     rails_event_store (2.14.0)
       activejob (>= 6.0)
@@ -106,7 +105,6 @@ GEM
     arkency-command_bus (0.4.1)
       concurrent-ruby
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)

--- a/contrib/ruby_event_store-sidekiq_scheduler/Gemfile.sidekiq_6_5.lock
+++ b/contrib/ruby_event_store-sidekiq_scheduler/Gemfile.sidekiq_6_5.lock
@@ -2,7 +2,6 @@ PATH
   remote: ../..
   specs:
     aggregate_root (2.14.0)
-      base64
       ruby_event_store (= 2.14.0)
     rails_event_store (2.14.0)
       activejob (>= 6.0)
@@ -106,7 +105,6 @@ GEM
     arkency-command_bus (0.4.1)
       concurrent-ruby
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)

--- a/rails_event_store/Gemfile.lock
+++ b/rails_event_store/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: ..
   specs:
     aggregate_root (2.14.0)
-      base64
       ruby_event_store (= 2.14.0)
     rails_event_store_active_record (2.14.0)
       ruby_event_store-active_record (= 2.14.0)

--- a/rails_event_store/Gemfile.rails_6_0.lock
+++ b/rails_event_store/Gemfile.rails_6_0.lock
@@ -2,7 +2,6 @@ PATH
   remote: ..
   specs:
     aggregate_root (2.14.0)
-      base64
       ruby_event_store (= 2.14.0)
     rails_event_store_active_record (2.14.0)
       ruby_event_store-active_record (= 2.14.0)
@@ -94,7 +93,6 @@ GEM
     arkency-command_bus (0.4.1)
       concurrent-ruby
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)

--- a/rails_event_store/Gemfile.rails_6_1.lock
+++ b/rails_event_store/Gemfile.rails_6_1.lock
@@ -2,7 +2,6 @@ PATH
   remote: ..
   specs:
     aggregate_root (2.14.0)
-      base64
       ruby_event_store (= 2.14.0)
     rails_event_store_active_record (2.14.0)
       ruby_event_store-active_record (= 2.14.0)
@@ -98,7 +97,6 @@ GEM
     arkency-command_bus (0.4.1)
       concurrent-ruby
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)

--- a/rails_event_store/Gemfile.rails_7_0.lock
+++ b/rails_event_store/Gemfile.rails_7_0.lock
@@ -2,7 +2,6 @@ PATH
   remote: ..
   specs:
     aggregate_root (2.14.0)
-      base64
       ruby_event_store (= 2.14.0)
     rails_event_store_active_record (2.14.0)
       ruby_event_store-active_record (= 2.14.0)
@@ -104,7 +103,6 @@ GEM
     arkency-command_bus (0.4.1)
       concurrent-ruby
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)

--- a/rails_event_store/spec/dummy_6_0/Gemfile.lock
+++ b/rails_event_store/spec/dummy_6_0/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: ../../../aggregate_root
   specs:
     aggregate_root (2.14.0)
-      base64
       ruby_event_store (= 2.14.0)
 
 PATH
@@ -100,7 +99,6 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     arkency-command_bus (0.4.1)
       concurrent-ruby
-    base64 (0.2.0)
     builder (3.2.4)
     concurrent-ruby (1.2.2)
     crass (1.0.6)

--- a/rails_event_store/spec/dummy_6_1/Gemfile.lock
+++ b/rails_event_store/spec/dummy_6_1/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: ../../../aggregate_root
   specs:
     aggregate_root (2.14.0)
-      base64
       ruby_event_store (= 2.14.0)
 
 PATH
@@ -104,7 +103,6 @@ GEM
       zeitwerk (~> 2.3)
     arkency-command_bus (0.4.1)
       concurrent-ruby
-    base64 (0.2.0)
     builder (3.2.4)
     concurrent-ruby (1.2.2)
     crass (1.0.6)

--- a/rails_event_store/spec/dummy_7_0/Gemfile.lock
+++ b/rails_event_store/spec/dummy_7_0/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: ../../../aggregate_root
   specs:
     aggregate_root (2.14.0)
-      base64
       ruby_event_store (= 2.14.0)
 
 PATH
@@ -110,7 +109,6 @@ GEM
       tzinfo (~> 2.0)
     arkency-command_bus (0.4.1)
       concurrent-ruby
-    base64 (0.2.0)
     builder (3.2.4)
     concurrent-ruby (1.2.2)
     crass (1.0.6)

--- a/rails_event_store/spec/dummy_7_1/Gemfile.lock
+++ b/rails_event_store/spec/dummy_7_1/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: ../../../aggregate_root
   specs:
     aggregate_root (2.14.0)
-      base64
       ruby_event_store (= 2.14.0)
 
 PATH

--- a/ruby_event_store-rspec/Gemfile.lock
+++ b/ruby_event_store-rspec/Gemfile.lock
@@ -9,7 +9,6 @@ PATH
   remote: ..
   specs:
     aggregate_root (2.14.0)
-      base64
       ruby_event_store (= 2.14.0)
     ruby_event_store (2.14.0)
       concurrent-ruby (~> 1.0, >= 1.1.6)
@@ -34,7 +33,6 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     ast (2.4.2)
-    base64 (0.2.0)
     concurrent-ruby (1.2.2)
     diff-lcs (1.3)
     i18n (1.14.1)


### PR DESCRIPTION
In #1719 `base64`` was added as a dependency to `aggregate_root` to prevent warnings/errors in Ruby 3.3/3.4

However there is only one require and no usages of `base64` so it can just be removed.