### PR TITLE
Use Data.define to set Record & SerializedRecord classes

### DIFF
--- a/ruby_event_store/lib/ruby_event_store/errors.rb
+++ b/ruby_event_store/lib/ruby_event_store/errors.rb
@@ -14,6 +14,7 @@ module RubyEventStore
   InvalidHandler = Class.new(Error)
   EventNotFoundInStream = Class.new(Error)
   SubscriptionsNotSupported = Class.new(Error)
+  StringsRequired = Class.new(Error)
 
   class EventNotFound < Error
     attr_reader :event_id

--- a/ruby_event_store/lib/ruby_event_store/record.rb
+++ b/ruby_event_store/lib/ruby_event_store/record.rb
@@ -1,41 +1,11 @@
 # frozen_string_literal: true
 
 module RubyEventStore
-  class Record
-    StringsRequired = Class.new(StandardError)
+  Record = Data.define(:event_id, :data, :metadata, :event_type, :timestamp, :valid_at) do
     def initialize(event_id:, data:, metadata:, event_type:, timestamp:, valid_at:)
       raise StringsRequired unless [event_id, event_type].all? { |v| v.instance_of?(String) }
-      @event_id = event_id
-      @data = data
-      @metadata = metadata
-      @event_type = event_type
-      @timestamp = timestamp
-      @valid_at = valid_at
       @serialized_records = {}
-      freeze
-    end
-
-    attr_reader :event_id, :data, :metadata, :event_type, :timestamp, :valid_at
-
-    def hash
-      [event_id, data, metadata, event_type, timestamp, valid_at].hash ^ self.class.hash
-    end
-
-    def ==(other)
-      other.instance_of?(self.class) && other.event_id.eql?(event_id) && other.data.eql?(data) &&
-        other.metadata.eql?(metadata) && other.event_type.eql?(event_type) && other.timestamp.eql?(timestamp) &&
-        other.valid_at.eql?(valid_at)
-    end
-
-    def to_h
-      {
-        event_id: event_id,
-        data: data,
-        metadata: metadata,
-        event_type: event_type,
-        timestamp: timestamp,
-        valid_at: valid_at,
-      }
+      super
     end
 
     def serialize(serializer)
@@ -48,7 +18,6 @@ module RubyEventStore
         valid_at: valid_at.iso8601(TIMESTAMP_PRECISION),
       )
     end
-
-    alias_method :eql?, :==
   end
+  Record::StringsRequired = StringsRequired
 end

--- a/ruby_event_store/lib/ruby_event_store/serialized_record.rb
+++ b/ruby_event_store/lib/ruby_event_store/serialized_record.rb
@@ -1,40 +1,10 @@
 # frozen_string_literal: true
 
 module RubyEventStore
-  class SerializedRecord
-    StringsRequired = Class.new(StandardError)
+  SerializedRecord = Data.define(:event_id, :data, :metadata, :event_type, :timestamp, :valid_at) do
     def initialize(event_id:, data:, metadata:, event_type:, timestamp:, valid_at:)
       raise StringsRequired unless [event_id, event_type].all? { |v| v.instance_of?(String) }
-      @event_id = event_id
-      @data = data
-      @metadata = metadata
-      @event_type = event_type
-      @timestamp = timestamp
-      @valid_at = valid_at
-      freeze
-    end
-
-    attr_reader :event_id, :data, :metadata, :event_type, :timestamp, :valid_at
-
-    def hash
-      [event_id, data, metadata, event_type, timestamp, valid_at].hash ^ self.class.hash
-    end
-
-    def ==(other)
-      other.instance_of?(self.class) && other.event_id.eql?(event_id) && other.data.eql?(data) &&
-        other.metadata.eql?(metadata) && other.event_type.eql?(event_type) && other.timestamp.eql?(timestamp) &&
-        other.valid_at.eql?(valid_at)
-    end
-
-    def to_h
-      {
-        event_id: event_id,
-        data: data,
-        metadata: metadata,
-        event_type: event_type,
-        timestamp: timestamp,
-        valid_at: valid_at,
-      }
+      super
     end
 
     def deserialize(serializer)
@@ -47,7 +17,6 @@ module RubyEventStore
         valid_at: Time.iso8601(valid_at),
       )
     end
-
-    alias_method :eql?, :==
   end
+  SerializedRecord::StringsRequired = StringsRequired
 end


### PR DESCRIPTION
The same functionality, or even better because we have now the Data#with
method available. Less code as most of it is implemented by Data class.
StringsRequired error class has been moved to RubyEventStore::Errors
namespace but the alias classes has been added for backward
compatibility.
