### PR TITLE
Delay loading ActiveRecord::Base for Rails

### DIFF
--- a/ruby_event_store-active_record/lib/ruby_event_store/active_record.rb
+++ b/ruby_event_store-active_record/lib/ruby_event_store/active_record.rb
@@ -7,7 +7,6 @@ require_relative "active_record/generators/event_id_index_migration_generator"
 require_relative "active_record/generators/rails_event_id_index_migration_generator"
 require_relative "active_record/generators/foreign_key_on_event_id_migration_generator"
 require_relative "active_record/generators/rails_foreign_key_on_event_id_migration_generator"
-require_relative "active_record/event"
 require_relative "active_record/with_default_models"
 require_relative "active_record/with_abstract_base_class"
 require_relative "active_record/event_repository"
@@ -16,4 +15,8 @@ require_relative "active_record/event_repository_reader"
 require_relative "active_record/index_violation_detector"
 require_relative "active_record/pg_linearized_event_repository"
 require_relative "active_record/version"
-require_relative "active_record/railtie" if defined?(Rails::Engine)
+if defined?(Rails::Engine)
+  require_relative "active_record/railtie"
+else
+  require_relative "active_record/event"
+end

--- a/ruby_event_store-active_record/lib/ruby_event_store/active_record/event_repository.rb
+++ b/ruby_event_store-active_record/lib/ruby_event_store/active_record/event_repository.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/array"
-
 module RubyEventStore
   module ActiveRecord
     class EventRepository

--- a/ruby_event_store-active_record/lib/ruby_event_store/active_record/railtie.rb
+++ b/ruby_event_store-active_record/lib/ruby_event_store/active_record/railtie.rb
@@ -2,6 +2,10 @@
 
 module RubyEventStore
   module ActiveRecord
-    Railtie = Class.new(::Rails::Railtie)
+    class Railtie < ::Rails::Railtie
+      initializer "ruby_event_store-active_record" do
+        ActiveSupport.on_load(:active_record) { require_relative "../active_record/event" }
+      end
+    end
   end
 end


### PR DESCRIPTION
Reason:
https://github.com/rails/rails/issues/31285

In short:

* when in Rails, let Rails load the models after it loads ActiveRecord
  itself

* when not Rails, proceed as usual
