### PR TITLE
Install c-ext gems selectively

### DIFF
--- a/.github/workflows/aggregate_root_coverage.yml
+++ b/.github/workflows/aggregate_root_coverage.yml
@@ -30,6 +30,7 @@ jobs:
       WORKING_DIRECTORY: aggregate_root
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/aggregate_root_mutate.yml
+++ b/.github/workflows/aggregate_root_mutate.yml
@@ -38,6 +38,7 @@ jobs:
       WORKING_DIRECTORY: aggregate_root
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/minitest-ruby_event_store_coverage.yml
+++ b/.github/workflows/minitest-ruby_event_store_coverage.yml
@@ -30,6 +30,7 @@ jobs:
       WORKING_DIRECTORY: contrib/minitest-ruby_event_store
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/minitest-ruby_event_store_mutate.yml
+++ b/.github/workflows/minitest-ruby_event_store_mutate.yml
@@ -28,6 +28,7 @@ jobs:
       WORKING_DIRECTORY: contrib/minitest-ruby_event_store
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rails_event_store_coverage.yml
+++ b/.github/workflows/rails_event_store_coverage.yml
@@ -30,6 +30,7 @@ jobs:
       WORKING_DIRECTORY: rails_event_store
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rails_event_store_mutate.yml
+++ b/.github/workflows/rails_event_store_mutate.yml
@@ -38,6 +38,7 @@ jobs:
       WORKING_DIRECTORY: rails_event_store
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby_event_store-active_record_coverage.yml
+++ b/.github/workflows/ruby_event_store-active_record_coverage.yml
@@ -24,12 +24,13 @@ on:
   - cron: 0 17 * * *
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     timeout-minutes: 120
     env:
       WORKING_DIRECTORY: ruby_event_store-active_record
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby_event_store-active_record_mutate.yml
+++ b/.github/workflows/ruby_event_store-active_record_mutate.yml
@@ -32,12 +32,13 @@ on:
     - "!support/ci/**"
 jobs:
   mutate:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     timeout-minutes: 120
     env:
       WORKING_DIRECTORY: ruby_event_store-active_record
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby_event_store-browser_coverage.yml
+++ b/.github/workflows/ruby_event_store-browser_coverage.yml
@@ -30,6 +30,7 @@ jobs:
       WORKING_DIRECTORY: ruby_event_store-browser
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby_event_store-browser_mutate.yml
+++ b/.github/workflows/ruby_event_store-browser_mutate.yml
@@ -38,6 +38,7 @@ jobs:
       WORKING_DIRECTORY: ruby_event_store-browser
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby_event_store-flipper_coverage.yml
+++ b/.github/workflows/ruby_event_store-flipper_coverage.yml
@@ -30,6 +30,7 @@ jobs:
       WORKING_DIRECTORY: contrib/ruby_event_store-flipper
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby_event_store-flipper_mutate.yml
+++ b/.github/workflows/ruby_event_store-flipper_mutate.yml
@@ -28,6 +28,7 @@ jobs:
       WORKING_DIRECTORY: contrib/ruby_event_store-flipper
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby_event_store-newrelic_coverage.yml
+++ b/.github/workflows/ruby_event_store-newrelic_coverage.yml
@@ -30,6 +30,7 @@ jobs:
       WORKING_DIRECTORY: contrib/ruby_event_store-newrelic
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby_event_store-newrelic_mutate.yml
+++ b/.github/workflows/ruby_event_store-newrelic_mutate.yml
@@ -28,6 +28,7 @@ jobs:
       WORKING_DIRECTORY: contrib/ruby_event_store-newrelic
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby_event_store-outbox_coverage.yml
+++ b/.github/workflows/ruby_event_store-outbox_coverage.yml
@@ -24,12 +24,13 @@ on:
   - cron: 0 17 * * *
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     timeout-minutes: 120
     env:
       WORKING_DIRECTORY: contrib/ruby_event_store-outbox
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby_event_store-outbox_mutate.yml
+++ b/.github/workflows/ruby_event_store-outbox_mutate.yml
@@ -22,12 +22,13 @@ on:
     - "!support/ci/**"
 jobs:
   mutate:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     timeout-minutes: 120
     env:
       WORKING_DIRECTORY: contrib/ruby_event_store-outbox
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby_event_store-profiler_coverage.yml
+++ b/.github/workflows/ruby_event_store-profiler_coverage.yml
@@ -30,6 +30,7 @@ jobs:
       WORKING_DIRECTORY: contrib/ruby_event_store-profiler
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby_event_store-profiler_mutate.yml
+++ b/.github/workflows/ruby_event_store-profiler_mutate.yml
@@ -28,6 +28,7 @@ jobs:
       WORKING_DIRECTORY: contrib/ruby_event_store-profiler
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby_event_store-protobuf_coverage.yml
+++ b/.github/workflows/ruby_event_store-protobuf_coverage.yml
@@ -30,6 +30,7 @@ jobs:
       WORKING_DIRECTORY: contrib/ruby_event_store-protobuf
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby_event_store-protobuf_mutate.yml
+++ b/.github/workflows/ruby_event_store-protobuf_mutate.yml
@@ -28,6 +28,7 @@ jobs:
       WORKING_DIRECTORY: contrib/ruby_event_store-protobuf
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby_event_store-rom_coverage.yml
+++ b/.github/workflows/ruby_event_store-rom_coverage.yml
@@ -24,12 +24,13 @@ on:
   - cron: 0 17 * * *
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     timeout-minutes: 120
     env:
       WORKING_DIRECTORY: contrib/ruby_event_store-rom
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby_event_store-rom_mutate.yml
+++ b/.github/workflows/ruby_event_store-rom_mutate.yml
@@ -22,12 +22,13 @@ on:
     - "!support/ci/**"
 jobs:
   mutate:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     timeout-minutes: 120
     env:
       WORKING_DIRECTORY: contrib/ruby_event_store-rom
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby_event_store-rspec_coverage.yml
+++ b/.github/workflows/ruby_event_store-rspec_coverage.yml
@@ -30,6 +30,7 @@ jobs:
       WORKING_DIRECTORY: ruby_event_store-rspec
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby_event_store-rspec_mutate.yml
+++ b/.github/workflows/ruby_event_store-rspec_mutate.yml
@@ -38,6 +38,7 @@ jobs:
       WORKING_DIRECTORY: ruby_event_store-rspec
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby_event_store-sequel_coverage.yml
+++ b/.github/workflows/ruby_event_store-sequel_coverage.yml
@@ -24,12 +24,13 @@ on:
   - cron: 0 17 * * *
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     timeout-minutes: 120
     env:
       WORKING_DIRECTORY: contrib/ruby_event_store-sequel
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby_event_store-sequel_mutate.yml
+++ b/.github/workflows/ruby_event_store-sequel_mutate.yml
@@ -22,12 +22,13 @@ on:
     - "!support/ci/**"
 jobs:
   mutate:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     timeout-minutes: 120
     env:
       WORKING_DIRECTORY: contrib/ruby_event_store-sequel
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby_event_store-sidekiq_scheduler_coverage.yml
+++ b/.github/workflows/ruby_event_store-sidekiq_scheduler_coverage.yml
@@ -30,6 +30,7 @@ jobs:
       WORKING_DIRECTORY: contrib/ruby_event_store-sidekiq_scheduler
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby_event_store-sidekiq_scheduler_mutate.yml
+++ b/.github/workflows/ruby_event_store-sidekiq_scheduler_mutate.yml
@@ -28,6 +28,7 @@ jobs:
       WORKING_DIRECTORY: contrib/ruby_event_store-sidekiq_scheduler
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby_event_store-transformations_coverage.yml
+++ b/.github/workflows/ruby_event_store-transformations_coverage.yml
@@ -30,6 +30,7 @@ jobs:
       WORKING_DIRECTORY: contrib/ruby_event_store-transformations
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby_event_store-transformations_mutate.yml
+++ b/.github/workflows/ruby_event_store-transformations_mutate.yml
@@ -28,6 +28,7 @@ jobs:
       WORKING_DIRECTORY: contrib/ruby_event_store-transformations
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby_event_store_coverage.yml
+++ b/.github/workflows/ruby_event_store_coverage.yml
@@ -30,6 +30,7 @@ jobs:
       WORKING_DIRECTORY: ruby_event_store
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby_event_store_mutate.yml
+++ b/.github/workflows/ruby_event_store_mutate.yml
@@ -38,6 +38,7 @@ jobs:
       WORKING_DIRECTORY: ruby_event_store
       RUBY_VERSION: "${{ matrix.ruby_version }}"
       BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      BUNDLE_WITHOUT: database
     strategy:
       fail-fast: false
       matrix:

