### PR TITLE
ActiveJob.perform_now(event) as a valid API to use when AsyncHandler is mixed in

### DIFF
--- a/rails_event_store/lib/rails_event_store/async_handler_helpers.rb
+++ b/rails_event_store/lib/rails_event_store/async_handler_helpers.rb
@@ -13,8 +13,12 @@ module RailsEventStore
     )
       Module.new do
         define_method :perform do |payload|
-          event_store = event_store_locator.call if event_store_locator
-          super(event_store.deserialize(serializer: serializer, **payload.transform_keys(&:to_sym)))
+          if Hash === payload
+            event_store = event_store_locator.call if event_store_locator
+            super(event_store.deserialize(serializer: serializer, **payload.transform_keys(&:to_sym)))
+          else
+            super(payload)
+          end
         end
       end
     end

--- a/rails_event_store/spec/async_handler_helpers_spec.rb
+++ b/rails_event_store/spec/async_handler_helpers_spec.rb
@@ -144,6 +144,26 @@ module RailsEventStore
       end
     end
 
+    specify "running inline via .perform_now" do
+      with_test_handler do |handler|
+        handler.prepend RailsEventStore::AsyncHandler
+
+        handler.perform_now(event)
+
+        expect_to_receive(event)
+      end
+    end
+
+    specify "running inline via #perform_now" do
+      with_test_handler do |handler|
+        handler.prepend RailsEventStore::AsyncHandler
+
+        handler.new(event).perform_now
+
+        expect_to_receive(event)
+      end
+    end
+
     private
 
     let(:event) { RubyEventStore::Event.new }


### PR DESCRIPTION
Figure out ways to unbreak `AJ.peform_now(payload)`