### PR TITLE
Remove `arkency-command_bus` dependency

### DIFF
--- a/rails_event_store/Gemfile.lock
+++ b/rails_event_store/Gemfile.lock
@@ -17,12 +17,11 @@ PATH
 PATH
   remote: .
   specs:
-    rails_event_store (2.14.0)
+    rails_event_store (2.14.1)
       activejob (>= 6.0)
       activemodel (>= 6.0)
       activesupport (>= 6.0)
       aggregate_root (= 2.14.0)
-      arkency-command_bus (>= 0.4)
       rails_event_store_active_record (= 2.14.0)
       ruby_event_store (= 2.14.0)
       ruby_event_store-browser (= 2.14.0)
@@ -109,8 +108,6 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
-    arkency-command_bus (0.4.1)
-      concurrent-ruby
     ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.6)

--- a/rails_event_store/Gemfile.rails_6_0.lock
+++ b/rails_event_store/Gemfile.rails_6_0.lock
@@ -17,12 +17,11 @@ PATH
 PATH
   remote: .
   specs:
-    rails_event_store (2.14.0)
+    rails_event_store (2.14.1)
       activejob (>= 6.0)
       activemodel (>= 6.0)
       activesupport (>= 6.0)
       aggregate_root (= 2.14.0)
-      arkency-command_bus (>= 0.4)
       rails_event_store_active_record (= 2.14.0)
       ruby_event_store (= 2.14.0)
       ruby_event_store-browser (= 2.14.0)
@@ -90,8 +89,6 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
-    arkency-command_bus (0.4.1)
-      concurrent-ruby
     ast (2.4.2)
     builder (3.2.4)
     concurrent-ruby (1.2.3)

--- a/rails_event_store/Gemfile.rails_6_1.lock
+++ b/rails_event_store/Gemfile.rails_6_1.lock
@@ -17,12 +17,11 @@ PATH
 PATH
   remote: .
   specs:
-    rails_event_store (2.14.0)
+    rails_event_store (2.14.1)
       activejob (>= 6.0)
       activemodel (>= 6.0)
       activesupport (>= 6.0)
       aggregate_root (= 2.14.0)
-      arkency-command_bus (>= 0.4)
       rails_event_store_active_record (= 2.14.0)
       ruby_event_store (= 2.14.0)
       ruby_event_store-browser (= 2.14.0)
@@ -94,8 +93,6 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    arkency-command_bus (0.4.1)
-      concurrent-ruby
     ast (2.4.2)
     builder (3.2.4)
     concurrent-ruby (1.2.3)

--- a/rails_event_store/Gemfile.rails_7_0.lock
+++ b/rails_event_store/Gemfile.rails_7_0.lock
@@ -17,12 +17,11 @@ PATH
 PATH
   remote: .
   specs:
-    rails_event_store (2.14.0)
+    rails_event_store (2.14.1)
       activejob (>= 6.0)
       activemodel (>= 6.0)
       activesupport (>= 6.0)
       aggregate_root (= 2.14.0)
-      arkency-command_bus (>= 0.4)
       rails_event_store_active_record (= 2.14.0)
       ruby_event_store (= 2.14.0)
       ruby_event_store-browser (= 2.14.0)
@@ -100,8 +99,6 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    arkency-command_bus (0.4.1)
-      concurrent-ruby
     ast (2.4.2)
     builder (3.2.4)
     concurrent-ruby (1.2.3)

--- a/rails_event_store/lib/rails_event_store/version.rb
+++ b/rails_event_store/lib/rails_event_store/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsEventStore
-  VERSION = "2.14.0"
+  VERSION = "2.14.1"
 end

--- a/rails_event_store/rails_event_store.gemspec
+++ b/rails_event_store/rails_event_store.gemspec
@@ -35,5 +35,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", ">= 6.0"
   spec.add_dependency "activemodel", ">= 6.0"
   spec.add_dependency "activejob", ">= 6.0"
-  spec.add_dependency "arkency-command_bus", ">= 0.4"
 end


### PR DESCRIPTION
AFAICT this is not referenced anywhere in the gem, and we (currently) don't plan to use it, so it would be nice to not need to install it.