--- a/support/bundler/Gemfile.database
+++ b/support/bundler/Gemfile.database
@@ -1,2 +1,4 @@
-gem "pg", "~> 1.5.6"
-gem "mysql2", "~> 0.5.6"
+group "database" do
+  gem "pg", "~> 1.5.6"
+  gem "mysql2", "~> 0.5.6"
+end

--- a/support/ci/generate
+++ b/support/ci/generate
@@ -101,8 +101,8 @@ class CI
             ),
           ),
       ),
-      release_mutate("ruby_event_store-active_record", runs_on: "ubuntu-latest"),
-      release_coverage("ruby_event_store-active_record", runs_on: "ubuntu-latest"),
+      release_mutate("ruby_event_store-active_record"),
+      release_coverage("ruby_event_store-active_record"),
       contrib_test(
         "ruby_event_store-flipper",
         matrix:
@@ -150,12 +150,10 @@ class CI
           setup_ruby,
           make_nix_shell("mutate-changes"),
         ],
-        runs_on: "ubuntu-latest",
       ),
       contrib_coverage(
         "ruby_event_store-outbox",
         steps: [checkout, setup_nix, setup_cachix, verify_lockfile, setup_ruby, make_nix_shell("mutate")],
-        runs_on: "ubuntu-latest",
       ),
       contrib_test("ruby_event_store-profiler"),
       contrib_mutate("ruby_event_store-profiler"),
