### PR TITLE
Pull request trigger should include synchronize type too

### DIFF
--- a/.github/workflows/aggregate_root_coverage.yml
+++ b/.github/workflows/aggregate_root_coverage.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - aggregate_root/Gemfile.lock
     - ".github/workflows/aggregate_root_coverage.yml"

--- a/.github/workflows/aggregate_root_mutate.yml
+++ b/.github/workflows/aggregate_root_mutate.yml
@@ -17,9 +17,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - aggregate_root/**
     - rails_event_store/**

--- a/.github/workflows/aggregate_root_test.yml
+++ b/.github/workflows/aggregate_root_test.yml
@@ -17,9 +17,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - aggregate_root/**
     - rails_event_store/**

--- a/.github/workflows/dres_client_test.yml
+++ b/.github/workflows/dres_client_test.yml
@@ -13,9 +13,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/dres_client/**
     - contrib/dres_rails/**

--- a/.github/workflows/dres_rails_test.yml
+++ b/.github/workflows/dres_rails_test.yml
@@ -13,9 +13,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/dres_client/**
     - contrib/dres_rails/**

--- a/.github/workflows/minitest-ruby_event_store_coverage.yml
+++ b/.github/workflows/minitest-ruby_event_store_coverage.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/minitest-ruby_event_store/Gemfile.lock
     - ".github/workflows/minitest-ruby_event_store_coverage.yml"

--- a/.github/workflows/minitest-ruby_event_store_mutate.yml
+++ b/.github/workflows/minitest-ruby_event_store_mutate.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/minitest-ruby_event_store/**
     - ".github/workflows/minitest-ruby_event_store_mutate.yml"

--- a/.github/workflows/minitest-ruby_event_store_test.yml
+++ b/.github/workflows/minitest-ruby_event_store_test.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/minitest-ruby_event_store/**
     - ".github/workflows/minitest-ruby_event_store_test.yml"

--- a/.github/workflows/rails_event_store_coverage.yml
+++ b/.github/workflows/rails_event_store_coverage.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - rails_event_store/Gemfile.lock
     - ".github/workflows/rails_event_store_coverage.yml"

--- a/.github/workflows/rails_event_store_mutate.yml
+++ b/.github/workflows/rails_event_store_mutate.yml
@@ -17,9 +17,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - aggregate_root/**
     - rails_event_store/**

--- a/.github/workflows/rails_event_store_test.yml
+++ b/.github/workflows/rails_event_store_test.yml
@@ -17,9 +17,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - aggregate_root/**
     - rails_event_store/**

--- a/.github/workflows/ruby_event_store-active_record_coverage.yml
+++ b/.github/workflows/ruby_event_store-active_record_coverage.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - ruby_event_store-active_record/Gemfile.lock
     - ".github/workflows/ruby_event_store-active_record_coverage.yml"

--- a/.github/workflows/ruby_event_store-active_record_mutate.yml
+++ b/.github/workflows/ruby_event_store-active_record_mutate.yml
@@ -17,9 +17,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - aggregate_root/**
     - rails_event_store/**

--- a/.github/workflows/ruby_event_store-active_record_test.yml
+++ b/.github/workflows/ruby_event_store-active_record_test.yml
@@ -17,9 +17,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - aggregate_root/**
     - rails_event_store/**

--- a/.github/workflows/ruby_event_store-browser_coverage.yml
+++ b/.github/workflows/ruby_event_store-browser_coverage.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - ruby_event_store-browser/Gemfile.lock
     - ".github/workflows/ruby_event_store-browser_coverage.yml"

--- a/.github/workflows/ruby_event_store-browser_mutate.yml
+++ b/.github/workflows/ruby_event_store-browser_mutate.yml
@@ -17,9 +17,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - aggregate_root/**
     - rails_event_store/**

--- a/.github/workflows/ruby_event_store-browser_test.yml
+++ b/.github/workflows/ruby_event_store-browser_test.yml
@@ -17,9 +17,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - aggregate_root/**
     - rails_event_store/**

--- a/.github/workflows/ruby_event_store-flipper_coverage.yml
+++ b/.github/workflows/ruby_event_store-flipper_coverage.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-flipper/Gemfile.lock
     - ".github/workflows/ruby_event_store-flipper_coverage.yml"

--- a/.github/workflows/ruby_event_store-flipper_mutate.yml
+++ b/.github/workflows/ruby_event_store-flipper_mutate.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-flipper/**
     - ".github/workflows/ruby_event_store-flipper_mutate.yml"

--- a/.github/workflows/ruby_event_store-flipper_test.yml
+++ b/.github/workflows/ruby_event_store-flipper_test.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-flipper/**
     - ".github/workflows/ruby_event_store-flipper_test.yml"

--- a/.github/workflows/ruby_event_store-newrelic_coverage.yml
+++ b/.github/workflows/ruby_event_store-newrelic_coverage.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-newrelic/Gemfile.lock
     - ".github/workflows/ruby_event_store-newrelic_coverage.yml"

--- a/.github/workflows/ruby_event_store-newrelic_mutate.yml
+++ b/.github/workflows/ruby_event_store-newrelic_mutate.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-newrelic/**
     - ".github/workflows/ruby_event_store-newrelic_mutate.yml"

--- a/.github/workflows/ruby_event_store-newrelic_test.yml
+++ b/.github/workflows/ruby_event_store-newrelic_test.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-newrelic/**
     - ".github/workflows/ruby_event_store-newrelic_test.yml"

--- a/.github/workflows/ruby_event_store-outbox_coverage.yml
+++ b/.github/workflows/ruby_event_store-outbox_coverage.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-outbox/Gemfile.lock
     - ".github/workflows/ruby_event_store-outbox_coverage.yml"

--- a/.github/workflows/ruby_event_store-outbox_mutate.yml
+++ b/.github/workflows/ruby_event_store-outbox_mutate.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-outbox/**
     - ".github/workflows/ruby_event_store-outbox_mutate.yml"

--- a/.github/workflows/ruby_event_store-outbox_test.yml
+++ b/.github/workflows/ruby_event_store-outbox_test.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-outbox/**
     - ".github/workflows/ruby_event_store-outbox_test.yml"

--- a/.github/workflows/ruby_event_store-profiler_coverage.yml
+++ b/.github/workflows/ruby_event_store-profiler_coverage.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-profiler/Gemfile.lock
     - ".github/workflows/ruby_event_store-profiler_coverage.yml"

--- a/.github/workflows/ruby_event_store-profiler_mutate.yml
+++ b/.github/workflows/ruby_event_store-profiler_mutate.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-profiler/**
     - ".github/workflows/ruby_event_store-profiler_mutate.yml"

--- a/.github/workflows/ruby_event_store-profiler_test.yml
+++ b/.github/workflows/ruby_event_store-profiler_test.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-profiler/**
     - ".github/workflows/ruby_event_store-profiler_test.yml"

--- a/.github/workflows/ruby_event_store-protobuf_coverage.yml
+++ b/.github/workflows/ruby_event_store-protobuf_coverage.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-protobuf/Gemfile.lock
     - ".github/workflows/ruby_event_store-protobuf_coverage.yml"

--- a/.github/workflows/ruby_event_store-protobuf_mutate.yml
+++ b/.github/workflows/ruby_event_store-protobuf_mutate.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-protobuf/**
     - ".github/workflows/ruby_event_store-protobuf_mutate.yml"

--- a/.github/workflows/ruby_event_store-protobuf_test.yml
+++ b/.github/workflows/ruby_event_store-protobuf_test.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-protobuf/**
     - ".github/workflows/ruby_event_store-protobuf_test.yml"

--- a/.github/workflows/ruby_event_store-rom_coverage.yml
+++ b/.github/workflows/ruby_event_store-rom_coverage.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-rom/Gemfile.lock
     - ".github/workflows/ruby_event_store-rom_coverage.yml"

--- a/.github/workflows/ruby_event_store-rom_mutate.yml
+++ b/.github/workflows/ruby_event_store-rom_mutate.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-rom/**
     - ".github/workflows/ruby_event_store-rom_mutate.yml"

--- a/.github/workflows/ruby_event_store-rom_test.yml
+++ b/.github/workflows/ruby_event_store-rom_test.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-rom/**
     - ".github/workflows/ruby_event_store-rom_test.yml"

--- a/.github/workflows/ruby_event_store-rspec_coverage.yml
+++ b/.github/workflows/ruby_event_store-rspec_coverage.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - ruby_event_store-rspec/Gemfile.lock
     - ".github/workflows/ruby_event_store-rspec_coverage.yml"

--- a/.github/workflows/ruby_event_store-rspec_mutate.yml
+++ b/.github/workflows/ruby_event_store-rspec_mutate.yml
@@ -17,9 +17,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - aggregate_root/**
     - rails_event_store/**

--- a/.github/workflows/ruby_event_store-rspec_test.yml
+++ b/.github/workflows/ruby_event_store-rspec_test.yml
@@ -17,9 +17,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - aggregate_root/**
     - rails_event_store/**

--- a/.github/workflows/ruby_event_store-sequel_coverage.yml
+++ b/.github/workflows/ruby_event_store-sequel_coverage.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-sequel/Gemfile.lock
     - ".github/workflows/ruby_event_store-sequel_coverage.yml"

--- a/.github/workflows/ruby_event_store-sequel_mutate.yml
+++ b/.github/workflows/ruby_event_store-sequel_mutate.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-sequel/**
     - ".github/workflows/ruby_event_store-sequel_mutate.yml"

--- a/.github/workflows/ruby_event_store-sequel_test.yml
+++ b/.github/workflows/ruby_event_store-sequel_test.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-sequel/**
     - ".github/workflows/ruby_event_store-sequel_test.yml"

--- a/.github/workflows/ruby_event_store-sidekiq_scheduler_coverage.yml
+++ b/.github/workflows/ruby_event_store-sidekiq_scheduler_coverage.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-sidekiq_scheduler/Gemfile.lock
     - ".github/workflows/ruby_event_store-sidekiq_scheduler_coverage.yml"

--- a/.github/workflows/ruby_event_store-sidekiq_scheduler_mutate.yml
+++ b/.github/workflows/ruby_event_store-sidekiq_scheduler_mutate.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-sidekiq_scheduler/**
     - ".github/workflows/ruby_event_store-sidekiq_scheduler_mutate.yml"

--- a/.github/workflows/ruby_event_store-sidekiq_scheduler_test.yml
+++ b/.github/workflows/ruby_event_store-sidekiq_scheduler_test.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-sidekiq_scheduler/**
     - ".github/workflows/ruby_event_store-sidekiq_scheduler_test.yml"

--- a/.github/workflows/ruby_event_store-transformations_coverage.yml
+++ b/.github/workflows/ruby_event_store-transformations_coverage.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-transformations/Gemfile.lock
     - ".github/workflows/ruby_event_store-transformations_coverage.yml"

--- a/.github/workflows/ruby_event_store-transformations_mutate.yml
+++ b/.github/workflows/ruby_event_store-transformations_mutate.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-transformations/**
     - ".github/workflows/ruby_event_store-transformations_mutate.yml"

--- a/.github/workflows/ruby_event_store-transformations_test.yml
+++ b/.github/workflows/ruby_event_store-transformations_test.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - contrib/ruby_event_store-transformations/**
     - ".github/workflows/ruby_event_store-transformations_test.yml"

--- a/.github/workflows/ruby_event_store_coverage.yml
+++ b/.github/workflows/ruby_event_store_coverage.yml
@@ -12,9 +12,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - ruby_event_store/Gemfile.lock
     - ".github/workflows/ruby_event_store_coverage.yml"

--- a/.github/workflows/ruby_event_store_mutate.yml
+++ b/.github/workflows/ruby_event_store_mutate.yml
@@ -17,9 +17,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - aggregate_root/**
     - rails_event_store/**

--- a/.github/workflows/ruby_event_store_test.yml
+++ b/.github/workflows/ruby_event_store_test.yml
@@ -17,9 +17,6 @@ on:
     - "!support/bundler/**"
     - "!support/ci/**"
   pull_request:
-    types:
-    - opened
-    - reopened
     paths:
     - aggregate_root/**
     - rails_event_store/**

--- a/support/ci/generate
+++ b/support/ci/generate
@@ -401,7 +401,7 @@ class CI
     end
 
     def pr_trigger(paths)
-      { "pull_request" => { "types" => %w[opened reopened], "paths" => paths } }
+      { "pull_request" => { "paths" => paths } }
     end
 
     def scheduled_trigger


### PR DESCRIPTION
In fact opened, reopened, synchronized are defaults — thus not
specifying types at all.

> For example, if no activity types are specified,
> the workflow runs when a pull request is opened or reopened
> or when the head branch of the pull request is updated

https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request
https://github.com/orgs/community/discussions/24567#discussioncomment-6307235
