### PR TITLE
Fix double instrumentation

### DIFF
--- a/rails_event_store/lib/rails_event_store/json_client.rb
+++ b/rails_event_store/lib/rails_event_store/json_client.rb
@@ -63,22 +63,7 @@ module RailsEventStore
       correlation_id_generator: default_correlation_id_generator,
       request_metadata: default_request_metadata
     )
-      super(
-        mapper:
-          RubyEventStore::Mappers::InstrumentedMapper.new(mapper, ActiveSupport::Notifications),
-        repository:
-          RubyEventStore::InstrumentedRepository.new(repository, ActiveSupport::Notifications),
-        subscriptions:
-          RubyEventStore::InstrumentedSubscriptions.new(
-            subscriptions,
-            ActiveSupport::Notifications,
-          ),
-        clock: clock,
-        correlation_id_generator: correlation_id_generator,
-        dispatcher:
-          RubyEventStore::InstrumentedDispatcher.new(dispatcher, ActiveSupport::Notifications),
-      )
-      @request_metadata = request_metadata
+      super
     end
   end
 end


### PR DESCRIPTION
As JSONClient inherits from RailsEventStore::Client it should not
copy the code from it, mapper, repository, subscriptions and
dispatcher will be wrapped in instrumentation by RailsEventStore::Client
initializer. No need to double it.
