### PR TITLE
Avoid infinite loop when upcast is a no-op

### DIFF
--- a/ruby_event_store/lib/ruby_event_store/mappers/transformation/upcast.rb
+++ b/ruby_event_store/lib/ruby_event_store/mappers/transformation/upcast.rb
@@ -12,7 +12,7 @@ module RubyEventStore
           def call(record)
             identity = lambda { |r| r }
             new_record = @upcast_map.fetch(record.event_type, identity)[record]
-            new_record.equal?(record) ? record : call(new_record)
+            new_record == record ? record : call(new_record)
           end
         end
 


### PR DESCRIPTION
Equality check makes upcast to process again the record
even if the upcast itself made no changes (no-op).
