### PR TITLE
Use topics

### DIFF
--- a/ruby_event_store/lib/ruby_event_store/broker.rb
+++ b/ruby_event_store/lib/ruby_event_store/broker.rb
@@ -12,9 +12,9 @@ module RubyEventStore
       subscribers.each { |subscriber| dispatcher.call(subscriber, event, record) }
     end
 
-    def add_subscription(subscriber, event_types)
+    def add_subscription(subscriber, topics)
       verify_subscription(subscriber)
-      subscriptions.add_subscription(subscriber, event_types)
+      subscriptions.add_subscription(subscriber, topics)
     end
 
     def add_global_subscription(subscriber)
@@ -22,9 +22,9 @@ module RubyEventStore
       subscriptions.add_global_subscription(subscriber)
     end
 
-    def add_thread_subscription(subscriber, event_types)
+    def add_thread_subscription(subscriber, topics)
       verify_subscription(subscriber)
-      subscriptions.add_thread_subscription(subscriber, event_types)
+      subscriptions.add_thread_subscription(subscriber, topics)
     end
 
     def add_thread_global_subscription(subscriber)

--- a/ruby_event_store/lib/ruby_event_store/broker.rb
+++ b/ruby_event_store/lib/ruby_event_store/broker.rb
@@ -32,8 +32,8 @@ module RubyEventStore
       subscriptions.add_thread_global_subscription(subscriber)
     end
 
-    def all_subscriptions_for(event_type)
-      subscriptions.all_for(event_type)
+    def all_subscriptions_for(topic)
+      subscriptions.all_for(topic)
     end
 
     private

--- a/ruby_event_store/lib/ruby_event_store/broker.rb
+++ b/ruby_event_store/lib/ruby_event_store/broker.rb
@@ -7,8 +7,8 @@ module RubyEventStore
       @dispatcher = dispatcher
     end
 
-    def call(event, record, topic = nil)
-      subscribers = subscriptions.all_for(topic || event.event_type)
+    def call(event, record, topic)
+      subscribers = subscriptions.all_for(topic)
       subscribers.each { |subscriber| dispatcher.call(subscriber, event, record) }
     end
 

--- a/ruby_event_store/lib/ruby_event_store/broker.rb
+++ b/ruby_event_store/lib/ruby_event_store/broker.rb
@@ -7,8 +7,8 @@ module RubyEventStore
       @dispatcher = dispatcher
     end
 
-    def call(event, record)
-      subscribers = subscriptions.all_for(event.event_type)
+    def call(event, record, topic = nil)
+      subscribers = subscriptions.all_for(topic || event.event_type)
       subscribers.each { |subscriber| dispatcher.call(subscriber, event, record) }
     end
 

--- a/ruby_event_store/lib/ruby_event_store/broker.rb
+++ b/ruby_event_store/lib/ruby_event_store/broker.rb
@@ -7,7 +7,7 @@ module RubyEventStore
       @dispatcher = dispatcher
     end
 
-    def call(event, record, topic)
+    def call(topic, event, record)
       subscribers = subscriptions.all_for(topic)
       subscribers.each { |subscriber| dispatcher.call(subscriber, event, record) }
     end

--- a/ruby_event_store/lib/ruby_event_store/client.rb
+++ b/ruby_event_store/lib/ruby_event_store/client.rb
@@ -58,10 +58,10 @@ module RubyEventStore
       enriched_events.zip(records) do |event, record|
         with_metadata(correlation_id: event.metadata.fetch(:correlation_id), causation_id: event.event_id) do
           if broker.public_method(:call).arity == 3
-            broker.call(event, record, topic || event.event_type)
+            broker.call(topic || event.event_type, event, record)
           else
             warn <<~EOW
-              Message broker shall support topics. 
+              Message broker shall support topics.
               Topic WILL BE IGNORED in the current broker.
               Modify the broker implementation to pass topic as an argument to broker.call method.
             EOW

--- a/ruby_event_store/lib/ruby_event_store/client.rb
+++ b/ruby_event_store/lib/ruby_event_store/client.rb
@@ -57,7 +57,7 @@ module RubyEventStore
       append_records_to_stream(records, stream_name: stream_name, expected_version: expected_version)
       enriched_events.zip(records) do |event, record|
         with_metadata(correlation_id: event.metadata.fetch(:correlation_id), causation_id: event.event_id) do
-          broker.call(event, record, topic)
+          broker.call(event, record, topic || event.event_type)
         end
       end
       self