@@ -198,8 +196,8 @@ class CI
             ),
           ),
       ),
-      contrib_mutate("ruby_event_store-rom", runs_on: "ubuntu-latest"),
-      contrib_coverage("ruby_event_store-rom", runs_on: "ubuntu-latest"),
+      contrib_mutate("ruby_event_store-rom"),
+      contrib_coverage("ruby_event_store-rom"),
       contrib_test(
         "ruby_event_store-sequel",
         services: [postgres_13, postgres_17, mysql_8_0, mysql_8_4],
@@ -225,8 +223,8 @@ class CI
             ),
           ),
       ),
-      contrib_mutate("ruby_event_store-sequel", runs_on: "ubuntu-latest"),
-      contrib_coverage("ruby_event_store-sequel", runs_on: "ubuntu-latest"),
+      contrib_mutate("ruby_event_store-sequel"),
+      contrib_coverage("ruby_event_store-sequel"),
       contrib_test(
         "ruby_event_store-sidekiq_scheduler",
         matrix: generate(ruby_version(MRI_RUBY), bundle_gemfile(GEMFILE, SIDEKIQ_GEMFILES)),
@@ -574,7 +572,8 @@ class CI
         steps: [checkout, verify_lockfile, setup_ruby, make("test")],
         services: [],
         triggers: release_triggers(name),
-        runs_on: "ubuntu-latest"
+        runs_on: "ubuntu-latest",
+        env: {}
       )
         @gem = gem
         @job_name = job_name
@@ -585,13 +584,14 @@ class CI
         @services = services
         @triggers = triggers
         @runs_on = runs_on
+        @env = env
       end
 
       def to_h
         { "name" => name, "on" => triggers.reduce(&:merge), "jobs" => { job_name => job } }
       end
 
-      attr_reader :gem, :job_name, :name, :working_directory, :matrix, :steps, :services, :triggers, :runs_on
+      attr_reader :gem, :job_name, :name, :working_directory, :matrix, :steps, :services, :triggers, :runs_on, :env
 
       private
 
@@ -599,7 +599,7 @@ class CI
         {
           "runs-on" => runs_on,
           "timeout-minutes" => 120,
-          "env" => { "WORKING_DIRECTORY" => working_directory }.merge(env(matrix)),
+          "env" => { "WORKING_DIRECTORY" => working_directory }.merge(mk_env(matrix)).merge(env),
           "services" => services.reduce(&:merge),
           "strategy" => {
             "fail-fast" => false,
@@ -611,7 +611,7 @@ class CI
         }.reject { |k, _| k == "services" && services.empty? }.reject { |k, _| k == "strategy" && matrix.empty? }
       end
 
-      def env(matrix)
+      def mk_env(matrix)
         matrix
           .take(1)
           .reduce({}) do |acc, matrix_item|
@@ -645,7 +645,17 @@ class CI
       steps: [checkout(depth: 0), verify_lockfile, setup_ruby, make("mutate-changes")],
       **
     )
-      Workflow.new(name, job_name: "mutate", matrix: matrix, steps: steps, runs_on: "macos-14", **)
+      Workflow.new(
+        name,
+        job_name: "mutate",
+        matrix: matrix,
+        steps: steps,
+        runs_on: "macos-14",
+        env: {
+          "BUNDLE_WITHOUT" => "database",
+        },
+        **,
+      )
     end
 
     def contrib_mutate(
@@ -663,6 +673,9 @@ class CI
         steps: steps,
         triggers: contrib_triggers("#{name}_mutate", working_directory),
         runs_on: "macos-14",
+        env: {
+          "BUNDLE_WITHOUT" => "database",
+        },
         **,
       )
     end
@@ -680,6 +693,9 @@ class CI
         steps: steps,
         triggers: coverage_triggers("#{name}_coverage", name),
         runs_on: "macos-14",
+        env: {
+          "BUNDLE_WITHOUT" => "database",
+        },
         **,
       )
     end
@@ -699,6 +715,9 @@ class CI
         steps: steps,
         triggers: coverage_triggers("#{name}_coverage", working_directory),
         runs_on: "macos-14",
+        env: {
+          "BUNDLE_WITHOUT" => "database",
+        },
         **,
       )
     end


### PR DESCRIPTION
This allows running mutant on M1 workers that do not have header files
for database drivers. And we don't need database drivers there (mutant
runs on in-memory sqlite).