### PR TITLE
Docs: Fix broken link to installation page

### DIFF
--- a/railseventstore.org/docs/core-concepts/request-metadata.md
+++ b/railseventstore.org/docs/core-concepts/request-metadata.md
@@ -6,7 +6,7 @@ In Rails environment, every event is enhanced with the request metadata provided
 
 ## Setup
 
-In order to enhance your events with metadata, you need to setup your client as described in [Installation](/docs/install).
+In order to enhance your events with metadata, you need to setup your client as described in [Installation](../getting-started/install).
 
 ## Defaults
 


### PR DESCRIPTION
This page https://railseventstore.org/docs/core-concepts/request-metadata had a broken link to installation page. I fixed it by using a similar link approach a working link is using on https://railseventstore.org/docs/core-concepts/browser page:

https://github.com/RailsEventStore/rails_event_store/blob/d8a68272e0564b6c86928e515cececb5fd07c1a6/railseventstore.org/docs/core-concepts/browser.md?plain=1#L19