--- a/ruby_event_store/lib/ruby_event_store/client.rb
+++ b/ruby_event_store/lib/ruby_event_store/client.rb
@@ -51,13 +51,13 @@ module RubyEventStore
     # @param stream_name [String] name of the stream for persisting events.
     # @param expected_version [:any, :auto, :none, Integer] controls optimistic locking strategy. {http://railseventstore.org/docs/expected_version/ Read more}
     # @return [self]
-    def publish(events, stream_name: GLOBAL_STREAM, expected_version: :any)
+    def publish(events, topic: nil, stream_name: GLOBAL_STREAM, expected_version: :any)
       enriched_events = enrich_events_metadata(events)
       records = transform(enriched_events)
       append_records_to_stream(records, stream_name: stream_name, expected_version: expected_version)
       enriched_events.zip(records) do |event, record|
         with_metadata(correlation_id: event.metadata.fetch(:correlation_id), causation_id: event.event_id) do
-          broker.(event, record)
+          broker.call(event, record, topic)
         end
       end
       self

--- a/ruby_event_store/lib/ruby_event_store/instrumented_broker.rb
+++ b/ruby_event_store/lib/ruby_event_store/instrumented_broker.rb
@@ -7,9 +7,9 @@ module RubyEventStore
       @instrumentation = instrumentation
     end
 
-    def call(event, record)
-      instrumentation.instrument("call.broker.rails_event_store", event: event, record: record) do
-        broker.call(event, record)
+    def call(event, record, topic)
+      instrumentation.instrument("call.broker.rails_event_store", event: event, record: record, topic: topic) do
+        broker.call(event, record, topic)
       end
     end
 

--- a/ruby_event_store/lib/ruby_event_store/instrumented_broker.rb
+++ b/ruby_event_store/lib/ruby_event_store/instrumented_broker.rb
@@ -7,10 +7,10 @@ module RubyEventStore
       @instrumentation = instrumentation
     end
 
-    def call(event, record, topic)
-      instrumentation.instrument("call.broker.rails_event_store", event: event, record: record, topic: topic) do
+    def call(topic, event, record)
+      instrumentation.instrument("call.broker.rails_event_store", topic: topic, event: event, record: record) do
         if broker.public_method(:call).arity == 3
-          broker.call(event, record, topic)
+          broker.call(topic, event, record)
         else
           warn <<~EOW
             Message broker shall support topics.

--- a/ruby_event_store/lib/ruby_event_store/instrumented_broker.rb
+++ b/ruby_event_store/lib/ruby_event_store/instrumented_broker.rb
@@ -9,7 +9,16 @@ module RubyEventStore
 
     def call(event, record, topic)
       instrumentation.instrument("call.broker.rails_event_store", event: event, record: record, topic: topic) do
-        broker.call(event, record, topic)
+        if broker.public_method(:call).arity == 3
+          broker.call(event, record, topic)
+        else
+          warn <<~EOW
+            Message broker shall support topics. 
+            Topic WILL BE IGNORED in the current broker.
+            Modify the broker implementation to pass topic as an argument to broker.call method.
+          EOW
+          broker.call(event, record)
+        end
       end
     end
 

--- a/ruby_event_store/lib/ruby_event_store/instrumented_broker.rb
+++ b/ruby_event_store/lib/ruby_event_store/instrumented_broker.rb
@@ -22,12 +22,10 @@ module RubyEventStore
       end
     end
 
-    def add_subscription(subscriber, event_types)
-      instrumentation.instrument(
-        "add_subscription.broker.rails_event_store",
-        subscriber: subscriber,
-        event_types: event_types,
-      ) { broker.add_subscription(subscriber, event_types) }
+    def add_subscription(subscriber, topics)
+      instrumentation.instrument("add_subscription.broker.rails_event_store", subscriber: subscriber, topics: topics) do
+        broker.add_subscription(subscriber, topics)
+      end
     end
 
     def add_global_subscription(subscriber)
@@ -36,12 +34,12 @@ module RubyEventStore
       end
     end
 
-    def add_thread_subscription(subscriber, event_types)
+    def add_thread_subscription(subscriber, topics)
       instrumentation.instrument(
         "add_thread_subscription.broker.rails_event_store",
         subscriber: subscriber,
-        event_types: event_types,
-      ) { broker.add_thread_subscription(subscriber, event_types) }
+        topics: topics,
+      ) { broker.add_thread_subscription(subscriber, topics) }
     end
 
     def add_thread_global_subscription(subscriber)
@@ -50,9 +48,9 @@ module RubyEventStore
       end
     end
 
