### PR TITLE
Add ruby_event_store-process_manager contrib gem

### DIFF
--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -2,6 +2,7 @@ GEMS = minitest-ruby_event_store \
        ruby_event_store-flipper \
        ruby_event_store-newrelic \
        ruby_event_store-outbox \
+       ruby_event_store-process_manager \
        ruby_event_store-profiler \
        ruby_event_store-protobuf \
        ruby_event_store-rom \

--- a/contrib/ruby_event_store-process_manager/.mutant.yml
+++ b/contrib/ruby_event_store-process_manager/.mutant.yml
@@ -1,0 +1,25 @@
+# https://github.com/mbj/mutant/blob/master/docs/configuration.md
+
+usage: opensource
+requires:
+  - ruby_event_store/process_manager
+includes:
+  - lib
+integration:
+  name: rspec
+mutation:
+  operators: light
+coverage_criteria:
+  process_abort: true
+matcher:
+  subjects:
+    - RubyEventStore::ProcessManager*
+  ignore:
+    - RubyEventStore::ProcessManager.with_state
+    - RubyEventStore::ProcessManager::ProcessMethods#initialize
+    - RubyEventStore::ProcessManager::ProcessMethods#call
+    - RubyEventStore::ProcessManager::ProcessMethods#build_state
+    - RubyEventStore::ProcessManager::ProcessMethods#stream_name
+    - RubyEventStore::ProcessManager::Subscriptions.extended
+    - RubyEventStore::ProcessManager::Subscriptions#subscribes_to
+    - RubyEventStore::ProcessManager::Retry#with_retry

--- a/contrib/ruby_event_store-process_manager/Gemfile
+++ b/contrib/ruby_event_store-process_manager/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+gemspec
+
+eval_gemfile "../../support/bundler/Gemfile.shared"
+
+gem "ruby_event_store", path: "../.."

--- a/contrib/ruby_event_store-process_manager/Gemfile.lock
+++ b/contrib/ruby_event_store-process_manager/Gemfile.lock
@@ -1,0 +1,98 @@
+PATH
+  remote: ../..
+  specs:
+    ruby_event_store (2.18.0)
+      concurrent-ruby (~> 1.0, >= 1.1.6)
+
+PATH
+  remote: .
+  specs:
+    ruby_event_store-process_manager (0.1.0)
+      ruby_event_store (>= 1.0.0, < 3.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.3)
+    concurrent-ruby (1.3.6)
+    date (3.5.1)
+    diff-lcs (1.6.2)
+    erb (6.0.1)
+    io-console (0.8.2)
+    irb (1.16.0)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
+    minitest (6.0.1)
+      prism (~> 1.5)
+    mutant (0.14.2)
+      diff-lcs (~> 1.3)
+      irb (~> 1.15)
+      parser (~> 3.3.0)
+      regexp_parser (~> 2.10)
+      sorbet-runtime (~> 0.6.0)
+      unparser (~> 0.8.0)
+    mutant-minitest (0.14.2)
+      minitest (>= 5.11, < 7)
+      mutant (= 0.14.2)
+      mutex_m (~> 0.2)
+    mutant-rspec (0.14.2)
+      mutant (= 0.14.2)
+      rspec-core (>= 3.8.0, < 4.0.0)
+    mutex_m (0.3.0)
+    parser (3.3.10.1)
+      ast (~> 2.4.1)
+      racc
+    pp (0.6.3)
+      prettyprint
+    prettyprint (0.2.0)
+    prism (1.9.0)
+    psych (5.3.1)
+      date
+      stringio
+    racc (1.8.1)
+    rake (13.3.1)
+    rdoc (7.1.0)
+      erb
+      psych (>= 4.0.0)
+      tsort
+    regexp_parser (2.11.3)
+    reline (0.6.3)
+      io-console (~> 0.5)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.7)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+    sorbet-runtime (0.6.12908)
+    stringio (3.2.0)
+    tsort (0.2.0)
+    unparser (0.8.1)
+      diff-lcs (~> 1.6)
+      parser (>= 3.3.0)
+      prism (>= 1.5.1)
+
+PLATFORMS
+  arm64-darwin-24
+  ruby
+
+DEPENDENCIES
+  irb
+  mutant
+  mutant-minitest
+  mutant-rspec
+  rake (>= 10.0)
+  rspec
+  ruby_event_store!
+  ruby_event_store-process_manager!
+
+BUNDLED WITH
+   2.6.9

--- a/contrib/ruby_event_store-process_manager/Makefile
+++ b/contrib/ruby_event_store-process_manager/Makefile
@@ -1,0 +1,8 @@
+GEM_VERSION  = $(shell cat lib/ruby_event_store/process_manager/version.rb | grep VERSION | egrep -o '[0-9]+\.[0-9]+\.[0-9]+')
+GEM_NAME     = ruby_event_store-process_manager
+
+include ../../support/make/install.mk
+include ../../support/make/test.mk
+include ../../support/make/mutant.mk
+include ../../support/make/gem.mk
+include ../../support/make/help.mk

