### PR TITLE
Improve outbox docs

### DIFF
--- a/contrib/ruby_event_store-outbox/README.md
+++ b/contrib/ruby_event_store-outbox/README.md
@@ -32,8 +32,14 @@ Additionally, your handler's `through_outbox?` method should return `true`, for 
 
 ```ruby
 class SomeHandler
+  include Sidekiq::Worker
+
   def self.through_outbox?
     true
+  end
+
+  def perform(payload)
+    # handle the event
   end
 end
 ```

--- a/contrib/ruby_event_store-outbox/README.md
+++ b/contrib/ruby_event_store-outbox/README.md
@@ -83,7 +83,7 @@ res_outbox --database-url="mysql2://root@0.0.0.0:3306/my_database" \
   --redis-url="redis://localhost:6379/0" \
   --log-level=info \
   --split-keys=sidekiq_queue1,sidekiq_queue2 \
-  --metrics-url=http://user:password@localhost:8086/dbname"
+  --metrics-url=http://user:password@localhost:8086/dbname
 ```
 
 ## Contributing

--- a/contrib/ruby_event_store-outbox/README.md
+++ b/contrib/ruby_event_store-outbox/README.md
@@ -1,6 +1,6 @@
 # Ruby Event Store Outbox
 
-![Ruby Event Store Outbox](https://github.com/RailsEventStore/rails_event_store/workflows/ruby_event_store-outbox/badge.svg)
+![Ruby Event Store Outbox](https://github.com/RailsEventStore/rails_event_store/actions/workflows/ruby_event_store-outbox_test.yml/badge.svg)
 
 **Experimental feature of RES ecosystem.**
 

--- a/contrib/ruby_event_store-outbox/README.md
+++ b/contrib/ruby_event_store-outbox/README.md
@@ -58,6 +58,22 @@ res_outbox \
 
 It is possible to run as many instances as you prefer, but it does not make sense to run more instances than there are different split keys (sidekiq queues), as one process is operating at one moment only one split key.
 
+### Options
+
+| Option              | Required | Default  | Description                                                                                               |
+| ------------------- | -------- | -------- | --------------------------------------------------------------------------------------------------------- |
+| `--database-url`    | yes      | —        | Database where the outbox table is stored                                                                 |
+| `--redis-url`       | yes      | —        | URL to the Redis database                                                                                 |
+| `--split-keys`      | no       | all      | Comma-separated list of split keys (Sidekiq queues) to handle                                            |
+| `--batch-size`      | no       | 100      | Number of records fetched per iteration. Larger values increase the risk of duplicates on network failure |
+| `--sleep-on-empty`  | no       | 0.5      | Seconds to sleep before next check when there was nothing to process                                      |
+| `--[no-]lock`       | no       | enabled  | Use distributed locking per split key. Disable with `--no-lock` to use `SKIP LOCKED` instead             |
+| `--cleanup`         | no       | none     | Strategy for removing old enqueued records. Use ISO 8601 duration (e.g. `P7D` for 7 days) or `none`      |
+| `--cleanup-limit`   | no       | all      | Number of records removed per cleanup run, or `all`                                                       |
+| `--log-level`       | no       | warn     | One of: `fatal`, `error`, `warn`, `info`, `debug`                                                         |
+| `--message-format`  | no       | sidekiq5 | Message format. Currently only `sidekiq5` is supported                                                    |
+| `--metrics-url`     | no       | —        | URI to InfluxDB metrics collector                                                                         |
+
 ### Metrics
 
 It is possible for the outbox process to send metrics to InfluxDB (this requires influxdb gem in version at least 0.8.1). In order to do that, specify a `--metrics-url` parameter, for example:

--- a/contrib/ruby_event_store-outbox/README.md
+++ b/contrib/ruby_event_store-outbox/README.md
@@ -2,8 +2,6 @@
 
 ![Ruby Event Store Outbox](https://github.com/RailsEventStore/rails_event_store/actions/workflows/ruby_event_store-outbox_test.yml/badge.svg)
 
-**Experimental feature of RES ecosystem.**
-
 This repository includes a process and a Rails Event Store scheduler, which can be used to transactionally enqueue background jobs into your background jobs tool of choice. The scheduler included in this repo adds the jobs into the RDBMS into specific table instead of redis inside your transaction, and the process is enqueuing the jobs from that table to the background jobs tool.
 
 ## Installation (app)

--- a/contrib/ruby_event_store-outbox/README.md
+++ b/contrib/ruby_event_store-outbox/README.md
@@ -58,6 +58,12 @@ res_outbox \
 
 It is possible to run as many instances as you prefer, but it does not make sense to run more instances than there are different split keys (sidekiq queues), as one process is operating at one moment only one split key.
 
+### Split keys
+
+A split key is the Sidekiq queue name. Each outbox record is stored with the queue name of the target worker as its split key. The `res_outbox` process picks up records matching the split keys it is configured to handle.
+
+When `--split-keys` is omitted, the process handles all queues. When running multiple instances, assign a distinct subset of queues to each instance — there is no benefit to having more instances than queues, since one process handles only one split key at a time.
+
 ### Options
 
 | Option              | Required | Default  | Description                                                                                               |

--- a/contrib/ruby_event_store-outbox/README.md
+++ b/contrib/ruby_event_store-outbox/README.md
@@ -2,7 +2,7 @@
 
 ![Ruby Event Store Outbox](https://github.com/RailsEventStore/rails_event_store/actions/workflows/ruby_event_store-outbox_test.yml/badge.svg)
 
-This repository includes a process and a Rails Event Store scheduler, which can be used to transactionally enqueue background jobs into your background jobs tool of choice. The scheduler included in this repo adds the jobs into the RDBMS into specific table instead of redis inside your transaction, and the process is enqueuing the jobs from that table to the background jobs tool.
+This gem includes a process and a Rails Event Store scheduler, which can be used to transactionally enqueue background jobs into your background jobs tool of choice. The scheduler included in this gem adds the jobs into the RDBMS into specific table instead of redis inside your transaction, and the process is enqueuing the jobs from that table to the background jobs tool.
 
 ## Installation (app)
 

--- a/railseventstore.org/docs/advanced-topics/outbox.md
+++ b/railseventstore.org/docs/advanced-topics/outbox.md
@@ -1,0 +1,93 @@
+---
+title: Transactional outbox
+sidebar_label: Outbox
+---
+
+The `ruby_event_store-outbox` gem provides a way to enqueue background jobs transactionally. Instead of writing to Redis directly inside your transaction (which can leave jobs enqueued for events that later roll back), the scheduler writes the job into the same database table within the same transaction. A separate `res_outbox` process then drains that table to your background jobs tool.
+
+## Installation (app)
+
+Add to your Gemfile:
+
+```ruby
+gem "ruby_event_store-outbox"
+```
+
+Generate and execute the migration adding the necessary tables. If needed, change the type of the `payload` column to `mediumbinary` or `longbinary`.
+
+```
+bin/rails generate ruby_event_store:outbox:migration
+```
+
+In your event store configuration, use `RubyEventStore::ImmediateAsyncDispatcher` with `RubyEventStore::Outbox::SidekiqScheduler`:
+
+```ruby
+RailsEventStore::Client.new(
+  dispatcher: RailsEventStore::ImmediateAsyncDispatcher.new(scheduler: RubyEventStore::Outbox::SidekiqScheduler.new),
+  ...
+)
+```
+
+Your handler's `through_outbox?` method must return `true`:
+
+```ruby
+class SomeHandler
+  include Sidekiq::Worker
+
+  def self.through_outbox?
+    true
+  end
+
+  def perform(payload)
+    # handle the event
+  end
+end
+```
+
+## Installation (outbox process)
+
+Run the following process in any way you prefer:
+
+```
+res_outbox \
+  --database-url="mysql2://root@0.0.0.0:3306/my_database" \
+  --redis-url="redis://localhost:6379/0" \
+  --log-level=info \
+  --split-keys=sidekiq_queue1,sidekiq_queue2
+```
+
+It is possible to run as many instances as you prefer, but it does not make sense to run more instances than there are different split keys (sidekiq queues), as one process is operating at one moment only one split key.
+
+### Split keys
+
+A split key is the Sidekiq queue name. Each outbox record is stored with the queue name of the target worker as its split key. The `res_outbox` process picks up records matching the split keys it is configured to handle.
+
+When `--split-keys` is omitted, the process handles all queues. When running multiple instances, assign a distinct subset of queues to each instance — there is no benefit to having more instances than queues, since one process handles only one split key at a time.
+
+### Options
+
+| Option              | Required | Default  | Description                                                                                               |
+| ------------------- | -------- | -------- | --------------------------------------------------------------------------------------------------------- |
+| `--database-url`    | yes      | —        | Database where the outbox table is stored                                                                 |
+| `--redis-url`       | yes      | —        | URL to the Redis database                                                                                 |
+| `--split-keys`      | no       | all      | Comma-separated list of split keys (Sidekiq queues) to handle                                            |
+| `--batch-size`      | no       | 100      | Number of records fetched per iteration. Larger values increase the risk of duplicates on network failure |
+| `--sleep-on-empty`  | no       | 0.5      | Seconds to sleep before next check when there was nothing to process                                      |
+| `--[no-]lock`       | no       | enabled  | Use distributed locking per split key. Disable with `--no-lock` to use `SKIP LOCKED` instead             |
+| `--cleanup`         | no       | none     | Strategy for removing old enqueued records. Use ISO 8601 duration (e.g. `P7D` for 7 days) or `none`      |
+| `--cleanup-limit`   | no       | all      | Number of records removed per cleanup run, or `all`                                                       |
+| `--log-level`       | no       | warn     | One of: `fatal`, `error`, `warn`, `info`, `debug`                                                         |
+| `--message-format`  | no       | sidekiq5 | Message format. Currently only `sidekiq5` is supported                                                    |
+| `--metrics-url`     | no       | —        | URI to InfluxDB metrics collector                                                                         |
+
+### Metrics
+
+It is possible for the outbox process to send metrics to InfluxDB (this requires the `influxdb` gem in version at least 0.8.1). Specify a `--metrics-url` parameter:
+
+```
+res_outbox --database-url="mysql2://root@0.0.0.0:3306/my_database" \
+  --redis-url="redis://localhost:6379/0" \
+  --log-level=info \
+  --split-keys=sidekiq_queue1,sidekiq_queue2 \
+  --metrics-url=http://user:password@localhost:8086/dbname
+```

--- a/railseventstore.org/docs/core-concepts/subscribe.md
+++ b/railseventstore.org/docs/core-concepts/subscribe.md
@@ -413,6 +413,10 @@ end
 
 It means that when your `ActiveJob` adapter (such as sidekiq or resque) is using non-SQL store your handler might get called before the whole transaction is committed or when the transaction was rolled-back.
 
+### Transactional outbox
+
+Both `AfterCommitDispatcher` and `ImmediateDispatcher` enqueue jobs directly to Redis. If the network call to Redis fails after the database transaction commits, the job is lost. To guarantee that jobs are never lost, use the [transactional outbox](../advanced-topics/outbox) pattern: jobs are written to the same database within the same transaction, and a separate process drains them to Redis.
+
 ## Removing subscriptions
 
 When you define a new subscription by `subscribe` method execution it will return a lambda that allows to remove defined subscription.

--- a/railseventstore.org/sidebars.json
+++ b/railseventstore.org/sidebars.json
@@ -51,6 +51,7 @@
         "advanced-topics/gdpr",
         "advanced-topics/migrating-existing-events",
         "advanced-topics/without-rails",
+        "advanced-topics/outbox",
         "advanced-topics/protobuf.html"
       ]
     },


### PR DESCRIPTION
## Summary                                                                                                                                                                                                      
                  
  - Fix broken CI badge URL in the outbox README
  - Remove outdated "Experimental feature" label
  - Fix wording ("this repository" → "this gem")                                                                                                                                                                  
  - Fix incomplete handler example (missing `include Sidekiq::Worker` and `perform`)                                                                                                                              
  - Add CLI options table with Required, Default, and Description columns                                                                                                                                         
  - Add split keys explanation                                                                                                                                                                                    
  - Fix stray quote in metrics URL example                                                                                                                                                                        
  - Add outbox documentation page to railseventstore.org (Advanced Topics)