### PR TITLE
Update docs to use non-deprecated class names

### DIFF
--- a/contrib/ruby_event_store-outbox/README.md
+++ b/contrib/ruby_event_store-outbox/README.md
@@ -23,7 +23,7 @@ In your event store configuration, as a dispatcher use `RubyEventStore::Immediat
 ```ruby
 
 RailsEventStore::Client.new(
-  dispatcher: RailsEventStore::ImmediateAsyncDispatcher.new(scheduler: RubyEventStore::Outbox::SidekiqScheduler.new),
+  dispatcher: RubyEventStore::ImmediateDispatcher.new(scheduler: RubyEventStore::Outbox::SidekiqScheduler.new),
   ...
 )
 ```

--- a/contrib/ruby_event_store-sidekiq_scheduler/README.md
+++ b/contrib/ruby_event_store-sidekiq_scheduler/README.md
@@ -16,7 +16,7 @@ Declare the scheduler in your Ruby Event Store configuration. We recommend to us
 
 ```ruby
 event_store = RailsEventStore::Client.new(
-  dispatcher: RailsEventStore::AfterCommitAsyncDispatcher.new(scheduler: RubyEventStore::SidekiqScheduler.new(serializer: RubyEventStore::Serializers::YAML),
+  dispatcher: RailsEventStore::AfterCommitDispatcher.new(scheduler: RubyEventStore::SidekiqScheduler.new(serializer: RubyEventStore::Serializers::YAML),
 )
 ```
 

--- a/railseventstore.org/docs/advanced-topics/custom-repository.md
+++ b/railseventstore.org/docs/advanced-topics/custom-repository.md
@@ -56,7 +56,7 @@ RSpec.configure do |c|
   c.around(:each)
     Rails.configuration.event_store = RailsEventStore::Client.new(
       repository: RubyEventStore::InMemoryRepository.new,
-      mapper: RubyEventStore::Mappers::NullMapper.new,
+      mapper: RubyEventStore::Mappers::Default.new,
     )
     # add subscribers here
   end

--- a/railseventstore.org/docs/advanced-topics/event-serialization-formats.md
+++ b/railseventstore.org/docs/advanced-topics/event-serialization-formats.md
@@ -38,7 +38,7 @@ Serialization is needed not only when writing to and reading from storage, but a
 Rails.configuration.event_store = RailsEventStore::Client.new(
   message_broker: RubyEventStore::Broker.new( 
     dispatcher: RubyEventStore::ComposedDispatcher.new(
-      RailsEventStore::AfterCommitAsyncDispatcher.new(scheduler: ActiveJobScheduler.new(serializer: Marshal)),
+      RailsEventStore::AfterCommitDispatcher.new(scheduler: ActiveJobScheduler.new(serializer: Marshal)),
       RubyEventStore::Dispatcher.new
     )
   )

--- a/railseventstore.org/docs/advanced-topics/mappers.md
+++ b/railseventstore.org/docs/advanced-topics/mappers.md
@@ -21,8 +21,7 @@ the table below.
 
 - Default mapper for `RubyEventStore::Client` and `RailsEventStore::Client`
 - Transforms an event into a record (and back). Additionally it symbolizes metadata keys
-- Provide `events_class_remapping` optional constructor parameter, which is a hash, to map old event names to new ones
-  after you refactored your codebase
+- Deprecated: `events_class_remapping` — use [upcasting](../advanced-topics/migrating-existing-events) instead
 
 ### [RubyEventStore::Mappers::Protobuf](https://github.com/RailsEventStore/rails_event_store/blob/master/contrib/ruby_event_store-protobuf/lib/ruby_event_store/protobuf/mappers/protobuf.rb)
 
@@ -30,7 +29,7 @@ the table below.
 
 ### [RubyEventStore::Mappers::NullMapper](https://github.com/RailsEventStore/rails_event_store/blob/master/ruby_event_store/lib/ruby_event_store/mappers/null_mapper.rb)
 
-- Performs no transformations. It's useful in tests
+- Deprecated: use `RubyEventStore::Mappers::Default.new` instead
 
 ### [RubyEventStore::Mappers::EncryptionMapper](https://github.com/RailsEventStore/rails_event_store/blob/master/ruby_event_store/lib/ruby_event_store/mappers/encryption_mapper.rb)
 

--- a/railseventstore.org/docs/core-concepts/internals.mdx
+++ b/railseventstore.org/docs/core-concepts/internals.mdx
@@ -62,7 +62,7 @@ The `RailsEventStore::Client` default setup uses composed dispatchers, allowing 
 of delivering events to subscribers. The defined dispatchers are processed in order, 
 and the first capable of handling delivery is used. This enables a mix of synchronous 
 and asynchronous delivery of domain events.
-Asynchrounus delivery is handled by `RailsEventStore::AfterCommitAsyncDispatcher`, 
+Asynchrounus delivery is handled by `RailsEventStore::AfterCommitDispatcher`, 
 which ensures that domain events are scheduled in the asynchronous queue only after being stored in the database.
 By default, it uses `RailsEventStore::ActiveJobScheduler` to schedule processing via `ActiveJob`, but 
 other solutions have also been implemented (like `Sidekiq` using [`ruby_event_store-sidekiq_scheduler` gem](https://rubygems.org/search?query=ruby_event_store-sidekiq_scheduler)).

--- a/railseventstore.org/docs/core-concepts/subscribe.md
+++ b/railseventstore.org/docs/core-concepts/subscribe.md
@@ -330,7 +330,7 @@ Then you have to initialize `RailsEventStore::Client` using asynchronous dispatc
 event_store =
   RailsEventStore::Client.new(
     message_broker: RubyEventStore::Broker.new(
-      dispatcher: RailsEventStore::AfterCommitAsyncDispatcher.new(scheduler: CustomScheduler.new),
+      dispatcher: RailsEventStore::AfterCommitDispatcher.new(scheduler: CustomScheduler.new),
     ),
   )
 ```
@@ -343,15 +343,15 @@ event_store =
     message_broker: RubyEventStore::Broker.new(
       dispatcher:
         RubyEventStore::ComposedDispatcher.new(
-          RailsEventStore::AfterCommitAsyncDispatcher.new(scheduler: CustomScheduler.new), # our asynchronous dispatcher, which expects that subscriber respond to `perform_async` method
-          RubyEventStore::Dispatcher.new, # regular synchronous dispatcher
+          RailsEventStore::AfterCommitDispatcher.new(scheduler: CustomScheduler.new), # our asynchronous dispatcher, which expects that subscriber respond to `perform_async` method
+          RubyEventStore::SyncScheduler.new, # regular synchronous dispatcher
         ),
     ),
   )
 ```
 ### When are async handlers scheduled?
 
-The default behaviour and examples above use `RubyEventStore::AfterCommitAsyncDispatcher`, which schedule handlers after the transaction is committed.
+The default behaviour and examples above use `RailsEventStore::AfterCommitDispatcher`, which schedule handlers after the transaction is committed.
 
 ```ruby
 class SendOrderEmail < ActiveJob::Base
@@ -380,7 +380,7 @@ end
 
 ### Scheduling async handlers immediately
 
-You can configure your dispatcher slightly different, to schedule async handlers immediately after events are stored in the database. Note the usage of `RubyEventStore::ImmediateAsyncDispatcher` instead of `RailsEventStore::AfterCommitAsyncDispatcher`.
+You can configure your dispatcher slightly different, to schedule async handlers immediately after events are stored in the database. Note the usage of `RubyEventStore::ImmediateDispatcher` instead of `RailsEventStore::AfterCommitDispatcher`.
 
 ```ruby
 class SendOrderEmail < ActiveJob::Base
@@ -393,8 +393,8 @@ end
 event_store = RailsEventStore::Client.new(
   message_broker: RubyEventStore::Broker.new(
     dispatcher: RubyEventStore::ComposedDispatcher.new(
-      RailsEventStore::ImmediateAsyncDispatcher.new(scheduler: RailsEventStore::ActiveJobScheduler.new),
-      RubyEventStore::Dispatcher.new
+      RailsEventStore::ImmediateDispatcher.new(scheduler: RailsEventStore::ActiveJobScheduler.new),
+      RubyEventStore::SyncScheduler.new
     )
   )
 )

--- a/railseventstore.org/docs/publish-sequence-diagram.mmd
+++ b/railseventstore.org/docs/publish-sequence-diagram.mmd
@@ -18,7 +18,7 @@ sequenceDiagram
     participant b as RubyEventStore::Broker
     participant s as RubyEventStore::Subscriptions
     participant d as RubyEventStore::ComposedDispatcher
-    participant acd as RailsEventStore::AfterCommitAsyncDispatcher
+    participant acd as RailsEventStore::AfterCommitDispatcher
     participant ddp as RubyEventStore::Dispatcher
     participant ajs as RailsEventStore::ActiveJobScheduler
   end

--- a/railseventstore.org/docs/subscribe-sequence-diagram.mmd
+++ b/railseventstore.org/docs/subscribe-sequence-diagram.mmd
@@ -7,7 +7,7 @@ sequenceDiagram
     participant b as RubyEventStore::Broker
     participant s as RubyEventStore::Subscriptions
     participant d as RubyEventStore::ComposedDispatcher
-    participant acd as RailsEventStore::AfterCommitAsyncDispatcher
+    participant acd as RailsEventStore::AfterCommitDispatcher
     participant ddp as RubyEventStore::Dispatcher
     participant ajs as RailsEventStore::ActiveJobScheduler
   end


### PR DESCRIPTION
Follow-up after merging deprecation warnings (#1929).

Updates all current docs (excluding versioned snapshots) to use the new non-deprecated names:

- `ImmediateAsyncDispatcher` → `ImmediateDispatcher`
- `AfterCommitAsyncDispatcher` → `AfterCommitDispatcher`
- `Dispatcher` → `SyncScheduler`
- `NullMapper` → `Mappers::Default.new`
- `events_class_remapping:` → upcasting

Files changed: `subscribe.md`, `internals.mdx`, `subscribe-sequence-diagram.mmd`, `publish-sequence-diagram.mmd`, `event-serialization-formats.md`, `mappers.md`, `custom-repository.md`, outbox README, sidekiq_scheduler README.