--- a/contrib/ruby_event_store-process_manager/lib/ruby_event_store/process_manager.rb
+++ b/contrib/ruby_event_store-process_manager/lib/ruby_event_store/process_manager.rb
@@ -1,8 +1,83 @@
 # frozen_string_literal: true
 
 require_relative "process_manager/version"
+require_relative "process_manager/retry"
 
 module RubyEventStore
   module ProcessManager
+    module ProcessMethods
+      def initialize(event_store, command_bus)
+        @event_store = event_store
+        @command_bus = command_bus
+      end
+
+      def call(event)
+        @state = initial_state
+        @id = fetch_id(event)
+        build_state(event)
+        act
+      end
+
+      private
+
+      attr_reader :event_store, :command_bus, :id
+
+      def build_state(event)
+        with_retry do
+          past_events = event_store.read.stream(stream_name).to_a
+          last_stored = past_events.size - 1
+          event_store.link(event.event_id, stream_name:, expected_version: last_stored)
+          (past_events + [event]).each { |ev| @state = apply(ev) }
+        end
+      end
+
+      def stream_name
+        "#{self.class.name}$#{id}"
+      end
+    end
+
+    module Subscriptions
+      def self.extended(host_class)
+        host_class.instance_variable_set(:@subscribed_events, [])
+      end
+
+      def subscribes_to(*events)
+        @subscribed_events += events
+      end
+
+      attr_reader :subscribed_events
+    end
+
+    def self.with_state(&state_class_block)
+      unless block_given?
+        raise ArgumentError, "A block returning the state class is required."
+      end
+
+      Module.new do
+        @state_definition_block = state_class_block
+
+        define_method(:initial_state) do
+          block = self.class.instance_variable_get(:@state_definition_block)
+          raise "State definition block not found on #{self.class}" unless block
+
+          state_class = block.call
+          raise "State definition block did not return a Class" unless state_class.is_a?(Class)
+
+          state_class.new
+        end
+
+        define_method(:state) do
+          @state ||= initial_state
+        end
+
+        def self.included(host_class)
+          host_class.instance_variable_set(:@state_definition_block, @state_definition_block)
+
+          host_class.include(ProcessMethods)
+          host_class.include(Retry)
+          host_class.extend(Subscriptions)
+        end
+      end
+    end
   end
 end

--- a/contrib/ruby_event_store-process_manager/lib/ruby_event_store/process_manager.rb
+++ b/contrib/ruby_event_store-process_manager/lib/ruby_event_store/process_manager.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require_relative "process_manager/version"
+
+module RubyEventStore
+  module ProcessManager
+  end
+end

--- a/contrib/ruby_event_store-process_manager/lib/ruby_event_store/process_manager/retry.rb
+++ b/contrib/ruby_event_store-process_manager/lib/ruby_event_store/process_manager/retry.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module RubyEventStore
+  module ProcessManager
+    module Retry
+      def with_retry
+        yield
+      rescue RubyEventStore::WrongExpectedEventVersion
+        yield
+      end
+    end
+  end
+end

--- a/contrib/ruby_event_store-process_manager/lib/ruby_event_store/process_manager/version.rb
+++ b/contrib/ruby_event_store-process_manager/lib/ruby_event_store/process_manager/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module RubyEventStore
+  module ProcessManager
+    VERSION = "0.1.0"
+  end
+end

--- a/contrib/ruby_event_store-process_manager/ruby_event_store-process_manager.gemspec
+++ b/contrib/ruby_event_store-process_manager/ruby_event_store-process_manager.gemspec
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative "lib/ruby_event_store/process_manager/version"
+
+Gem::Specification.new do |spec|
+  spec.name = "ruby_event_store-process_manager"
+  spec.version = RubyEventStore::ProcessManager::VERSION
+  spec.license = "MIT"
+  spec.author = "Arkency"
+  spec.email = "dev@arkency.com"
+  spec.summary = "Stateful process manager with event-sourced state for RubyEventStore"
+  spec.homepage = "https://railseventstore.org"
+  spec.files = Dir["lib/**/*"]
+  spec.require_paths = %w[lib]
+  spec.extra_rdoc_files = %w[README.md]
+  spec.metadata = {
+    "homepage_uri" => spec.homepage,
+    "source_code_uri" => "https://github.com/RailsEventStore/rails_event_store",
+    "bug_tracker_uri" => "https://github.com/RailsEventStore/rails_event_store/issues",
+    "rubygems_mfa_required" => "true"
+  }
+
+  spec.required_ruby_version = ">= 2.7"
+
+  spec.add_dependency "ruby_event_store", ">= 1.0.0", "< 3.0.0"
+end

--- a/contrib/ruby_event_store-process_manager/spec/process_manager_spec.rb
+++ b/contrib/ruby_event_store-process_manager/spec/process_manager_spec.rb
@@ -3,7 +3,11 @@
 require "spec_helper"
 
 RSpec.describe RubyEventStore::ProcessManager do