-    def all_subscriptions_for(event_type)
-      instrumentation.instrument("all_subscriptions_for.broker.rails_event_store", event_type: event_type) do
-        broker.all_subscriptions_for(event_type)
+    def all_subscriptions_for(topic)
+      instrumentation.instrument("all_subscriptions_for.broker.rails_event_store", topic: topic) do
+        broker.all_subscriptions_for(topic)
       end
     end
 

--- a/ruby_event_store/lib/ruby_event_store/instrumented_broker.rb
+++ b/ruby_event_store/lib/ruby_event_store/instrumented_broker.rb
@@ -13,7 +13,7 @@ module RubyEventStore
           broker.call(event, record, topic)
         else
           warn <<~EOW
-            Message broker shall support topics. 
+            Message broker shall support topics.
             Topic WILL BE IGNORED in the current broker.
             Modify the broker implementation to pass topic as an argument to broker.call method.
           EOW

--- a/ruby_event_store/lib/ruby_event_store/spec/broker_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/broker_lint.rb
@@ -14,6 +14,12 @@ RSpec.shared_examples "broker" do |broker_klass|
     broker.call(event, record)
   end
 
+  specify 'calls subscription using topic' do
+    expect(subscriptions).to receive(:all_for).with('topic').and_return([handler])
+    expect(dispatcher).to receive(:call).with(handler, event, record)
+    broker.call(event, record, 'topic')
+  end
+
   specify "calls subscription" do
     expect(subscriptions).to receive(:all_for).with("EventType").and_return([handler])
     expect(dispatcher).to receive(:call).with(handler, event, record)

--- a/ruby_event_store/lib/ruby_event_store/spec/broker_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/broker_lint.rb
@@ -11,7 +11,7 @@ RSpec.shared_examples "broker" do |broker_klass|
   specify "no dispatch when no subscriptions" do
     expect(subscriptions).to receive(:all_for).with("EventType").and_return([])
     expect(dispatcher).not_to receive(:call)
-    broker.call(event, record)
+    broker.call(event, record, event.event_type)
   end
 
   specify 'calls subscription using topic' do
@@ -23,20 +23,20 @@ RSpec.shared_examples "broker" do |broker_klass|
   specify "calls subscription" do
     expect(subscriptions).to receive(:all_for).with("EventType").and_return([handler])
     expect(dispatcher).to receive(:call).with(handler, event, record)
-    broker.call(event, record)
+    broker.call(event, record, event.event_type)
   end
 
   specify "calls subscribed class" do
     expect(subscriptions).to receive(:all_for).with("EventType").and_return([HandlerClass])
     expect(dispatcher).to receive(:call).with(HandlerClass, event, record)
-    broker.call(event, record)
+    broker.call(event, record, event.event_type)
   end
 
   specify "calls all subscriptions" do
     expect(subscriptions).to receive(:all_for).with("EventType").and_return([handler, HandlerClass])
     expect(dispatcher).to receive(:call).with(handler, event, record)
     expect(dispatcher).to receive(:call).with(HandlerClass, event, record)
-    broker.call(event, record)
+    broker.call(event, record, event.event_type)
   end
 
   specify "raise error when no subscriber" do

--- a/ruby_event_store/lib/ruby_event_store/spec/broker_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/broker_lint.rb
@@ -11,32 +11,32 @@ RSpec.shared_examples "broker" do |broker_klass|
   specify "no dispatch when no subscriptions" do
     expect(subscriptions).to receive(:all_for).with("EventType").and_return([])
     expect(dispatcher).not_to receive(:call)
-    broker.call(event, record, event.event_type)
+    broker.call(event.event_type, event, record)
   end
 
-  specify 'calls subscription using topic' do
-    expect(subscriptions).to receive(:all_for).with('topic').and_return([handler])
+  specify "calls subscription using topic" do
+    expect(subscriptions).to receive(:all_for).with("topic").and_return([handler])
     expect(dispatcher).to receive(:call).with(handler, event, record)
-    broker.call(event, record, 'topic')
+    broker.call("topic", event, record)
   end
 
   specify "calls subscription" do
     expect(subscriptions).to receive(:all_for).with("EventType").and_return([handler])
     expect(dispatcher).to receive(:call).with(handler, event, record)
-    broker.call(event, record, event.event_type)
+    broker.call(event.event_type, event, record)
   end
 
   specify "calls subscribed class" do
     expect(subscriptions).to receive(:all_for).with("EventType").and_return([HandlerClass])
     expect(dispatcher).to receive(:call).with(HandlerClass, event, record)
