### PR TITLE
Remove unnecessary import of ostruct

### DIFF
--- a/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
+++ b/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "ostruct"
 module RubyEventStore
   class InMemoryRepository
     class UnsupportedVersionAnyUsage < StandardError


### PR DESCRIPTION
This line is not needed and triggers the error message

```
warning: ostruct was loaded from the standard library,
but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```