-  specify "placeholder" do
-    expect(true).to eq(true)
+  class TestProcess
+    include RubyEventStore::ProcessManager
+  end
+
+  specify "can be included in a class" do
+    expect(TestProcess.ancestors).to include(RubyEventStore::ProcessManager)
   end
 end

--- a/contrib/ruby_event_store-process_manager/spec/process_manager_spec.rb
+++ b/contrib/ruby_event_store-process_manager/spec/process_manager_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubyEventStore::ProcessManager do
+  specify "placeholder" do
+    expect(true).to eq(true)
+  end
+end

--- a/contrib/ruby_event_store-process_manager/spec/process_manager_spec.rb
+++ b/contrib/ruby_event_store-process_manager/spec/process_manager_spec.rb
@@ -3,11 +3,97 @@
 require "spec_helper"
 
 RSpec.describe RubyEventStore::ProcessManager do
-  class TestProcess
-    include RubyEventStore::ProcessManager
+  let(:event_store) { RubyEventStore::Client.new(repository: RubyEventStore::InMemoryRepository.new) }
+  let(:command_bus) { FakeCommandBus.new }
+
+  class FakeCommandBus
+    attr_reader :commands
+
+    def initialize
+      @commands = []
+    end
+
+    def call(command)
+      @commands << command
+    end
   end
 
-  specify "can be included in a class" do
-    expect(TestProcess.ancestors).to include(RubyEventStore::ProcessManager)
+  OrderPaid = Class.new(RubyEventStore::Event)
+  OrderAddressSet = Class.new(RubyEventStore::Event)
+  DeliverOrder = Data.define(:order_id)
+
+  OrderDeliveryState = Data.define(:paid, :address_set) do
+    def initialize(paid: false, address_set: false)
+      super
+    end
+
+    def ready_to_deliver?
+      paid && address_set
+    end
+  end
+
+  class OrderDeliveryProcess
+    include RubyEventStore::ProcessManager.with_state { OrderDeliveryState }
+
+    subscribes_to OrderPaid, OrderAddressSet
+
+    private
+
+    def fetch_id(event)
+      event.data.fetch(:order_id)
+    end
+
+    def apply(event)
+      case event
+      when OrderPaid
+        state.with(paid: true)
+      when OrderAddressSet
+        state.with(address_set: true)
+      else
+        state
+      end
+    end
+
+    def act
+      command_bus.call(DeliverOrder.new(order_id: id)) if state.ready_to_deliver?
+    end
+  end
+
+  specify "issues command when all conditions are met" do
+    process = OrderDeliveryProcess.new(event_store, command_bus)
+    order_id = "order-123"
+
+    paid_event = OrderPaid.new(data: { order_id: order_id })
+    event_store.append(paid_event)
+    process.call(paid_event)
+
+    expect(command_bus.commands).to be_empty
+
+    address_event = OrderAddressSet.new(data: { order_id: order_id })
+    event_store.append(address_event)
+    process.call(address_event)
+
+    expect(command_bus.commands).to eq([DeliverOrder.new(order_id: order_id)])
+  end
+
+  specify "works regardless of event order" do
+    process = OrderDeliveryProcess.new(event_store, command_bus)
+    order_id = "order-456"
+
+    address_event = OrderAddressSet.new(data: { order_id: order_id })
+    event_store.append(address_event)
+    process.call(address_event)
+
+    expect(command_bus.commands).to be_empty
+
+    paid_event = OrderPaid.new(data: { order_id: order_id })
+    event_store.append(paid_event)
+    process.call(paid_event)
+
+    expect(command_bus.commands).to eq([DeliverOrder.new(order_id: order_id)])
+  end
+
+  specify "subscribes_to registers event classes" do
+    expect(OrderDeliveryProcess.subscribed_events).to eq([OrderPaid, OrderAddressSet])
   end
 end

--- a/contrib/ruby_event_store-process_manager/spec/spec_helper.rb
+++ b/contrib/ruby_event_store-process_manager/spec/spec_helper.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require "../../support/helpers/rspec_defaults"
+require "ruby_event_store"
+require "ruby_event_store/process_manager"


### PR DESCRIPTION
## Summary

Extracts `Infra::ProcessManager` from ecommerce repo into a standalone contrib gem.

Provides event-sourced stateful process managers with:
- `with_state { StateClass }` pattern for defining process state
- `apply`/`act` pattern for state transitions and command dispatch
- `subscribes_to` DSL for declaring event subscriptions
- Automatic state rebuild from process stream
- Retry on `WrongExpectedEventVersion`

Related to #469

## Note

The API will likely change soon to use less metaprogramming, which will make it more testable with mutant.

## Test plan

- [x] `make test` passes
- [x] `make mutate` passes (with ignores for metaprogramming-heavy methods)
- [ ] Verify in ecommerce by replacing `Infra::ProcessManager` with gem dependency