### PR TITLE
original intent

### DIFF
--- a/ruby_event_store/lib/ruby_event_store/client.rb
+++ b/ruby_event_store/lib/ruby_event_store/client.rb
@@ -22,7 +22,6 @@ module RubyEventStore
       @event_type_resolver      = subscriptions.event_type_resolver
     end
 
-
     # Persists events and notifies subscribed handlers about them
     #
     # @param events [Array<Event>, Event] event(s)
@@ -110,7 +109,7 @@ module RubyEventStore
     def subscribe(subscriber = nil, to:, &proc)
       raise ArgumentError, "subscriber must be first argument or block, cannot be both" if subscriber && proc
       subscriber ||= proc
-      broker.add_subscription(subscriber, to)
+      broker.add_subscription(subscriber, to.map(&event_type_resolver))
     end
 
     # Subscribes a handler (subscriber) that will be invoked for all published events
@@ -140,11 +139,12 @@ module RubyEventStore
     # which are active only during the invocation of the provided
     # block of code.
     class Within
-      def initialize(block, broker)
+      def initialize(block, broker, resolver)
         @block = block
         @broker = broker
         @global_subscribers = []
         @subscribers = Hash.new {[]}
+        @resolver = resolver
       end
 
       # Subscribes temporary handlers that
@@ -176,9 +176,9 @@ module RubyEventStore
       #   @param to [Array<Class>] types of events to subscribe
       #   @param handler [Proc] handler passed as proc
       #   @return [self]
-      def subscribe(handler=nil, to:, &handler2)
+      def subscribe(handler = nil, to:, &handler2)
         raise ArgumentError if handler && handler2
-        @subscribers[handler || handler2] += Array(to)
+        @subscribers[handler || handler2] += Array(to).map(&resolver)
         self
       end
 
@@ -196,6 +196,7 @@ module RubyEventStore
       end
 
       private
+      attr_reader :resolver
 
       def add_thread_subscribers
         @subscribers.map do |subscriber, types|
@@ -217,7 +218,7 @@ module RubyEventStore
     # @return [Within] builder object which collects temporary subscriptions
     def within(&block)
       raise ArgumentError if block.nil?
-      Within.new(block, broker)
+      Within.new(block, broker, event_type_resolver)
     end
 
     # Set additional metadata for all events published within the provided block

--- a/ruby_event_store/lib/ruby_event_store/client.rb
+++ b/ruby_event_store/lib/ruby_event_store/client.rb
@@ -4,14 +4,14 @@ require 'concurrent'
 
 module RubyEventStore
   class Client
-    def initialize(repository:,
-                   mapper: Mappers::Default.new,
-                   subscriptions: Subscriptions.new,
-                   dispatcher: Dispatcher.new,
-                   clock: default_clock,
-                   correlation_id_generator: default_correlation_id_generator)
-
-
+    def initialize(
+      repository:,
+      mapper: Mappers::Default.new,
+      subscriptions: Subscriptions.new,
+      dispatcher: Dispatcher.new,
+      clock: default_clock,
+      correlation_id_generator: default_correlation_id_generator
+    )
       @repository     = repository
       @mapper         = mapper
       @subscriptions  = subscriptions
@@ -19,6 +19,7 @@ module RubyEventStore
       @clock          = clock
       @metadata       = Concurrent::ThreadLocalVar.new
       @correlation_id_generator = correlation_id_generator
+      @event_type_resolver      = subscriptions.event_type_resolver
     end
 
 
@@ -328,10 +329,6 @@ module RubyEventStore
 
     protected
 
-    def event_type_resolver
-      subscriptions.event_type_resolver
-    end
-
     def metadata=(value)
       @metadata.value = value
     end
@@ -344,6 +341,6 @@ module RubyEventStore
       ->{ SecureRandom.uuid }
     end
 
-    attr_reader :repository, :mapper, :subscriptions, :broker, :clock, :correlation_id_generator
+    attr_reader :repository, :mapper, :subscriptions, :broker, :clock, :correlation_id_generator, :event_type_resolver
   end
 end

--- a/ruby_event_store/lib/ruby_event_store/spec/subscriptions_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/subscriptions_lint.rb
@@ -22,8 +22,8 @@ RSpec.shared_examples :subscriptions do |subscriptions_class|
     another_handler = TestHandler.new
     global_handler  = TestHandler.new
 