-    broker.call(event, record, event.event_type)
+    broker.call(event.event_type, event, record)
   end
 
   specify "calls all subscriptions" do
     expect(subscriptions).to receive(:all_for).with("EventType").and_return([handler, HandlerClass])
     expect(dispatcher).to receive(:call).with(handler, event, record)
     expect(dispatcher).to receive(:call).with(HandlerClass, event, record)
-    broker.call(event, record, event.event_type)
+    broker.call(event.event_type, event, record)
   end
 
   specify "raise error when no subscriber" do

--- a/ruby_event_store/spec/client_subscriptions_spec.rb
+++ b/ruby_event_store/spec/client_subscriptions_spec.rb
@@ -113,7 +113,7 @@ module RubyEventStore
     specify "warns when using old broker" do
       expect { RubyEventStore::Client.new(message_broker: LegacyBroker.new).publish(TestEvent.new) }.to output(
         <<~EOS,
-          Message broker shall support topics. 
+          Message broker shall support topics.
           Topic WILL BE IGNORED in the current broker.
           Modify the broker implementation to pass topic as an argument to broker.call method.
         EOS

--- a/ruby_event_store/spec/client_subscriptions_spec.rb
+++ b/ruby_event_store/spec/client_subscriptions_spec.rb
@@ -50,6 +50,20 @@ module RubyEventStore
       expect(subscriber.handled_events).to eq [event]
     end
 
+    specify 'notifies subscribers listening on topic' do
+      subscriber = Subscribers::ValidHandler.new
+      client.subscribe(subscriber, to: ['topic', TestEvent])
+      event_1 = OrderCreated.new
+      event_2 = ProductAdded.new
+      event_3 = TestEvent.new
+      event_4 = TestEvent.new
+      client.publish(event_1, topic: 'topic')
+      client.publish(event_2, topic: 'another_topic')
+      client.publish(event_3)
+      client.publish(event_4, topic: 'not_that_topic')
+      expect(subscriber.handled_events).to eq [event_1, event_3]
+    end
+
     specify "notifies subscribers listening on list of events" do
       subscriber = Subscribers::ValidHandler.new
       client.subscribe(subscriber, to: [OrderCreated, ProductAdded])

--- a/ruby_event_store/spec/instrumented_broker_spec.rb
+++ b/ruby_event_store/spec/instrumented_broker_spec.rb
@@ -16,9 +16,9 @@ module RubyEventStore
         record = Object.new
 
         expect(some_broker).to receive(:public_method).with(:call).and_return(double(arity: 3))
-        instrumented_broker.call(event, record, "topic")
+        instrumented_broker.call("topic", event, record)
 
-        expect(some_broker).to have_received(:call).with(event, record, "topic")
+        expect(some_broker).to have_received(:call).with("topic", event, record)
       end
 
       specify "wraps around legacy implementation" do
@@ -28,7 +28,7 @@ module RubyEventStore
         record = Object.new
 
         expect(some_broker).to receive(:public_method).with(:call).and_return(double(arity: 2))
-        expect { instrumented_broker.call(event, record, "topic") }.to output(<<~EOS).to_stderr
+        expect { instrumented_broker.call("topic", event, record) }.to output(<<~EOS).to_stderr
             Message broker shall support topics.
             Topic WILL BE IGNORED in the current broker.
             Modify the broker implementation to pass topic as an argument to broker.call method.
@@ -45,9 +45,9 @@ module RubyEventStore
           record = Object.new
 
           expect(some_broker).to receive(:public_method).with(:call).and_return(double(arity: 3))
-          instrumented_broker.call(event, record, "topic")
+          instrumented_broker.call("topic", event, record)
 
-          expect(notification_calls).to eq([{ event: event, record: record, topic: "topic" }])
+          expect(notification_calls).to eq([{ topic: "topic", event: event, record: record }])
         end
       end
     end

--- a/ruby_event_store/spec/instrumented_broker_spec.rb
+++ b/ruby_event_store/spec/instrumented_broker_spec.rb
@@ -15,9 +15,9 @@ module RubyEventStore
         event = Object.new
         record = Object.new
 
-        instrumented_broker.call(event, record)
+        instrumented_broker.call(event, record, "topic")
 
-        expect(some_broker).to have_received(:call).with(event, record)
+        expect(some_broker).to have_received(:call).with(event, record, "topic")
       end
 
       specify "instruments" do
@@ -26,9 +26,9 @@ module RubyEventStore
           event = Object.new
           record = Object.new
 
-          instrumented_broker.call(event, record)
+          instrumented_broker.call(event, record, "topic")
 
-          expect(notification_calls).to eq([{ event: event, record: record }])
+          expect(notification_calls).to eq([{ event: event, record: record, topic: "topic" }])
         end
       end
     end

--- a/ruby_event_store/spec/instrumented_broker_spec.rb
+++ b/ruby_event_store/spec/instrumented_broker_spec.rb
@@ -57,22 +57,22 @@ module RubyEventStore
         some_broker = spy
         instrumented_broker = InstrumentedBroker.new(some_broker, ActiveSupport::Notifications)
         subscriber = -> {}
-        event_types = []
+        topics = []
 
-        instrumented_broker.add_subscription(subscriber, event_types)
+        instrumented_broker.add_subscription(subscriber, topics)
 
-        expect(some_broker).to have_received(:add_subscription).with(subscriber, event_types)
+        expect(some_broker).to have_received(:add_subscription).with(subscriber, topics)
       end
 
       specify "instruments" do
         instrumented_broker = InstrumentedBroker.new(spy, ActiveSupport::Notifications)
         subscribe_to("add_subscription.broker.rails_event_store") do |notification_calls|
           subscriber = -> {}
-          event_types = []
+          topics = []
 
-          instrumented_broker.add_subscription(subscriber, event_types)
+          instrumented_broker.add_subscription(subscriber, topics)
 
-          expect(notification_calls).to eq([{ subscriber: subscriber, event_types: event_types }])
+          expect(notification_calls).to eq([{ subscriber: subscriber, topics: topics }])
         end
       end
     end
@@ -105,22 +105,22 @@ module RubyEventStore
         some_broker = spy
         instrumented_broker = InstrumentedBroker.new(some_broker, ActiveSupport::Notifications)
         subscriber = -> {}
-        event_types = []
+        topics = []
 
-        instrumented_broker.add_thread_subscription(subscriber, event_types)
+        instrumented_broker.add_thread_subscription(subscriber, topics)
 
-        expect(some_broker).to have_received(:add_thread_subscription).with(subscriber, event_types)
+        expect(some_broker).to have_received(:add_thread_subscription).with(subscriber, topics)
       end
 
       specify "instruments" do
         instrumented_broker = InstrumentedBroker.new(spy, ActiveSupport::Notifications)
         subscribe_to("add_thread_subscription.broker.rails_event_store") do |notification_calls|
           subscriber = -> {}
-          event_types = []
+          topics = []
 
-          instrumented_broker.add_thread_subscription(subscriber, event_types)
+          instrumented_broker.add_thread_subscription(subscriber, topics)
 
-          expect(notification_calls).to eq([{ subscriber: subscriber, event_types: event_types }])
+          expect(notification_calls).to eq([{ subscriber: subscriber, topics: topics }])
         end
       end
     end
@@ -152,21 +152,21 @@ module RubyEventStore
       specify "wraps around original implementation" do
         some_broker = spy
         instrumented_broker = InstrumentedBroker.new(some_broker, ActiveSupport::Notifications)
-        event_type = String.new
+        topic = String.new
 
-        instrumented_broker.all_subscriptions_for(event_type)
+        instrumented_broker.all_subscriptions_for(topic)
 
-        expect(some_broker).to have_received(:all_subscriptions_for).with(event_type)
+        expect(some_broker).to have_received(:all_subscriptions_for).with(topic)
       end
 
       specify "instruments" do
         instrumented_broker = InstrumentedBroker.new(spy, ActiveSupport::Notifications)
         subscribe_to("all_subscriptions_for.broker.rails_event_store") do |notification_calls|
-          event_type = String.new
+          topic = String.new
 
-          instrumented_broker.all_subscriptions_for(event_type)
+          instrumented_broker.all_subscriptions_for(topic)
 
-          expect(notification_calls).to eq([{ event_type: event_type }])
+          expect(notification_calls).to eq([{ topic: topic }])
         end
       end
     end

--- a/ruby_event_store/spec/instrumented_broker_spec.rb
+++ b/ruby_event_store/spec/instrumented_broker_spec.rb
@@ -29,7 +29,7 @@ module RubyEventStore
 
         expect(some_broker).to receive(:public_method).with(:call).and_return(double(arity: 2))
         expect { instrumented_broker.call(event, record, "topic") }.to output(<<~EOS).to_stderr
-            Message broker shall support topics. 
+            Message broker shall support topics.
             Topic WILL BE IGNORED in the current broker.
             Modify the broker implementation to pass topic as an argument to broker.call method.
           EOS


### PR DESCRIPTION
Currently we always use event type as a topic to which events are published.
This PR allows developer to explicite specify topic.
If it is not specified (default behaviour) the event type is used as it is now (no breaking changes).