### PR TITLE
Outbox require issue

### DIFF
--- a/contrib/ruby_event_store-outbox/CHANGELOG.md
+++ b/contrib/ruby_event_store-outbox/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.0.29  2025-03-25
+
+* Fix an issue with uninitialized constant `RubyEventStore::Outbox::RetriableError` when using `bin/res_outbox`
+
 ### 0.0.28  2024-04-12
 
 * Fix issues that prevent res_outbox CLI from processing

--- a/contrib/ruby_event_store-outbox/Gemfile.lock
+++ b/contrib/ruby_event_store-outbox/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 PATH
   remote: .
   specs:
-    ruby_event_store-outbox (0.0.28)
+    ruby_event_store-outbox (0.0.29)
       activerecord (>= 6.0)
       ruby_event_store (>= 1.0.0)
 

--- a/contrib/ruby_event_store-outbox/Gemfile.rails_7_0.lock
+++ b/contrib/ruby_event_store-outbox/Gemfile.rails_7_0.lock
@@ -7,7 +7,7 @@ PATH
 PATH
   remote: .
   specs:
-    ruby_event_store-outbox (0.0.28)
+    ruby_event_store-outbox (0.0.29)
       activerecord (>= 6.0)
       ruby_event_store (>= 1.0.0)
 

--- a/contrib/ruby_event_store-outbox/Gemfile.rails_7_1.lock
+++ b/contrib/ruby_event_store-outbox/Gemfile.rails_7_1.lock
@@ -7,7 +7,7 @@ PATH
 PATH
   remote: .
   specs:
-    ruby_event_store-outbox (0.0.28)
+    ruby_event_store-outbox (0.0.29)
       activerecord (>= 6.0)
       ruby_event_store (>= 1.0.0)
 

--- a/contrib/ruby_event_store-outbox/Gemfile.rails_7_2.lock
+++ b/contrib/ruby_event_store-outbox/Gemfile.rails_7_2.lock
@@ -7,7 +7,7 @@ PATH
 PATH
   remote: .
   specs:
-    ruby_event_store-outbox (0.0.28)
+    ruby_event_store-outbox (0.0.29)
       activerecord (>= 6.0)
       ruby_event_store (>= 1.0.0)
 

--- a/contrib/ruby_event_store-outbox/Gemfile.sidekiq_6_5.lock
+++ b/contrib/ruby_event_store-outbox/Gemfile.sidekiq_6_5.lock
@@ -7,7 +7,7 @@ PATH
 PATH
   remote: .
   specs:
-    ruby_event_store-outbox (0.0.28)
+    ruby_event_store-outbox (0.0.29)
       activerecord (>= 6.0)
       ruby_event_store (>= 1.0.0)
 

--- a/contrib/ruby_event_store-outbox/bin/res_outbox
+++ b/contrib/ruby_event_store-outbox/bin/res_outbox
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-
+require "ruby_event_store/outbox"
 require "ruby_event_store/outbox/cli"
 
 cli = RubyEventStore::Outbox::CLI.new

--- a/contrib/ruby_event_store-outbox/lib/ruby_event_store/outbox/version.rb
+++ b/contrib/ruby_event_store-outbox/lib/ruby_event_store/outbox/version.rb
@@ -2,6 +2,6 @@
 
 module RubyEventStore
   module Outbox
-    VERSION = "0.0.28"
+    VERSION = "0.0.29"
   end
 end


### PR DESCRIPTION
Lock wait timeouts were causing

```
uninitialized constant RubyEventStore::Outbox::Consumer::RetriableError (NameError)

      rescue RetriableError => error
             ^^^^^^^^^^^^^^
```