### PR TITLE
Update browser time to follow ISO 8601 standard

### DIFF
--- a/ruby_event_store-browser/elm/src/BrowserTime.elm
+++ b/ruby_event_store-browser/elm/src/BrowserTime.elm
@@ -16,12 +16,12 @@ defaultTimeZone =
 format : TimeZone -> Time.Posix -> String
 format { zone } time =
     DateFormat.format
-        [ dayOfMonthFixed
-        , text "."
+        [ yearNumber
+        , text "-"
         , monthFixed
-        , text "."
-        , yearNumber
-        , text " "
+        , text "-"
+        , dayOfMonthFixed
+        , text "T"
         , hourMilitaryFixed
         , text ":"
         , minuteFixed


### PR DESCRIPTION
I'm finding it difficult to read little-endian datetime formats in the events browser. ISO 8601 is the most universally recognized standard that is locale-agnostic.

This PR updates the formatting logic for Rails Events Browser to use ISO 8601.