-    subscriptions.add_subscription(handler, [Test1DomainEvent, Test3DomainEvent])
-    subscriptions.add_subscription(another_handler, [Test2DomainEvent])
+    subscriptions.add_subscription(handler, ['Test1DomainEvent', 'Test3DomainEvent'])
+    subscriptions.add_subscription(another_handler, ['Test2DomainEvent'])
     subscriptions.add_global_subscription(global_handler)
 
     expect(subscriptions.all_for('Test1DomainEvent')).to eq([handler, global_handler])
@@ -36,11 +36,11 @@ RSpec.shared_examples :subscriptions do |subscriptions_class|
     another_handler = TestHandler.new
     global_handler  = TestHandler.new
 
-    subscriptions.add_thread_subscription(handler, [Test1DomainEvent, Test3DomainEvent])
-    subscriptions.add_thread_subscription(another_handler, [Test2DomainEvent])
+    subscriptions.add_thread_subscription(handler, ['Test1DomainEvent', 'Test3DomainEvent'])
+    subscriptions.add_thread_subscription(another_handler, ['Test2DomainEvent'])
     subscriptions.add_thread_global_subscription(global_handler)
     t = Thread.new do
-      subscriptions.add_thread_subscription(handler, [Test2DomainEvent])
+      subscriptions.add_thread_subscription(handler, ['Test2DomainEvent'])
       subscriptions.add_thread_global_subscription(another_handler)
       expect(subscriptions.all_for('Test2DomainEvent')).to eq([another_handler, handler])
     end
@@ -77,7 +77,7 @@ RSpec.shared_examples :subscriptions do |subscriptions_class|
   it 'revokes subscription' do
     handler   = TestHandler.new
 
-    revoke    = subscriptions.add_subscription(handler, [Test1DomainEvent, Test2DomainEvent])
+    revoke    = subscriptions.add_subscription(handler, ['Test1DomainEvent', 'Test2DomainEvent'])
     expect(subscriptions.all_for('Test1DomainEvent')).to eq([handler])
     expect(subscriptions.all_for('Test2DomainEvent')).to eq([handler])
     revoke.()
@@ -99,7 +99,7 @@ RSpec.shared_examples :subscriptions do |subscriptions_class|
   it 'revokes thread subscription' do
     handler           = TestHandler.new
 
-    revoke    = subscriptions.add_thread_subscription(handler, [Test1DomainEvent, Test2DomainEvent])
+    revoke    = subscriptions.add_thread_subscription(handler, ['Test1DomainEvent', 'Test2DomainEvent'])
     expect(subscriptions.all_for('Test1DomainEvent')).to eq([handler])
     expect(subscriptions.all_for('Test2DomainEvent')).to eq([handler])
     revoke.()
@@ -117,8 +117,8 @@ RSpec.shared_examples :subscriptions do |subscriptions_class|
 
   it 'subscribes by type of event which is a class' do
     handler         = TestHandler.new
-    subscriptions.add_subscription(handler, [Test1DomainEvent])
-    subscriptions.add_thread_subscription(handler, [Test1DomainEvent])
+    subscriptions.add_subscription(handler, ['Test1DomainEvent'])
+    subscriptions.add_thread_subscription(handler, ['Test1DomainEvent'])
 
     expect(subscriptions.all_for('Test1DomainEvent')).to eq([handler, handler])
   end

--- a/ruby_event_store/lib/ruby_event_store/subscriptions.rb
+++ b/ruby_event_store/lib/ruby_event_store/subscriptions.rb
@@ -12,7 +12,7 @@ module RubyEventStore
     end
 
     def add_subscription(subscriber, event_types)
-      local.add(subscriber, resolve_event_types(event_types))
+      local.add(subscriber, event_types)
     end
 
     def add_global_subscription(subscriber)
@@ -20,7 +20,7 @@ module RubyEventStore
     end
 
     def add_thread_subscription(subscriber, event_types)
-      thread.local.add(subscriber, resolve_event_types(event_types))
+      thread.local.add(subscriber, event_types)
     end
 
     def add_thread_global_subscription(subscriber)
@@ -38,14 +38,6 @@ module RubyEventStore
 
     def default_event_type_resolver
       ->(value) { value.to_s }
-    end
-
-    def resolve_event_types(event_types)
-      event_types.map(&method(:resolve_event_type))
-    end
-
-    def resolve_event_type(type)
-      event_type_resolver.call(type)
     end
 
     class ThreadSubscriptions


### PR DESCRIPTION
- **Refactor**
  

- **Subscriptions don't transform class to event_type**
  Their scope is limited to event_type. Let facade od that heavy lifiting.
  