### PR TITLE
Add support for event pattern matching

### DIFF
--- a/ruby_event_store/lib/ruby_event_store/event.rb
+++ b/ruby_event_store/lib/ruby_event_store/event.rb
@@ -123,6 +123,21 @@ module RubyEventStore
       self
     end
 
+    # Returns a hash of the name/value pairs for the given event attributes.
+    #
+    # @param attributes [Array] attributes to deconstruct
+    # @return [Hash] deconstructed event
+    def deconstruct_keys(attributes)
+      {
+        causation_id: causation_id,
+        correlation_id: correlation_id,
+        data: data,
+        event_id: event_id,
+        event_type: event_type,
+        metadata: metadata.to_h
+      }.slice(*attributes)
+    end
+
     alias_method :eql?, :==
   end
 end


### PR DESCRIPTION
Pattern matching is available in Ruby since 2.7, so the lowest supported version (it was experimental then but nothing changed in usage).

This would allow to enhance event handlers with pattern matching like:

```ruby
def call(event)
  case event
  in Foo(event_id:, data: {abc: 1})
    handle_foo_for_abc_1(event_id, event)
  in Foo(data: {abc:})
    handle_foo_abc(abc)
  end # raise NoMatchingPatternError when nothing matches
end
```