### PR TITLE
Res mcp

### DIFF
--- a/.github/workflows/ruby_event_store-mcp_mutate.yml
+++ b/.github/workflows/ruby_event_store-mcp_mutate.yml
@@ -1,0 +1,52 @@
+name: ruby_event_store-mcp_mutate
+on:
+  workflow_dispatch:
+  repository_dispatch:
+    types:
+    - script
+  push:
+    branches:
+    - master
+    paths:
+    - contrib/ruby_event_store-mcp/**
+    - ".github/workflows/ruby_event_store-mcp_mutate.yml"
+    - support/**
+    - "!support/bundler/**"
+    - "!support/ci/**"
+  pull_request:
+    paths:
+    - contrib/ruby_event_store-mcp/**
+    - ".github/workflows/ruby_event_store-mcp_mutate.yml"
+    - support/**
+    - "!support/bundler/**"
+    - "!support/ci/**"
+jobs:
+  mutate:
+    runs-on: macos-14
+    timeout-minutes: 120
+    env:
+      WORKING_DIRECTORY: contrib/ruby_event_store-mcp
+      RUBY_VERSION: "${{ matrix.ruby_version }}"
+      BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+      SINCE_SHA: "${{ github.event.pull_request.base.sha || 'HEAD~1' }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - ruby_version: ruby-3.4
+          bundle_gemfile: Gemfile
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - run: test -e ${{ env.BUNDLE_GEMFILE }}.lock
+      working-directory: "${{ env.WORKING_DIRECTORY }}"
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: "${{ env.RUBY_VERSION }}"
+        bundler-cache: true
+        working-directory: "${{ env.WORKING_DIRECTORY }}"
+    - run: make mutate-changes
+      working-directory: "${{ env.WORKING_DIRECTORY }}"
+      env:
+        RUBYOPT: "--enable-frozen-string-literal"

--- a/.github/workflows/ruby_event_store-mcp_test.yml
+++ b/.github/workflows/ruby_event_store-mcp_test.yml
@@ -1,0 +1,55 @@
+name: ruby_event_store-mcp_test
+on:
+  workflow_dispatch:
+  repository_dispatch:
+    types:
+    - script
+  push:
+    branches:
+    - master
+    paths:
+    - contrib/ruby_event_store-mcp/**
+    - ".github/workflows/ruby_event_store-mcp_test.yml"
+    - support/**
+    - "!support/bundler/**"
+    - "!support/ci/**"
+  pull_request:
+    paths:
+    - contrib/ruby_event_store-mcp/**
+    - ".github/workflows/ruby_event_store-mcp_test.yml"
+    - support/**
+    - "!support/bundler/**"
+    - "!support/ci/**"
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    env:
+      WORKING_DIRECTORY: contrib/ruby_event_store-mcp
+      RUBY_VERSION: "${{ matrix.ruby_version }}"
+      BUNDLE_GEMFILE: "${{ matrix.bundle_gemfile }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - ruby_version: ruby-3.4
+          bundle_gemfile: Gemfile
+        - ruby_version: ruby-3.3
+          bundle_gemfile: Gemfile
+        - ruby_version: ruby-3.2
+          bundle_gemfile: Gemfile
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+    - run: test -e ${{ env.BUNDLE_GEMFILE }}.lock
+      working-directory: "${{ env.WORKING_DIRECTORY }}"
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: "${{ env.RUBY_VERSION }}"
+        bundler-cache: true
+        working-directory: "${{ env.WORKING_DIRECTORY }}"
+    - run: make test
+      working-directory: "${{ env.WORKING_DIRECTORY }}"
+      env:
+        RUBYOPT: "--enable-frozen-string-literal"

--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -9,6 +9,7 @@ GEMS = minitest-ruby_event_store \
        ruby_event_store-sequel \
        ruby_event_store-sidekiq_scheduler \
        ruby_event_store-transformations \
+       ruby_event_store-mcp \
 			 dres_rails \
 			 dres_client
 

--- a/contrib/ruby_event_store-mcp/.mutant.yml
+++ b/contrib/ruby_event_store-mcp/.mutant.yml
@@ -1,0 +1,16 @@
+# https://github.com/mbj/mutant/blob/master/docs/configuration.md
+
+usage: opensource
+requires:
+  - ruby_event_store/mcp
+includes:
+  - lib
+integration:
+  name: rspec
+mutation:
+  operators: light
+coverage_criteria:
+  process_abort: true
+matcher:
+  subjects:
+    - RubyEventStore::MCP*

--- a/contrib/ruby_event_store-mcp/.mutant.yml
+++ b/contrib/ruby_event_store-mcp/.mutant.yml
@@ -14,3 +14,5 @@ coverage_criteria:
 matcher:
   subjects:
     - RubyEventStore::MCP*
+  ignore:
+    - RubyEventStore::MCP::Server#start

--- a/contrib/ruby_event_store-mcp/Gemfile
+++ b/contrib/ruby_event_store-mcp/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+gemspec
+
+eval_gemfile "../../support/bundler/Gemfile.shared"
+gem "ruby_event_store", path: "../.."

--- a/contrib/ruby_event_store-mcp/Gemfile.lock
+++ b/contrib/ruby_event_store-mcp/Gemfile.lock
@@ -1,0 +1,101 @@
+PATH
+  remote: ../..
+  specs:
+    ruby_event_store (2.18.0)
+      concurrent-ruby (~> 1.0, >= 1.1.6)
+
+PATH
+  remote: .
+  specs:
+    ruby_event_store-mcp (0.1.0)
+      ruby_event_store (>= 1.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.3)
+    concurrent-ruby (1.3.6)
+    date (3.5.1)
+    diff-lcs (1.6.2)
+    drb (2.2.3)
+    erb (6.0.4)
+    io-console (0.8.2)
+    irb (1.18.0)
+      pp (>= 0.6.0)
+      prism (>= 1.3.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
+    minitest (6.0.5)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    mutant (0.15.1)
+      diff-lcs (>= 1.6, < 3)
+      irb (~> 1.15)
+      parser (~> 3.3.10)
+      regexp_parser (~> 2.10)
+      sorbet-runtime (~> 0.6.0)
+      unparser (~> 0.8.2)
+    mutant-minitest (0.15.1)
+      minitest (>= 5.11, < 7)
+      mutant (= 0.15.1)
+      mutex_m (~> 0.2)
+    mutant-rspec (0.15.1)
+      mutant (= 0.15.1)
+      rspec-core (>= 3.8.0, < 5.0.0)
+    mutex_m (0.3.0)
+    parser (3.3.11.1)
+      ast (~> 2.4.1)
+      racc
+    pp (0.6.3)
+      prettyprint
+    prettyprint (0.2.0)
+    prism (1.9.0)
+    psych (5.3.1)
+      date
+      stringio
+    racc (1.8.1)
+    rake (13.4.2)
+    rdoc (7.2.0)
+      erb
+      psych (>= 4.0.0)
+      tsort
+    regexp_parser (2.12.0)
+    reline (0.6.3)
+      io-console (~> 0.5)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+    sorbet-runtime (0.6.13164)
+    stringio (3.2.0)
+    tsort (0.2.0)
+    unparser (0.8.2)
+      diff-lcs (>= 1.6, < 3)
+      parser (>= 3.3.0)
+      prism (>= 1.5.1)
+
+PLATFORMS
+  arm64-darwin-23
+  ruby
+
+DEPENDENCIES
+  irb
+  mutant
+  mutant-minitest
+  mutant-rspec
+  rake (>= 10.0)
+  rspec
+  ruby_event_store!
+  ruby_event_store-mcp!
+
+BUNDLED WITH
+   2.7.1

--- a/contrib/ruby_event_store-mcp/Gemfile.lock
+++ b/contrib/ruby_event_store-mcp/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    ruby_event_store (2.18.0)
+    ruby_event_store (2.19.2)
       concurrent-ruby (~> 1.0, >= 1.1.6)
 
 PATH

--- a/contrib/ruby_event_store-mcp/Makefile
+++ b/contrib/ruby_event_store-mcp/Makefile
@@ -1,0 +1,8 @@
+GEM_VERSION  = $(shell cat lib/ruby_event_store/mcp/version.rb | grep VERSION | egrep -o '[0-9]+\.[0-9]+\.[0-9]+')
+GEM_NAME     = ruby_event_store-mcp
+
+include ../../support/make/install.mk
+include ../../support/make/test.mk
+include ../../support/make/mutant.mk
+include ../../support/make/gem.mk
+include ../../support/make/help.mk

--- a/contrib/ruby_event_store-mcp/README.md
+++ b/contrib/ruby_event_store-mcp/README.md
@@ -32,6 +32,16 @@ The server communicates over stdio using the MCP protocol. Configure it in Claud
 }
 ```
 
+**Claude Code config file locations:**
+
+- `~/.claude/settings.json` — global, works for all projects
+- `.claude/settings.json` — project-local, committed with your app
+
+**Claude Desktop config file locations:**
+
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
 ## Requirements
 
 - Ruby >= 3.0

--- a/contrib/ruby_event_store-mcp/README.md
+++ b/contrib/ruby_event_store-mcp/README.md
@@ -39,12 +39,14 @@ The server communicates over stdio using the MCP protocol. Configure it in Claud
 
 ## Available tools
 
-| Tool | Description |
-|---|---|
-| `stream_show` | Event count, version, first/last event for a stream |
-| `stream_events` | List events in a stream (filter by type, time range, limit) |
-| `event_show` | Full event details: data, metadata, timestamps |
-| `event_streams` | All streams an event has been published or linked to |
-| `search` | Search events by type, time range, or stream |
-| `stats` | Total event count and unique event types |
-| `trace` | Causation tree for all events sharing a correlation ID |
+| Tool                | Description                                                      |
+|---------------------|------------------------------------------------------------------|
+| `recent`            | Most recent events across all streams (default: 20, newest first)|
+| `stream_show`       | Event count, version, first/last event for a stream              |
+| `stream_events`     | List events in a stream (filter by type, time range, limit)      |
+| `event_show`        | Full event details: data, metadata, timestamps                   |
+| `event_streams`     | All streams an event has been published or linked to             |
+| `aggregate_history` | Full event history of an aggregate instance by type and ID       |
+| `search`            | Search events by type, time range, or stream                     |
+| `stats`             | Total event count and unique event types                         |
+| `trace`             | Causation tree for all events sharing a correlation ID           |

--- a/contrib/ruby_event_store-mcp/README.md
+++ b/contrib/ruby_event_store-mcp/README.md
@@ -1,0 +1,50 @@
+# ruby_event_store-mcp
+
+Model Context Protocol (MCP) server for [RubyEventStore](https://railseventstore.org). Exposes your event store as AI tools so Claude (and other MCP clients) can inspect streams, events, and causal relationships directly.
+
+## Installation
+
+Add to your Rails app's `Gemfile`:
+
+```ruby
+gem "ruby_event_store-mcp"
+```
+
+## Usage
+
+Run from the root of your Rails application:
+
+```bash
+bundle exec res-mcp
+```
+
+The server communicates over stdio using the MCP protocol. Configure it in Claude Desktop or Claude Code:
+
+```json
+{
+  "mcpServers": {
+    "res": {
+      "command": "bundle",
+      "args": ["exec", "res-mcp"],
+      "cwd": "/path/to/your/rails/app"
+    }
+  }
+}
+```
+
+## Requirements
+
+- Ruby >= 3.0
+- A Rails application with `Rails.configuration.event_store` configured
+
+## Available tools
+
+| Tool | Description |
+|---|---|
+| `stream_show` | Event count, version, first/last event for a stream |
+| `stream_events` | List events in a stream (filter by type, time range, limit) |
+| `event_show` | Full event details: data, metadata, timestamps |
+| `event_streams` | All streams an event has been published or linked to |
+| `search` | Search events by type, time range, or stream |
+| `stats` | Total event count and unique event types |
+| `trace` | Causation tree for all events sharing a correlation ID |

--- a/contrib/ruby_event_store-mcp/README.md
+++ b/contrib/ruby_event_store-mcp/README.md
@@ -18,7 +18,28 @@ Run from the root of your Rails application:
 bundle exec res-mcp
 ```
 
-The server communicates over stdio using the MCP protocol. Configure it in Claude Desktop or Claude Code:
+The server communicates over stdio using the MCP protocol. Installing the gem only provides the `res-mcp` binary — you still have to register it with your MCP client. Every client takes the same server definition; only the file it lives in differs.
+
+### Claude Code
+
+Add a `.mcp.json` to your project root (or run `claude mcp add res -- bundle exec res-mcp`):
+
+```json
+{
+  "mcpServers": {
+    "res": {
+      "command": "bundle",
+      "args": ["exec", "res-mcp"]
+    }
+  }
+}
+```
+
+Launched from the project directory, Claude Code runs the server there, so no `cwd` is needed. On the next launch Claude Code asks you to trust the server — approve it, then run `/mcp` to confirm `res` is connected with its tools.
+
+### Claude Desktop
+
+Add the same block with an explicit `cwd` pointing at your app's root, in `claude_desktop_config.json`:
 
 ```json
 {
@@ -32,15 +53,14 @@ The server communicates over stdio using the MCP protocol. Configure it in Claud
 }
 ```
 
-**Claude Code config file locations:**
-
-- `~/.claude/settings.json` — global, works for all projects
-- `.claude/settings.json` — project-local, committed with your app
-
-**Claude Desktop config file locations:**
+Config file locations:
 
 - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
 - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+### Other MCP clients
+
+Cursor, Windsurf, Cline and others take the same `mcpServers` block in their own config file. VS Code's built-in MCP support uses a `servers` key with `"type": "stdio"` instead. The `bundle exec res-mcp` command is the portable part.
 
 ## Requirements
 

--- a/contrib/ruby_event_store-mcp/bin/res-mcp
+++ b/contrib/ruby_event_store-mcp/bin/res-mcp
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../lib/ruby_event_store/mcp"
+
+env_file = File.expand_path("config/environment.rb")
+
+abort "Could not find config/environment.rb. Run `res-mcp` from the root of your Rails application." unless File.exist?(env_file)
+
+require env_file
+
+abort <<~MSG unless defined?(Rails) && Rails.configuration.respond_to?(:event_store)
+  Could not find event store instance after loading config/environment.rb.
+
+  Expected Rails.configuration.event_store to be set (standard RES setup).
+MSG
+
+RubyEventStore::MCP.server(Rails.configuration.event_store).start

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp.rb
@@ -1,9 +1,28 @@
 # frozen_string_literal: true
 
 require_relative "mcp/version"
+require_relative "mcp/read_events"
 require_relative "mcp/server"
+require_relative "mcp/tools/stream_show"
+require_relative "mcp/tools/stream_events"
+require_relative "mcp/tools/event_show"
+require_relative "mcp/tools/event_streams"
+require_relative "mcp/tools/search"
+require_relative "mcp/tools/stats"
+require_relative "mcp/tools/trace"
 
 module RubyEventStore
   module MCP
+    def self.server(event_store)
+      Server
+        .new(event_store: event_store)
+        .register(Tools::StreamShow.new)
+        .register(Tools::StreamEvents.new)
+        .register(Tools::EventShow.new)
+        .register(Tools::EventStreams.new)
+        .register(Tools::Search.new)
+        .register(Tools::Stats.new)
+        .register(Tools::Trace.new)
+    end
   end
 end

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp.rb
@@ -11,6 +11,7 @@ require_relative "mcp/tools/search"
 require_relative "mcp/tools/stats"
 require_relative "mcp/tools/trace"
 require_relative "mcp/tools/aggregate_history"
+require_relative "mcp/tools/recent"
 
 module RubyEventStore
   module MCP
@@ -25,6 +26,7 @@ module RubyEventStore
         .register(Tools::Stats.new)
         .register(Tools::Trace.new)
         .register(Tools::AggregateHistory.new)
+        .register(Tools::Recent.new)
     end
   end
 end

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "mcp/version"
+require_relative "mcp/server"
 
 module RubyEventStore
   module MCP

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require_relative "mcp/version"
+
+module RubyEventStore
+  module MCP
+  end
+end

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp.rb
@@ -10,6 +10,7 @@ require_relative "mcp/tools/event_streams"
 require_relative "mcp/tools/search"
 require_relative "mcp/tools/stats"
 require_relative "mcp/tools/trace"
+require_relative "mcp/tools/aggregate_history"
 
 module RubyEventStore
   module MCP
@@ -23,6 +24,7 @@ module RubyEventStore
         .register(Tools::Search.new)
         .register(Tools::Stats.new)
         .register(Tools::Trace.new)
+        .register(Tools::AggregateHistory.new)
     end
   end
 end

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/read_events.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/read_events.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module RubyEventStore
+  module MCP
+    class ReadEvents
+      def self.of(specification, type: nil, after: nil, before: nil, from: nil, limit: nil)
+        specification = specification.of_type(resolve_type(type))    if type
+        specification = specification.newer_than(Time.parse(after))  if after
+        specification = specification.older_than(Time.parse(before)) if before
+        specification = specification.from(from)                     if from
+        limit ? specification.limit(limit.to_i).to_a : specification.to_a
+      end
+
+      def self.resolve_type(name)
+        Object.const_get(name)
+      rescue NameError
+        raise "Unknown event type: #{name}"
+      end
+    end
+  end
+end

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/server.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/server.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "json"
+
+module RubyEventStore
+  module MCP
+    class Server
+      PROTOCOL_VERSION = "2024-11-05"
+
+      attr_reader :event_store, :name, :version, :tools
+
+      def initialize(event_store:, name: "ruby-event-store", version: VERSION)
+        @event_store = event_store
+        @name = name
+        @version = version
+        @tools = []
+      end
+
+      def register(tool)
+        tools << tool
+        self
+      end
+
+      def start(input: $stdin, output: $stdout)
+        output.sync = true
+        input.each_line do |line|
+          request = JSON.parse(line.strip)
+          response = handle(request)
+          output.puts(JSON.generate(response)) if response
+        end
+      end
+
+      private
+
+      def handle(request)
+        id = request["id"]
+        method = request["method"]
+
+        case method
+        when "initialize"
+          result = {
+            protocolVersion: PROTOCOL_VERSION,
+            capabilities: { tools: {} },
+            serverInfo: { name: name, version: version }
+          }
+          jsonrpc_result(id, result)
+        when "notifications/initialized"
+          nil
+        when "tools/list"
+          jsonrpc_result(id, { tools: tools.map(&:schema) })
+        when "tools/call"
+          call_tool(id, request["params"])
+        when "ping"
+          jsonrpc_result(id, {})
+        else
+          jsonrpc_error(id, -32601, "Method not found: #{method}")
+        end
+      rescue => e
+        jsonrpc_error(request["id"], -32603, e.message)
+      end
+
+      def call_tool(id, params)
+        tool_name = params["name"]
+        arguments = params["arguments"] || {}
+        tool = tools.find { |t| t.name == tool_name }
+        return jsonrpc_result(id, { content: [{ type: "text", text: "Unknown tool: #{tool_name}" }], isError: true }) unless tool
+
+        result = tool.call(event_store, arguments)
+        jsonrpc_result(id, { content: [{ type: "text", text: result }] })
+      rescue => e
+        jsonrpc_result(id, { content: [{ type: "text", text: "Error: #{e.message}" }], isError: true })
+      end
+
+      def jsonrpc_result(id, result)
+        { jsonrpc: "2.0", id: id, result: result }
+      end
+
+      def jsonrpc_error(id, code, message)
+        { jsonrpc: "2.0", id: id, error: { code: code, message: message } }
+      end
+    end
+  end
+end

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/aggregate_history.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/aggregate_history.rb
@@ -38,12 +38,9 @@ module RubyEventStore
         end
 
         def render(stream_name, events)
-          lines = ["Aggregate: #{stream_name}", "Events:    #{events.size}"]
-          unless events.empty?
-            lines << ""
-            lines.concat(events.map { |e| "#{e.timestamp.iso8601(3)}  #{e.event_type}  [#{e.event_id}]" })
-          end
-          lines.join("\n")
+          header = "Aggregate: #{stream_name}\nEvents:    #{events.size}"
+          return header if events.empty?
+          "#{header}\n\n#{events.map { |e| "#{e.timestamp.iso8601(3)}  #{e.event_type}  [#{e.event_id}]" }.join("\n")}"
         end
       end
     end

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/aggregate_history.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/aggregate_history.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module RubyEventStore
+  module MCP
+    module Tools
+      class AggregateHistory
+        def name
+          "aggregate_history"
+        end
+
+        def schema
+          {
+            name: name,
+            description: "Show the full event history of an aggregate instance",
+            inputSchema: {
+              type: "object",
+              properties: {
+                aggregate_type: { type: "string", description: "Aggregate class name (e.g. Order, Payment::Invoice)" },
+                aggregate_id: { type: "string", description: "Aggregate ID (UUID or other identifier)" }
+              },
+              required: %w[aggregate_type aggregate_id]
+            }
+          }
+        end
+
+        def call(event_store, args)
+          aggregate_type = args.fetch("aggregate_type")
+          aggregate_id = args.fetch("aggregate_id")
+          stream_name = "#{aggregate_type}$#{aggregate_id}"
+          events = events(event_store, stream_name)
+          render(stream_name, events)
+        end
+
+        private
+
+        def events(event_store, stream_name)
+          event_store.read.stream(stream_name).to_a
+        end
+
+        def render(stream_name, events)
+          lines = ["Aggregate: #{stream_name}", "Events:    #{events.size}"]
+          unless events.empty?
+            lines << ""
+            lines.concat(events.map { |e| "#{e.timestamp.iso8601(3)}  #{e.event_type}  [#{e.event_id}]" })
+          end
+          lines.join("\n")
+        end
+      end
+    end
+  end
+end

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/event_show.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/event_show.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "json"
+
+module RubyEventStore
+  module MCP
+    module Tools
+      class EventShow
+        def name
+          "event_show"
+        end
+
+        def schema
+          {
+            name: name,
+            description: "Show full event details including data, metadata, and timestamps",
+            inputSchema: {
+              type: "object",
+              properties: {
+                event_id: { type: "string", description: "Event ID (UUID)" }
+              },
+              required: ["event_id"]
+            }
+          }
+        end
+
+        def call(event_store, args)
+          event = event_store.read.event!(args["event_id"])
+          format_event(event)
+        end
+
+        private
+
+        def format_event(event)
+          [
+            "Event ID:   #{event.event_id}",
+            "Type:       #{event.event_type}",
+            "Timestamp:  #{event.timestamp.iso8601(3)}",
+            "Valid at:   #{event.valid_at.iso8601(3)}",
+            "Data:       #{JSON.pretty_generate(event.data)}",
+            "Metadata:   #{JSON.pretty_generate(event.metadata.to_h)}"
+          ].join("\n")
+        end
+      end
+    end
+  end
+end

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/event_show.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/event_show.rb
@@ -25,7 +25,7 @@ module RubyEventStore
         end
 
         def call(event_store, args)
-          event = event_store.read.event!(args["event_id"])
+          event = event_store.read.event!(args.fetch("event_id"))
           format_event(event)
         end
 

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/event_streams.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/event_streams.rb
@@ -23,7 +23,7 @@ module RubyEventStore
         end
 
         def call(event_store, args)
-          streams = event_store.streams_of(args["event_id"])
+          streams = event_store.streams_of(args.fetch("event_id"))
           return "(no streams — event not found or not linked to any stream)" if streams.empty?
           format_streams(streams)
         end

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/event_streams.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/event_streams.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module RubyEventStore
+  module MCP
+    module Tools
+      class EventStreams
+        def name
+          "event_streams"
+        end
+
+        def schema
+          {
+            name: name,
+            description: "List all streams the event has been published or linked to",
+            inputSchema: {
+              type: "object",
+              properties: {
+                event_id: { type: "string", description: "Event ID (UUID)" }
+              },
+              required: ["event_id"]
+            }
+          }
+        end
+
+        def call(event_store, args)
+          streams = event_store.streams_of(args["event_id"])
+          return "(no streams — event not found or not linked to any stream)" if streams.empty?
+          format_streams(streams)
+        end
+
+        private
+
+        def format_streams(streams)
+          streams.map(&:name).join("\n")
+        end
+      end
+    end
+  end
+end

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/recent.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/recent.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module RubyEventStore
+  module MCP
+    module Tools
+      class Recent
+        DEFAULT_LIMIT = 20
+
+        def name
+          "recent"
+        end
+
+        def schema
+          {
+            name: name,
+            description: "Show the most recent events across all streams",
+            inputSchema: {
+              type: "object",
+              properties: {
+                limit: { type: "integer", description: "Number of events to return (default: #{DEFAULT_LIMIT})" }
+              },
+              required: []
+            }
+          }
+        end
+
+        def call(event_store, args)
+          limit = args.fetch("limit", DEFAULT_LIMIT).to_i
+          events = event_store.read.limit(limit).backward.to_a
+          return "(no events)" if events.empty?
+          render(events)
+        end
+
+        private
+
+        def render(events)
+          events.map { |e| "#{e.timestamp.iso8601(3)}  #{e.event_type}  [#{e.event_id}]" }.join("\n")
+        end
+      end
+    end
+  end
+end

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/search.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/search.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require_relative "../read_events"
+
+module RubyEventStore
+  module MCP
+    module Tools
+      class Search
+        def name
+          "search"
+        end
+
+        def schema
+          {
+            name: name,
+            description: "Search events across all streams by type, time range, or stream name",
+            inputSchema: {
+              type: "object",
+              properties: {
+                type: { type: "string", description: "Filter by event type class name" },
+                after: { type: "string", description: "Filter events newer than timestamp (ISO8601)" },
+                before: { type: "string", description: "Filter events older than timestamp (ISO8601)" },
+                stream: { type: "string", description: "Limit search to a specific stream" },
+                limit: { type: "integer", description: "Max number of events (default: 50)" }
+              }
+            }
+          }
+        end
+
+        def call(event_store, args)
+          specification = args["stream"] ? event_store.read.stream(args["stream"]) : event_store.read
+          events = ReadEvents.of(
+            specification,
+            type: args["type"],
+            after: args["after"],
+            before: args["before"],
+            limit: args.fetch("limit", 50)
+          )
+          return "(no events found)" if events.empty?
+          format_events(events)
+        end
+
+        private
+
+        def format_events(events)
+          events.map { |e| "#{e.timestamp.iso8601(3)}  #{e.event_type}  [#{e.event_id}]" }.join("\n")
+        end
+      end
+    end
+  end
+end

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/search.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/search.rb
@@ -28,7 +28,7 @@ module RubyEventStore
         end
 
         def call(event_store, args)
-          specification = args["stream"] ? event_store.read.stream(args["stream"]) : event_store.read
+          specification = args.key?("stream") ? event_store.read.stream(args.fetch("stream")) : event_store.read
           events = ReadEvents.of(
             specification,
             type: args["type"],

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/stats.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/stats.rb
@@ -22,7 +22,7 @@ module RubyEventStore
         end
 
         def call(event_store, args)
-          specification = args["stream"] ? event_store.read.stream(args["stream"]) : event_store.read
+          specification = args.key?("stream") ? event_store.read.stream(args.fetch("stream")) : event_store.read
           format_stats(specification, stream: args["stream"])
         end
 

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/stats.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/stats.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module RubyEventStore
+  module MCP
+    module Tools
+      class Stats
+        def name
+          "stats"
+        end
+
+        def schema
+          {
+            name: name,
+            description: "Show event count and unique event types. Use stream to get per-stream stats.",
+            inputSchema: {
+              type: "object",
+              properties: {
+                stream: { type: "string", description: "Show stats for a specific stream" }
+              }
+            }
+          }
+        end
+
+        def call(event_store, args)
+          specification = args["stream"] ? event_store.read.stream(args["stream"]) : event_store.read
+          format_stats(specification, stream: args["stream"])
+        end
+
+        private
+
+        def format_stats(specification, stream:)
+          lines = []
+          lines << "Stream:  #{stream}" if stream
+          lines << "Events:  #{specification.count}"
+          lines.concat(format_event_types(specification))
+          lines.join("\n")
+        end
+
+        def format_event_types(specification)
+          types = specification.map(&:event_type).uniq.sort
+          return [] if types.empty?
+          ["\nEvent types:"] + types.map { |t| "  #{t}" }
+        end
+      end
+    end
+  end
+end

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/stream_events.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/stream_events.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_relative "../read_events"
+
+module RubyEventStore
+  module MCP
+    module Tools
+      class StreamEvents
+        def name
+          "stream_events"
+        end
+
+        def schema
+          {
+            name: name,
+            description: "List events in a stream with optional filters",
+            inputSchema: {
+              type: "object",
+              properties: {
+                stream_name: { type: "string", description: "Stream name" },
+                limit: { type: "integer", description: "Max number of events (default: 20)" },
+                type: { type: "string", description: "Filter by event type class name" },
+                after: { type: "string", description: "Filter events newer than timestamp (ISO8601)" },
+                before: { type: "string", description: "Filter events older than timestamp (ISO8601)" },
+                from: { type: "string", description: "Start reading from event ID (exclusive)" }
+              },
+              required: ["stream_name"]
+            }
+          }
+        end
+
+        def call(event_store, args)
+          events = ReadEvents.of(
+            event_store.read.stream(args["stream_name"]),
+            type: args["type"],
+            after: args["after"],
+            before: args["before"],
+            from: args["from"],
+            limit: args.fetch("limit", 20)
+          )
+          return "(no events)" if events.empty?
+          format_events(events)
+        end
+
+        private
+
+        def format_events(events)
+          events.map { |e| "#{e.timestamp.iso8601(3)}  #{e.event_type}  [#{e.event_id}]" }.join("\n")
+        end
+      end
+    end
+  end
+end

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/stream_events.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/stream_events.rb
@@ -31,7 +31,7 @@ module RubyEventStore
 
         def call(event_store, args)
           events = ReadEvents.of(
-            event_store.read.stream(args["stream_name"]),
+            event_store.read.stream(args.fetch("stream_name")),
             type: args["type"],
             after: args["after"],
             before: args["before"],

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/stream_show.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/stream_show.rb
@@ -23,8 +23,9 @@ module RubyEventStore
         end
 
         def call(event_store, args)
-          specification = event_store.read.stream(args["stream_name"])
-          format_stream(args["stream_name"], specification)
+          stream_name = args.fetch("stream_name")
+          specification = event_store.read.stream(stream_name)
+          format_stream(stream_name, specification)
         end
 
         private

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/stream_show.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/stream_show.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module RubyEventStore
+  module MCP
+    module Tools
+      class StreamShow
+        def name
+          "stream_show"
+        end
+
+        def schema
+          {
+            name: name,
+            description: "Show event count, version, and first/last event for a stream",
+            inputSchema: {
+              type: "object",
+              properties: {
+                stream_name: { type: "string", description: "Stream name" }
+              },
+              required: ["stream_name"]
+            }
+          }
+        end
+
+        def call(event_store, args)
+          specification = event_store.read.stream(args["stream_name"])
+          format_stream(args["stream_name"], specification)
+        end
+
+        private
+
+        def format_stream(stream_name, specification)
+          count = specification.count
+          lines = ["Stream:  #{stream_name}", "Events:  #{count}"]
+          lines.concat(format_bounds(specification, count)) if count > 0
+          lines.join("\n")
+        end
+
+        def format_bounds(specification, count)
+          first = specification.first
+          last = specification.last
+          [
+            "Version: #{count - 1}",
+            "First:   #{first.timestamp.iso8601(3)} (#{first.event_type})",
+            "Last:    #{last.timestamp.iso8601(3)} (#{last.event_type})"
+          ]
+        end
+      end
+    end
+  end
+end

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/trace.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/trace.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module RubyEventStore
+  module MCP
+    module Tools
+      class Trace
+        def name
+          "trace"
+        end
+
+        def schema
+          {
+            name: name,
+            description: "Show the causation tree for all events sharing a correlation ID",
+            inputSchema: {
+              type: "object",
+              properties: {
+                correlation_id: { type: "string", description: "Correlation ID (UUID)" }
+              },
+              required: ["correlation_id"]
+            }
+          }
+        end
+
+        def call(event_store, args)
+          events = events_for(event_store, args["correlation_id"])
+          return "(no events found for correlation ID #{args["correlation_id"]})" if events.empty?
+          build_tree(events)
+        end
+
+        private
+
+        def events_for(event_store, correlation_id)
+          event_store.read.stream("$by_correlation_id_#{correlation_id}").to_a
+        end
+
+        def build_tree(events)
+          by_causation = events.group_by { |e| e.metadata[:causation_id] }
+          roots = root_events(events)
+          lines = []
+          roots.each { |e| render_node(e, by_causation, "", true, roots.last == e, lines) }
+          lines.join("\n")
+        end
+
+        def root_events(events)
+          event_ids = events.map(&:event_id).to_set
+          events.reject { |e| event_ids.include?(e.metadata[:causation_id]) }
+        end
+
+        def render_node(event, by_causation, prefix, root, last, lines)
+          connector = root ? "" : (last ? "└── " : "├── ")
+          lines << "#{prefix}#{connector}#{event.event_type} [#{event.event_id}]"
+          children = by_causation[event.event_id] || []
+          child_prefix = root ? prefix : prefix + (last ? "    " : "│   ")
+          children.each_with_index do |child, i|
+            render_node(child, by_causation, child_prefix, false, i == children.size - 1, lines)
+          end
+        end
+      end
+    end
+  end
+end

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/trace.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/trace.rb
@@ -43,13 +43,13 @@ module RubyEventStore
         end
 
         def root_events(events)
-          event_ids = events.map(&:event_id).to_set
+          event_ids = events.map(&:event_id)
           events.reject { |e| event_ids.include?(e.metadata[:causation_id]) }
         end
 
         def render_node(event, by_causation, prefix, root, last, lines)
           connector = root ? "" : (last ? "└── " : "├── ")
-          lines << "#{prefix}#{connector}#{event.event_type} [#{event.event_id}]"
+          lines << "#{prefix + connector}#{event.event_type} [#{event.event_id}]"
           children = by_causation[event.event_id] || []
           child_prefix = root ? prefix : prefix + (last ? "    " : "│   ")
           children.each_with_index do |child, i|

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/trace.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/trace.rb
@@ -23,8 +23,8 @@ module RubyEventStore
         end
 
         def call(event_store, args)
-          events = events_for(event_store, args["correlation_id"])
-          return "(no events found for correlation ID #{args["correlation_id"]})" if events.empty?
+          events = events_for(event_store, args.fetch("correlation_id"))
+          return "(no events found for correlation ID #{args.fetch("correlation_id")})" if events.empty?
           build_tree(events)
         end
 
@@ -38,7 +38,10 @@ module RubyEventStore
           by_causation = events.group_by { |e| e.metadata[:causation_id] }
           roots = root_events(events)
           lines = []
-          roots.each { |e| render_node(e, by_causation, "", true, roots.last == e, lines) }
+          roots.each do |e|
+            lines << "#{e.event_type} [#{e.event_id}]"
+            render_children(e, by_causation, "", lines)
+          end
           lines.join("\n")
         end
 
@@ -47,14 +50,22 @@ module RubyEventStore
           events.reject { |e| event_ids.include?(e.metadata[:causation_id]) }
         end
 
-        def render_node(event, by_causation, prefix, root, last, lines)
-          connector = root ? "" : (last ? "└── " : "├── ")
-          lines << "#{prefix + connector}#{event.event_type} [#{event.event_id}]"
+        def render_node(event, by_causation, prefix, lines)
+          lines << "#{prefix}├── #{event.event_type} [#{event.event_id}]"
+          render_children(event, by_causation, prefix + "│   ", lines)
+        end
+
+        def render_last_node(event, by_causation, prefix, lines)
+          lines << "#{prefix}└── #{event.event_type} [#{event.event_id}]"
+          render_children(event, by_causation, prefix + "    ", lines)
+        end
+
+        def render_children(event, by_causation, prefix, lines)
           children = by_causation[event.event_id] || []
-          child_prefix = root ? prefix : prefix + (last ? "    " : "│   ")
-          children.each_with_index do |child, i|
-            render_node(child, by_causation, child_prefix, false, i == children.size - 1, lines)
-          end
+          return if children.empty?
+          *rest, last = children
+          rest.each { |child| render_node(child, by_causation, prefix, lines) }
+          render_last_node(last, by_causation, prefix, lines)
         end
       end
     end

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/trace.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/tools/trace.rb
@@ -51,20 +51,25 @@ module RubyEventStore
         end
 
         def render_node(event, by_causation, prefix, lines)
-          lines << "#{prefix}├── #{event.event_type} [#{event.event_id}]"
-          render_children(event, by_causation, prefix + "│   ", lines)
+          lines << event_line(event, prefix, "├── ")
+          child_prefix = prefix + "│   "
+          render_children(event, by_causation, child_prefix, lines)
         end
 
         def render_last_node(event, by_causation, prefix, lines)
-          lines << "#{prefix}└── #{event.event_type} [#{event.event_id}]"
-          render_children(event, by_causation, prefix + "    ", lines)
+          lines << event_line(event, prefix, "└── ")
+          child_prefix = prefix + "    "
+          render_children(event, by_causation, child_prefix, lines)
+        end
+
+        def event_line(event, prefix, connector)
+          "#{prefix}#{connector}#{event.event_type} [#{event.event_id}]"
         end
 
         def render_children(event, by_causation, prefix, lines)
-          children = by_causation[event.event_id] || []
-          return if children.empty?
-          *rest, last = children
-          rest.each { |child| render_node(child, by_causation, prefix, lines) }
+          *non_last, last = by_causation[event.event_id]
+          return if last.nil?
+          non_last.each { |child| render_node(child, by_causation, prefix, lines) }
           render_last_node(last, by_causation, prefix, lines)
         end
       end

--- a/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/version.rb
+++ b/contrib/ruby_event_store-mcp/lib/ruby_event_store/mcp/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module RubyEventStore
+  module MCP
+    VERSION = "0.1.0"
+  end
+end

--- a/contrib/ruby_event_store-mcp/ruby_event_store-mcp.gemspec
+++ b/contrib/ruby_event_store-mcp/ruby_event_store-mcp.gemspec
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require_relative "lib/ruby_event_store/mcp/version"
+
+Gem::Specification.new do |spec|
+  spec.name = "ruby_event_store-mcp"
+  spec.version = RubyEventStore::MCP::VERSION
+  spec.license = "MIT"
+  spec.author = "Arkency"
+  spec.email = "dev@arkency.com"
+  spec.summary = "Model Context Protocol server for Ruby Event Store"
+  spec.homepage = "https://railseventstore.org"
+  spec.files = Dir["lib/**/*", "bin/**/*"]
+  spec.require_paths = %w[lib]
+  spec.extra_rdoc_files = %w[README.md]
+  spec.bindir = "bin"
+  spec.executables = %w[res-mcp]
+
+  spec.metadata = {
+    "homepage_uri" => spec.homepage,
+    "source_code_uri" => "https://github.com/RailsEventStore/rails_event_store",
+    "bug_tracker_uri" => "https://github.com/RailsEventStore/rails_event_store/issues",
+    "rubygems_mfa_required" => "true"
+  }
+
+  spec.required_ruby_version = ">= 3.0"
+
+  spec.add_dependency "ruby_event_store", ">= 1.0.0"
+end

--- a/contrib/ruby_event_store-mcp/spec/integration_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/integration_spec.rb
@@ -28,12 +28,12 @@ module RubyEventStore
         expect(responses.first["result"]["protocolVersion"]).to eq(Server::PROTOCOL_VERSION)
       end
 
-      it "lists all 7 tools" do
+      it "lists all 8 tools" do
         responses = call(server, { jsonrpc: "2.0", id: 1, method: "tools/list" })
         names = responses.first["result"]["tools"].map { |t| t["name"] }
         expect(names).to contain_exactly(
           "stream_show", "stream_events", "event_show",
-          "event_streams", "search", "stats", "trace"
+          "event_streams", "search", "stats", "trace", "aggregate_history"
         )
       end
 

--- a/contrib/ruby_event_store-mcp/spec/integration_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/integration_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "ruby_event_store/mcp"
+
+module RubyEventStore
+  module MCP
+    class OrderPlaced < RubyEventStore::Event; end
+
+    ::RSpec.describe "MCP integration" do
+      let(:event_store) { RubyEventStore::Client.new }
+      let(:server) { MCP.server(event_store) }
+
+      def call(server, *requests)
+        input = StringIO.new(requests.map { |r| JSON.generate(r) }.join("\n") + "\n")
+        output = StringIO.new
+        server.start(input: input, output: output)
+        output.rewind
+        output.read.split("\n").map { |l| JSON.parse(l) }
+      end
+
+      def tool_call(tool_name, arguments = {})
+        { jsonrpc: "2.0", id: 1, method: "tools/call", params: { "name" => tool_name, "arguments" => arguments } }
+      end
+
+      it "completes initialize handshake" do
+        responses = call(server, { jsonrpc: "2.0", id: 1, method: "initialize", params: {} })
+        expect(responses.first["result"]["protocolVersion"]).to eq(Server::PROTOCOL_VERSION)
+      end
+
+      it "lists all 7 tools" do
+        responses = call(server, { jsonrpc: "2.0", id: 1, method: "tools/list" })
+        names = responses.first["result"]["tools"].map { |t| t["name"] }
+        expect(names).to contain_exactly(
+          "stream_show", "stream_events", "event_show",
+          "event_streams", "search", "stats", "trace"
+        )
+      end
+
+      it "stream_show returns stream info" do
+        event_store.publish(OrderPlaced.new, stream_name: "Order$1")
+        responses = call(server, tool_call("stream_show", "stream_name" => "Order$1"))
+        expect(responses.first["result"]["content"].first["text"]).to include("Events:  1")
+      end
+
+      it "stream_events lists events" do
+        event_store.publish(OrderPlaced.new, stream_name: "Order$1")
+        responses = call(server, tool_call("stream_events", "stream_name" => "Order$1"))
+        expect(responses.first["result"]["content"].first["text"]).to include("OrderPlaced")
+      end
+
+      it "event_show returns event details" do
+        event = OrderPlaced.new(data: { amount: 100 })
+        event_store.publish(event, stream_name: "Order$1")
+        responses = call(server, tool_call("event_show", "event_id" => event.event_id))
+        text = responses.first["result"]["content"].first["text"]
+        expect(text).to include("OrderPlaced")
+        expect(text).to include("amount")
+      end
+
+      it "event_streams lists streams for event" do
+        event = OrderPlaced.new
+        event_store.publish(event, stream_name: "Order$1")
+        responses = call(server, tool_call("event_streams", "event_id" => event.event_id))
+        expect(responses.first["result"]["content"].first["text"]).to include("Order$1")
+      end
+
+      it "search finds events" do
+        event_store.publish(OrderPlaced.new, stream_name: "Order$1")
+        responses = call(server, tool_call("search"))
+        expect(responses.first["result"]["content"].first["text"]).to include("OrderPlaced")
+      end
+
+      it "stats shows event count" do
+        event_store.publish(OrderPlaced.new, stream_name: "Order$1")
+        responses = call(server, tool_call("stats"))
+        expect(responses.first["result"]["content"].first["text"]).to include("Events:  1")
+      end
+
+      it "trace shows causation tree" do
+        correlation_id = SecureRandom.uuid
+        event = OrderPlaced.new(metadata: { correlation_id: correlation_id })
+        event_store.publish(event, stream_name: "Order$1")
+        event_store.link(event.event_id, stream_name: "$by_correlation_id_#{correlation_id}")
+        responses = call(server, tool_call("trace", "correlation_id" => correlation_id))
+        expect(responses.first["result"]["content"].first["text"]).to include("OrderPlaced")
+      end
+
+      it "unknown tool returns isError" do
+        responses = call(server, tool_call("nonexistent"))
+        expect(responses.first["result"]["isError"]).to be(true)
+      end
+    end
+  end
+end

--- a/contrib/ruby_event_store-mcp/spec/integration_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/integration_spec.rb
@@ -28,12 +28,12 @@ module RubyEventStore
         expect(responses.first["result"]["protocolVersion"]).to eq(Server::PROTOCOL_VERSION)
       end
 
-      it "lists all 8 tools" do
+      it "lists all 9 tools" do
         responses = call(server, { jsonrpc: "2.0", id: 1, method: "tools/list" })
         names = responses.first["result"]["tools"].map { |t| t["name"] }
         expect(names).to contain_exactly(
           "stream_show", "stream_events", "event_show",
-          "event_streams", "search", "stats", "trace", "aggregate_history"
+          "event_streams", "search", "stats", "trace", "aggregate_history", "recent"
         )
       end
 

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/read_events_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/read_events_spec.rb
@@ -34,6 +34,18 @@ module RubyEventStore
           expect(result.size).to eq(2)
         end
 
+        it "accepts string limit by converting via to_i" do
+          3.times { event_store.publish(TestEvent.new, stream_name: "test") }
+          result = ReadEvents.of(event_store.read, limit: "2")
+          expect(result.size).to eq(2)
+        end
+
+        it "extracts leading digits from partial numeric string limit via to_i" do
+          3.times { event_store.publish(TestEvent.new, stream_name: "test") }
+          result = ReadEvents.of(event_store.read, limit: "2abc")
+          expect(result.size).to eq(2)
+        end
+
         it "returns all events when no limit given" do
           3.times { event_store.publish(TestEvent.new, stream_name: "test") }
           result = ReadEvents.of(event_store.read)
@@ -96,6 +108,12 @@ module RubyEventStore
         it "raises for unknown event type" do
           expect { ReadEvents.of(event_store.read, type: "NonExistentClass") }
             .to raise_error(RuntimeError, /NonExistentClass/)
+        end
+
+        it "does not resolve unqualified names from ReadEvents namespace" do
+          stub_const("RubyEventStore::MCP::ReadEvents::LocalEvent", Class.new(RubyEventStore::Event))
+          expect { ReadEvents.of(event_store.read, type: "LocalEvent") }
+            .to raise_error(RuntimeError, /Unknown event type/)
         end
       end
     end

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/read_events_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/read_events_spec.rb
@@ -95,7 +95,7 @@ module RubyEventStore
 
         it "raises for unknown event type" do
           expect { ReadEvents.of(event_store.read, type: "NonExistentClass") }
-            .to raise_error(/Unknown event type/)
+            .to raise_error(RuntimeError, /NonExistentClass/)
         end
       end
     end

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/read_events_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/read_events_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "ruby_event_store/mcp/read_events"
+
+module RubyEventStore
+  module MCP
+    ::RSpec.describe ReadEvents do
+      let(:event_store) { RubyEventStore::Client.new }
+
+      class TestEvent < RubyEventStore::Event; end
+
+      describe ".of" do
+        it "returns all events with no options" do
+          event_store.publish(TestEvent.new, stream_name: "test")
+          result = ReadEvents.of(event_store.read)
+          expect(result).not_to be_empty
+        end
+
+        it "returns an array" do
+          result = ReadEvents.of(event_store.read)
+          expect(result).to be_an(Array)
+        end
+
+        it "returns event objects" do
+          event_store.publish(TestEvent.new, stream_name: "test")
+          result = ReadEvents.of(event_store.read)
+          expect(result.first).to respond_to(:event_type)
+        end
+
+        it "applies limit when given" do
+          3.times { event_store.publish(TestEvent.new, stream_name: "test") }
+          result = ReadEvents.of(event_store.read, limit: 2)
+          expect(result.size).to eq(2)
+        end
+
+        it "returns all events when no limit given" do
+          3.times { event_store.publish(TestEvent.new, stream_name: "test") }
+          result = ReadEvents.of(event_store.read)
+          expect(result.size).to eq(3)
+        end
+
+        it "filters by type" do
+          event_store.publish(TestEvent.new, stream_name: "test")
+          event_store.publish(RubyEventStore::Event.new, stream_name: "test")
+          result = ReadEvents.of(event_store.read, type: "RubyEventStore::MCP::TestEvent")
+          expect(result.map(&:event_type).uniq).to eq(["RubyEventStore::MCP::TestEvent"])
+        end
+
+        it "filters by after timestamp excluding old events" do
+          event_store.publish(TestEvent.new, stream_name: "test")
+          result = ReadEvents.of(event_store.read, after: (Time.now + 3600).iso8601)
+          expect(result).to be_empty
+        end
+
+        it "filters by after timestamp including newer events" do
+          event_store.publish(TestEvent.new, stream_name: "test")
+          result = ReadEvents.of(event_store.read, after: (Time.now - 3600).iso8601)
+          expect(result).not_to be_empty
+        end
+
+        it "filters by before timestamp excluding newer events" do
+          event_store.publish(TestEvent.new, stream_name: "test")
+          result = ReadEvents.of(event_store.read, before: (Time.now - 3600).iso8601)
+          expect(result).to be_empty
+        end
+
+        it "filters by before timestamp including older events" do
+          event_store.publish(TestEvent.new, stream_name: "test")
+          result = ReadEvents.of(event_store.read, before: (Time.now + 3600).iso8601)
+          expect(result).not_to be_empty
+        end
+
+        it "filters by from event id excluding the referenced event" do
+          e1 = TestEvent.new
+          e2 = TestEvent.new
+          event_store.publish(e1, stream_name: "test")
+          event_store.publish(e2, stream_name: "test")
+          result = ReadEvents.of(event_store.read.stream("test"), from: e1.event_id)
+          event_ids = result.map(&:event_id)
+          expect(event_ids).to include(e2.event_id)
+          expect(event_ids).not_to include(e1.event_id)
+        end
+
+        it "returns all events when from is not given" do
+          e1 = TestEvent.new
+          e2 = TestEvent.new
+          event_store.publish(e1, stream_name: "test")
+          event_store.publish(e2, stream_name: "test")
+          result = ReadEvents.of(event_store.read.stream("test"))
+          event_ids = result.map(&:event_id)
+          expect(event_ids).to include(e1.event_id)
+          expect(event_ids).to include(e2.event_id)
+        end
+
+        it "raises for unknown event type" do
+          expect { ReadEvents.of(event_store.read, type: "NonExistentClass") }
+            .to raise_error(/Unknown event type/)
+        end
+      end
+    end
+  end
+end

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/server_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/server_spec.rb
@@ -206,6 +206,16 @@ module RubyEventStore
           s = Server.new(event_store: event_store)
           expect(s.version).to eq(MCP::VERSION)
         end
+
+        it "stores given event_store" do
+          s = Server.new(event_store: event_store)
+          expect(s.event_store).to equal(event_store)
+        end
+
+        it "starts with empty tools list" do
+          s = Server.new(event_store: event_store)
+          expect(s.tools).to eq([])
+        end
       end
 
       describe "#jsonrpc_result" do
@@ -411,6 +421,42 @@ module RubyEventStore
           result = call_tool(1, { "name" => "event_show", "arguments" => { "event_id" => SecureRandom.uuid } })
           text = result[:result][:content].first[:text]
           expect(text).to match(/Error: .+/)
+        end
+
+        it "passes arguments to tool" do
+          event_store.publish(RubyEventStore::Event.new, stream_name: "test")
+          server.register(Tools::StreamShow.new)
+          result = call_tool(1, { "name" => "stream_show", "arguments" => { "stream_name" => "test" } })
+          expect(result[:result][:content].first[:text]).to include("Stream:")
+        end
+
+        it "returns correct id for successful call" do
+          server.register(Tools::Stats.new)
+          result = call_tool(55, { "name" => "stats" })
+          expect(result[:id]).to eq(55)
+        end
+
+        it "success content type is text" do
+          server.register(Tools::Stats.new)
+          result = call_tool(1, { "name" => "stats" })
+          expect(result[:result][:content].first[:type]).to eq("text")
+        end
+
+        it "finds non-last tool by name" do
+          server.register(Tools::Stats.new)
+          server.register(Tools::StreamShow.new)
+          result = call_tool(1, { "name" => "stats" })
+          expect(result[:result][:content].first[:text]).to include("Events:")
+        end
+
+        it "returns correct id for unknown tool" do
+          result = call_tool(55, { "name" => "nonexistent" })
+          expect(result[:id]).to eq(55)
+        end
+
+        it "unknown tool content type is text" do
+          result = call_tool(1, { "name" => "nonexistent" })
+          expect(result[:result][:content].first[:type]).to eq("text")
         end
       end
 

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/server_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/server_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "ruby_event_store/mcp/server"
+
+module RubyEventStore
+  module MCP
+    ::RSpec.describe Server do
+      let(:event_store) { RubyEventStore::Client.new }
+      let(:server) { Server.new(event_store: event_store, name: "test-server", version: "0.0.1") }
+
+      def call(server, request)
+        input = StringIO.new(JSON.generate(request) + "\n")
+        output = StringIO.new
+        server.start(input: input, output: output)
+        output.rewind
+        lines = output.read.split("\n").reject(&:empty?)
+        lines.map { |l| JSON.parse(l) }
+      end
+
+      describe "initialize" do
+        it "returns server info and capabilities" do
+          responses = call(server, { jsonrpc: "2.0", id: 1, method: "initialize", params: {} })
+          result = responses.first["result"]
+          expect(result["protocolVersion"]).to eq(Server::PROTOCOL_VERSION)
+          expect(result["serverInfo"]["name"]).to eq("test-server")
+          expect(result["capabilities"]).to have_key("tools")
+        end
+      end
+
+      describe "notifications/initialized" do
+        it "produces no response" do
+          responses = call(server, { jsonrpc: "2.0", method: "notifications/initialized" })
+          expect(responses).to be_empty
+        end
+      end
+
+      describe "ping" do
+        it "returns empty result" do
+          responses = call(server, { jsonrpc: "2.0", id: 2, method: "ping" })
+          expect(responses.first["result"]).to eq({})
+        end
+      end
+
+      describe "tools/list" do
+        it "returns empty list when no tools registered" do
+          responses = call(server, { jsonrpc: "2.0", id: 3, method: "tools/list" })
+          expect(responses.first["result"]["tools"]).to eq([])
+        end
+
+        it "returns registered tool schemas" do
+          tool = instance_double("tool", name: "my_tool", schema: { name: "my_tool", description: "desc", inputSchema: {} })
+          server.register(tool)
+          responses = call(server, { jsonrpc: "2.0", id: 3, method: "tools/list" })
+          expect(responses.first["result"]["tools"].first["name"]).to eq("my_tool")
+        end
+      end
+
+      describe "tools/call" do
+        it "returns isError result for unknown tool" do
+          responses = call(server, { jsonrpc: "2.0", id: 4, method: "tools/call", params: { "name" => "unknown" } })
+          expect(responses.first["result"]["isError"]).to be(true)
+          expect(responses.first["result"]["content"].first["text"]).to include("Unknown tool")
+        end
+
+        it "calls the matching tool and returns its output" do
+          tool = instance_double("tool", name: "my_tool")
+          allow(tool).to receive(:call).with(event_store, {}).and_return("hello")
+          server.register(tool)
+          responses = call(server, { jsonrpc: "2.0", id: 4, method: "tools/call", params: { "name" => "my_tool", "arguments" => {} } })
+          expect(responses.first["result"]["content"].first["text"]).to eq("hello")
+        end
+      end
+
+      describe "unknown method" do
+        it "returns method not found error" do
+          responses = call(server, { jsonrpc: "2.0", id: 5, method: "unknown/method" })
+          expect(responses.first["error"]["code"]).to eq(-32601)
+        end
+      end
+    end
+  end
+end

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/server_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/server_spec.rb
@@ -153,6 +153,13 @@ module RubyEventStore
       end
 
       describe "#start" do
+        it "sets output to sync mode" do
+          output = StringIO.new
+          expect(output).to receive(:sync=).with(true)
+          input = StringIO.new(JSON.generate({ jsonrpc: "2.0", id: 1, method: "ping" }) + "\n")
+          server.start(input: input, output: output)
+        end
+
         it "handles multiple requests in sequence" do
           input = StringIO.new(
             JSON.generate({ jsonrpc: "2.0", id: 1, method: "ping" }) + "\n" +
@@ -264,6 +271,13 @@ module RubyEventStore
           def call(_, _) = "ok"
         end
 
+        it "returns nil id in rescue response when request has no id field" do
+          server.register(BrokenSchemaTool.new)
+          response = server.send(:handle, { "method" => "tools/list" })
+          expect(response[:id]).to be_nil
+          expect(response[:error][:code]).to eq(-32603)
+        end
+
         it "returns -32603 error when an internal exception is raised" do
           server.register(BrokenSchemaTool.new)
           responses = call(server, { jsonrpc: "2.0", id: 7, method: "tools/list" })
@@ -348,11 +362,25 @@ module RubyEventStore
           expect(response[:id]).to eq(99)
           expect(response[:error][:message]).to include("broken_schema_error")
         end
+
+        it "returns -32601 when method key is absent" do
+          response = handle({ "id" => 1 })
+          expect(response[:error][:code]).to eq(-32601)
+        end
       end
 
       describe "#start strip" do
-        it "strips whitespace from lines before parsing" do
-          input = StringIO.new("  " + JSON.generate({ jsonrpc: "2.0", id: 1, method: "ping" }) + "  \n")
+        it "strips leading whitespace from lines before parsing" do
+          input = StringIO.new("  " + JSON.generate({ jsonrpc: "2.0", id: 1, method: "ping" }) + "\n")
+          output = StringIO.new
+          server.start(input: input, output: output)
+          output.rewind
+          responses = output.read.split("\n").map { |l| JSON.parse(l) }
+          expect(responses.first["id"]).to eq(1)
+        end
+
+        it "strips trailing whitespace from lines before parsing" do
+          input = StringIO.new(JSON.generate({ jsonrpc: "2.0", id: 1, method: "ping" }) + "  \n")
           output = StringIO.new
           server.start(input: input, output: output)
           output.rewind
@@ -382,8 +410,31 @@ module RubyEventStore
       end
 
       describe "#call_tool (direct)" do
+        class ErrorWithDistinctToS < StandardError
+          def to_s = "to_s_value"
+          def message = "message_value"
+        end
+
+        class ToSOverridingTool
+          def name = "tos_tool"
+          def schema = { name: "tos_tool", description: "test", inputSchema: { type: "object", properties: {}, required: [] } }
+          def call(_, _) = raise ErrorWithDistinctToS
+        end
+
         def call_tool(id, params)
           server.send(:call_tool, id, params)
+        end
+
+        it "uses exception message (not to_s) in error text" do
+          server.register(ToSOverridingTool.new)
+          result = call_tool(1, { "name" => "tos_tool" })
+          expect(result[:result][:content].first[:text]).to eq("Error: message_value")
+        end
+
+        it "returns unknown tool error when name key is absent" do
+          result = call_tool(1, { "arguments" => {} })
+          expect(result[:result][:content].first[:text]).to include("Unknown tool")
+          expect(result[:result][:isError]).to be(true)
         end
 
         it "returns isError for unknown tool" do
@@ -497,6 +548,12 @@ module RubyEventStore
         it "returns unknown method error with correct id" do
           response = handle({ "id" => 99, "method" => "some/unknown" })
           expect(response[:id]).to eq(99)
+        end
+
+        it "returns result (not jsonrpc error) when params key is absent from tools/call" do
+          response = handle({ "id" => 1, "method" => "tools/call" })
+          expect(response).to have_key(:result)
+          expect(response).not_to have_key(:error)
         end
       end
     end

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/server_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/server_spec.rb
@@ -2,6 +2,9 @@
 
 require "spec_helper"
 require "ruby_event_store/mcp/server"
+require "ruby_event_store/mcp/tools/stream_show"
+require "ruby_event_store/mcp/tools/event_show"
+require "ruby_event_store/mcp/tools/stats"
 
 module RubyEventStore
   module MCP
@@ -19,12 +22,26 @@ module RubyEventStore
       end
 
       describe "initialize" do
-        it "returns server info and capabilities" do
+        it "returns protocol version" do
           responses = call(server, { jsonrpc: "2.0", id: 1, method: "initialize", params: {} })
-          result = responses.first["result"]
-          expect(result["protocolVersion"]).to eq(Server::PROTOCOL_VERSION)
-          expect(result["serverInfo"]["name"]).to eq("test-server")
-          expect(result["capabilities"]).to have_key("tools")
+          expect(responses.first["result"]["protocolVersion"]).to eq(Server::PROTOCOL_VERSION)
+        end
+
+        it "returns server name and version" do
+          responses = call(server, { jsonrpc: "2.0", id: 1, method: "initialize", params: {} })
+          info = responses.first["result"]["serverInfo"]
+          expect(info["name"]).to eq("test-server")
+          expect(info["version"]).to eq("0.0.1")
+        end
+
+        it "returns tools capability as object" do
+          responses = call(server, { jsonrpc: "2.0", id: 1, method: "initialize", params: {} })
+          expect(responses.first["result"]["capabilities"]["tools"]).to be_a(Hash)
+        end
+
+        it "echoes back the request id" do
+          responses = call(server, { jsonrpc: "2.0", id: 42, method: "initialize", params: {} })
+          expect(responses.first["id"]).to eq(42)
         end
       end
 
@@ -49,10 +66,14 @@ module RubyEventStore
         end
 
         it "returns registered tool schemas" do
-          tool = instance_double("tool", name: "my_tool", schema: { name: "my_tool", description: "desc", inputSchema: {} })
-          server.register(tool)
+          server.register(Tools::StreamShow.new)
           responses = call(server, { jsonrpc: "2.0", id: 3, method: "tools/list" })
-          expect(responses.first["result"]["tools"].first["name"]).to eq("my_tool")
+          expect(responses.first["result"]["tools"].first["name"]).to eq("stream_show")
+        end
+
+        it "echoes back the request id" do
+          responses = call(server, { jsonrpc: "2.0", id: 99, method: "tools/list" })
+          expect(responses.first["id"]).to eq(99)
         end
       end
 
@@ -64,18 +85,372 @@ module RubyEventStore
         end
 
         it "calls the matching tool and returns its output" do
-          tool = instance_double("tool", name: "my_tool")
-          allow(tool).to receive(:call).with(event_store, {}).and_return("hello")
-          server.register(tool)
-          responses = call(server, { jsonrpc: "2.0", id: 4, method: "tools/call", params: { "name" => "my_tool", "arguments" => {} } })
-          expect(responses.first["result"]["content"].first["text"]).to eq("hello")
+          event_store.publish(RubyEventStore::Event.new, stream_name: "test")
+          server.register(Tools::StreamShow.new)
+          responses = call(server, { jsonrpc: "2.0", id: 4, method: "tools/call", params: { "name" => "stream_show", "arguments" => { "stream_name" => "test" } } })
+          expect(responses.first["result"]["content"].first["text"]).to include("Events:  1")
+        end
+
+        it "defaults arguments to empty hash allowing tools to succeed without arguments" do
+          server.register(Tools::Stats.new)
+          responses = call(server, { jsonrpc: "2.0", id: 4, method: "tools/call", params: { "name" => "stats" } })
+          expect(responses.first["result"]["isError"]).to be_nil
+          expect(responses.first["result"]["content"].first["text"]).to include("Events:")
+        end
+
+        it "finds tool by name not by position" do
+          server.register(Tools::StreamShow.new)
+          server.register(Tools::Stats.new)
+          responses = call(server, { jsonrpc: "2.0", id: 4, method: "tools/call", params: { "name" => "stats" } })
+          expect(responses.first["result"]["content"].first["text"]).to include("Events:")
+        end
+
+        it "returns isError result when tool raises" do
+          server.register(Tools::EventShow.new)
+          responses = call(server, { jsonrpc: "2.0", id: 4, method: "tools/call", params: { "name" => "event_show", "arguments" => { "event_id" => SecureRandom.uuid } } })
+          expect(responses.first["result"]["isError"]).to be(true)
+          expect(responses.first["result"]["content"].first["text"]).to include("Error:")
+        end
+
+        it "unknown tool error content has type text" do
+          responses = call(server, { jsonrpc: "2.0", id: 4, method: "tools/call", params: { "name" => "unknown" } })
+          expect(responses.first["result"]["content"].first["type"]).to eq("text")
+        end
+
+        it "result content has type text" do
+          server.register(Tools::StreamShow.new)
+          responses = call(server, { jsonrpc: "2.0", id: 4, method: "tools/call", params: { "name" => "stream_show", "arguments" => { "stream_name" => "test" } } })
+          expect(responses.first["result"]["content"].first["type"]).to eq("text")
+        end
+
+        it "unknown tool error echoes request id" do
+          responses = call(server, { jsonrpc: "2.0", id: 55, method: "tools/call", params: { "name" => "unknown" } })
+          expect(responses.first["id"]).to eq(55)
+        end
+
+        it "tool call echoes request id" do
+          server.register(Tools::Stats.new)
+          responses = call(server, { jsonrpc: "2.0", id: 66, method: "tools/call", params: { "name" => "stats" } })
+          expect(responses.first["id"]).to eq(66)
         end
       end
 
       describe "unknown method" do
-        it "returns method not found error" do
+        it "returns method not found error code" do
           responses = call(server, { jsonrpc: "2.0", id: 5, method: "unknown/method" })
           expect(responses.first["error"]["code"]).to eq(-32601)
+        end
+
+        it "includes method name in error message" do
+          responses = call(server, { jsonrpc: "2.0", id: 5, method: "unknown/method" })
+          expect(responses.first["error"]["message"]).to include("unknown/method")
+        end
+
+        it "echoes back the request id" do
+          responses = call(server, { jsonrpc: "2.0", id: 77, method: "unknown/method" })
+          expect(responses.first["id"]).to eq(77)
+        end
+      end
+
+      describe "#start" do
+        it "handles multiple requests in sequence" do
+          input = StringIO.new(
+            JSON.generate({ jsonrpc: "2.0", id: 1, method: "ping" }) + "\n" +
+            JSON.generate({ jsonrpc: "2.0", id: 2, method: "ping" }) + "\n"
+          )
+          output = StringIO.new
+          server.start(input: input, output: output)
+          output.rewind
+          responses = output.read.split("\n").map { |l| JSON.parse(l) }
+          expect(responses.size).to eq(2)
+          expect(responses.map { |r| r["id"] }).to eq([1, 2])
+        end
+
+        it "skips output for notifications" do
+          input = StringIO.new(
+            JSON.generate({ jsonrpc: "2.0", method: "notifications/initialized" }) + "\n" +
+            JSON.generate({ jsonrpc: "2.0", id: 1, method: "ping" }) + "\n"
+          )
+          output = StringIO.new
+          server.start(input: input, output: output)
+          output.rewind
+          responses = output.read.split("\n").map { |l| JSON.parse(l) }
+          expect(responses.size).to eq(1)
+          expect(responses.first["id"]).to eq(1)
+        end
+      end
+
+      describe "#register" do
+        it "returns self to allow chaining" do
+          expect(server.register(Tools::StreamShow.new)).to eq(server)
+        end
+
+        it "adds tool to tools list" do
+          expect { server.register(Tools::StreamShow.new) }.to change { server.tools.size }.by(1)
+        end
+
+        it "adds the exact tool object to the list" do
+          tool = Tools::StreamShow.new
+          server.register(tool)
+          expect(server.tools.last.name).to eq("stream_show")
+        end
+      end
+
+      describe "#initialize" do
+        it "defaults name to ruby-event-store" do
+          s = Server.new(event_store: event_store)
+          expect(s.name).to eq("ruby-event-store")
+        end
+
+        it "defaults version to MCP::VERSION" do
+          s = Server.new(event_store: event_store)
+          expect(s.version).to eq(MCP::VERSION)
+        end
+      end
+
+      describe "#jsonrpc_result" do
+        it "includes jsonrpc 2.0 version string" do
+          responses = call(server, { jsonrpc: "2.0", id: 1, method: "ping" })
+          expect(responses.first["jsonrpc"]).to eq("2.0")
+        end
+
+        it "returns jsonrpc 2.0, given id, and given result" do
+          response = server.send(:jsonrpc_result, 42, { foo: "bar" })
+          expect(response[:jsonrpc]).to eq("2.0")
+          expect(response[:id]).to eq(42)
+          expect(response[:result]).to eq({ foo: "bar" })
+        end
+
+        it "has exactly jsonrpc, id, result keys" do
+          response = server.send(:jsonrpc_result, 1, {})
+          expect(response.keys).to contain_exactly(:jsonrpc, :id, :result)
+        end
+      end
+
+      describe "#jsonrpc_error" do
+        it "includes jsonrpc 2.0 version string" do
+          responses = call(server, { jsonrpc: "2.0", id: 1, method: "unknown/method" })
+          expect(responses.first["jsonrpc"]).to eq("2.0")
+        end
+
+        it "returns jsonrpc 2.0, given id, code, and message in error" do
+          response = server.send(:jsonrpc_error, 42, -32601, "not found")
+          expect(response[:jsonrpc]).to eq("2.0")
+          expect(response[:id]).to eq(42)
+          expect(response[:error][:code]).to eq(-32601)
+          expect(response[:error][:message]).to eq("not found")
+        end
+
+        it "has exactly jsonrpc, id, error keys" do
+          response = server.send(:jsonrpc_error, 1, -32601, "msg")
+          expect(response.keys).to contain_exactly(:jsonrpc, :id, :error)
+        end
+      end
+
+      describe "#handle rescue" do
+        class BrokenSchemaTool
+          def name = "broken_tool"
+          def schema = raise "broken_schema_error"
+          def call(_, _) = "ok"
+        end
+
+        it "returns -32603 error when an internal exception is raised" do
+          server.register(BrokenSchemaTool.new)
+          responses = call(server, { jsonrpc: "2.0", id: 7, method: "tools/list" })
+          expect(responses.first["error"]["code"]).to eq(-32603)
+        end
+
+        it "includes exception message in -32603 error" do
+          server.register(BrokenSchemaTool.new)
+          responses = call(server, { jsonrpc: "2.0", id: 7, method: "tools/list" })
+          expect(responses.first["error"]["message"]).to include("broken_schema_error")
+        end
+
+        it "echoes request id in -32603 error" do
+          server.register(BrokenSchemaTool.new)
+          responses = call(server, { jsonrpc: "2.0", id: 42, method: "tools/list" })
+          expect(responses.first["id"]).to eq(42)
+        end
+
+        it "includes jsonrpc 2.0 in -32603 error" do
+          server.register(BrokenSchemaTool.new)
+          responses = call(server, { jsonrpc: "2.0", id: 7, method: "tools/list" })
+          expect(responses.first["jsonrpc"]).to eq("2.0")
+        end
+      end
+
+      describe "#handle (direct)" do
+        def handle(request)
+          server.send(:handle, request)
+        end
+
+        it "returns id from request" do
+          response = handle({ "id" => 42, "method" => "ping" })
+          expect(response[:id]).to eq(42)
+        end
+
+        it "returns nil for notifications/initialized" do
+          response = handle({ "method" => "notifications/initialized" })
+          expect(response).to be_nil
+        end
+
+        it "returns empty hash result for ping" do
+          response = handle({ "id" => 1, "method" => "ping" })
+          expect(response[:result]).to eq({})
+        end
+
+        it "returns protocol version in initialize result" do
+          response = handle({ "id" => 1, "method" => "initialize", "params" => {} })
+          expect(response[:result][:protocolVersion]).to eq(Server::PROTOCOL_VERSION)
+        end
+
+        it "returns tools capability as hash in initialize" do
+          response = handle({ "id" => 1, "method" => "initialize", "params" => {} })
+          expect(response[:result][:capabilities][:tools]).to be_a(Hash)
+        end
+
+        it "returns server name in initialize serverInfo" do
+          response = handle({ "id" => 1, "method" => "initialize", "params" => {} })
+          expect(response[:result][:serverInfo][:name]).to eq("test-server")
+        end
+
+        it "returns server version in initialize serverInfo" do
+          response = handle({ "id" => 1, "method" => "initialize", "params" => {} })
+          expect(response[:result][:serverInfo][:version]).to eq("0.0.1")
+        end
+
+        it "returns tools list for tools/list" do
+          server.register(Tools::Stats.new)
+          response = handle({ "id" => 1, "method" => "tools/list" })
+          expect(response[:result][:tools].map { |t| t[:name] }).to include("stats")
+        end
+
+        it "returns -32601 error for unknown method" do
+          response = handle({ "id" => 1, "method" => "unknown/xyz" })
+          expect(response[:error][:code]).to eq(-32601)
+          expect(response[:error][:message]).to include("unknown/xyz")
+        end
+
+        it "returns -32603 and uses request id from request hash on internal error" do
+          server.register(BrokenSchemaTool.new)
+          response = handle({ "id" => 99, "method" => "tools/list" })
+          expect(response[:error][:code]).to eq(-32603)
+          expect(response[:id]).to eq(99)
+          expect(response[:error][:message]).to include("broken_schema_error")
+        end
+      end
+
+      describe "#start strip" do
+        it "strips whitespace from lines before parsing" do
+          input = StringIO.new("  " + JSON.generate({ jsonrpc: "2.0", id: 1, method: "ping" }) + "  \n")
+          output = StringIO.new
+          server.start(input: input, output: output)
+          output.rewind
+          responses = output.read.split("\n").map { |l| JSON.parse(l) }
+          expect(responses.first["id"]).to eq(1)
+        end
+      end
+
+      describe "#tools/call details" do
+        it "includes tool name in unknown tool error message" do
+          responses = call(server, { jsonrpc: "2.0", id: 4, method: "tools/call", params: { "name" => "specific_unknown_tool" } })
+          expect(responses.first["result"]["content"].first["text"]).to include("specific_unknown_tool")
+        end
+
+        it "includes exception message text in tool error response" do
+          server.register(Tools::EventShow.new)
+          responses = call(server, { jsonrpc: "2.0", id: 4, method: "tools/call", params: { "name" => "event_show", "arguments" => { "event_id" => SecureRandom.uuid } } })
+          text = responses.first["result"]["content"].first["text"]
+          expect(text).to match(/Error: .+/)
+        end
+
+        it "error result content has type text" do
+          server.register(Tools::EventShow.new)
+          responses = call(server, { jsonrpc: "2.0", id: 4, method: "tools/call", params: { "name" => "event_show", "arguments" => { "event_id" => SecureRandom.uuid } } })
+          expect(responses.first["result"]["content"].first["type"]).to eq("text")
+        end
+      end
+
+      describe "#call_tool (direct)" do
+        def call_tool(id, params)
+          server.send(:call_tool, id, params)
+        end
+
+        it "returns isError for unknown tool" do
+          result = call_tool(1, { "name" => "nonexistent" })
+          expect(result[:result][:isError]).to be(true)
+        end
+
+        it "includes tool name in unknown tool error text" do
+          result = call_tool(1, { "name" => "specific_unknown_xyz" })
+          expect(result[:result][:content].first[:text]).to include("specific_unknown_xyz")
+        end
+
+        it "finds tool by name not by position" do
+          server.register(Tools::StreamShow.new)
+          server.register(Tools::Stats.new)
+          result = call_tool(1, { "name" => "stats" })
+          expect(result[:result][:content].first[:text]).to include("Events:")
+        end
+
+        it "returns correct id in error response when tool raises" do
+          server.register(Tools::EventShow.new)
+          result = call_tool(42, { "name" => "event_show", "arguments" => { "event_id" => SecureRandom.uuid } })
+          expect(result[:result][:isError]).to be(true)
+          expect(result[:id]).to eq(42)
+        end
+
+        it "error content type is text" do
+          server.register(Tools::EventShow.new)
+          result = call_tool(1, { "name" => "event_show", "arguments" => { "event_id" => SecureRandom.uuid } })
+          expect(result[:result][:content].first[:type]).to eq("text")
+        end
+
+        it "error text includes the exception message" do
+          server.register(Tools::EventShow.new)
+          result = call_tool(1, { "name" => "event_show", "arguments" => { "event_id" => SecureRandom.uuid } })
+          text = result[:result][:content].first[:text]
+          expect(text).to match(/Error: .+/)
+        end
+      end
+
+      describe "#handle tools/call routing (direct)" do
+        def handle(request)
+          server.send(:handle, request)
+        end
+
+        it "returns id from request for initialize" do
+          response = handle({ "id" => 42, "method" => "initialize", "params" => {} })
+          expect(response[:id]).to eq(42)
+        end
+
+        it "returns id from request for tools/list" do
+          response = handle({ "id" => 77, "method" => "tools/list" })
+          expect(response[:id]).to eq(77)
+        end
+
+        it "routes tools/call using params name to find the right tool" do
+          server.register(Tools::Stats.new)
+          response = handle({ "id" => 1, "method" => "tools/call", "params" => { "name" => "stats" } })
+          expect(response[:result][:content].first[:text]).to include("Events:")
+        end
+
+        it "passes params to call_tool so tool arguments are used" do
+          event_store.publish(RubyEventStore::Event.new, stream_name: "x")
+          server.register(Tools::StreamShow.new)
+          response = handle({ "id" => 1, "method" => "tools/call", "params" => { "name" => "stream_show", "arguments" => { "stream_name" => "x" } } })
+          expect(response[:result][:content].first[:text]).to include("Events:")
+        end
+
+        it "returns id from tools/call response" do
+          server.register(Tools::Stats.new)
+          response = handle({ "id" => 55, "method" => "tools/call", "params" => { "name" => "stats" } })
+          expect(response[:id]).to eq(55)
+        end
+
+        it "returns unknown method error with correct id" do
+          response = handle({ "id" => 99, "method" => "some/unknown" })
+          expect(response[:id]).to eq(99)
         end
       end
     end

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/aggregate_history_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/aggregate_history_spec.rb
@@ -68,6 +68,13 @@ module RubyEventStore
             expect(result.lines[2].chomp).to eq("")
           end
 
+          it "puts each event on its own line" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            event_store.publish(OrderShipped.new, stream_name: "Order$1")
+            result = tool.call(event_store, "aggregate_type" => "Order", "aggregate_id" => "1")
+            expect(result.lines.count).to eq(5)
+          end
+
           it "formats event type as plain class name without object notation" do
             event_store.publish(OrderCreated.new, stream_name: "Order$1")
             result = tool.call(event_store, "aggregate_type" => "Order", "aggregate_id" => "1")

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/aggregate_history_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/aggregate_history_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "ruby_event_store/mcp/tools/aggregate_history"
+
+module RubyEventStore
+  module MCP
+    module Tools
+      ::RSpec.describe AggregateHistory do
+        let(:event_store) { RubyEventStore::Client.new }
+        let(:tool) { AggregateHistory.new }
+
+        class OrderCreated < RubyEventStore::Event; end
+        class OrderShipped < RubyEventStore::Event; end
+
+        describe "#name" do
+          it { expect(tool.name).to eq("aggregate_history") }
+        end
+
+        describe "#schema" do
+          it "has expected structure" do
+            expect(tool.schema).to eq(
+              name: "aggregate_history",
+              description: "Show the full event history of an aggregate instance",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  aggregate_type: { type: "string", description: "Aggregate class name (e.g. Order, Payment::Invoice)" },
+                  aggregate_id: { type: "string", description: "Aggregate ID (UUID or other identifier)" }
+                },
+                required: %w[aggregate_type aggregate_id]
+              }
+            )
+          end
+        end
+
+        describe "#call" do
+          it "shows stream name formed from aggregate type and id" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$abc-123")
+            result = tool.call(event_store, "aggregate_type" => "Order", "aggregate_id" => "abc-123")
+            expect(result).to include("Aggregate: Order$abc-123")
+          end
+
+          it "shows event count" do
+            3.times { event_store.publish(OrderCreated.new, stream_name: "Order$1") }
+            result = tool.call(event_store, "aggregate_type" => "Order", "aggregate_id" => "1")
+            expect(result).to include("Events:    3")
+          end
+
+          it "shows zero events for unknown aggregate" do
+            result = tool.call(event_store, "aggregate_type" => "Order", "aggregate_id" => "missing")
+            expect(result).to include("Events:    0")
+          end
+
+          it "omits event list for empty stream" do
+            result = tool.call(event_store, "aggregate_type" => "Order", "aggregate_id" => "missing")
+            expect(result.lines.count).to eq(2)
+          end
+
+          it "does not add trailing newline for empty stream" do
+            result = tool.call(event_store, "aggregate_type" => "Order", "aggregate_id" => "missing")
+            expect(result).not_to end_with("\n")
+          end
+
+          it "separates header and event list with a blank line" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            result = tool.call(event_store, "aggregate_type" => "Order", "aggregate_id" => "1")
+            expect(result.lines[2].chomp).to eq("")
+          end
+
+          it "formats event type as plain class name without object notation" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            result = tool.call(event_store, "aggregate_type" => "Order", "aggregate_id" => "1")
+            expect(result).not_to include("#<")
+          end
+
+          it "lists events in chronological order" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            event_store.publish(OrderShipped.new, stream_name: "Order$1")
+            result = tool.call(event_store, "aggregate_type" => "Order", "aggregate_id" => "1")
+            created_pos = result.index("OrderCreated")
+            shipped_pos = result.index("OrderShipped")
+            expect(created_pos).to be < shipped_pos
+          end
+
+          it "includes event type for each event" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            result = tool.call(event_store, "aggregate_type" => "Order", "aggregate_id" => "1")
+            expect(result).to include("OrderCreated")
+          end
+
+          it "includes event id for each event" do
+            e = OrderCreated.new
+            event_store.publish(e, stream_name: "Order$1")
+            result = tool.call(event_store, "aggregate_type" => "Order", "aggregate_id" => "1")
+            expect(result).to include("[#{e.event_id}]")
+          end
+
+          it "includes iso8601 timestamp for each event" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            result = tool.call(event_store, "aggregate_type" => "Order", "aggregate_id" => "1")
+            expect(result).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/)
+          end
+
+          it "only shows events from the aggregate stream" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            event_store.publish(OrderShipped.new, stream_name: "Order$2")
+            result = tool.call(event_store, "aggregate_type" => "Order", "aggregate_id" => "1")
+            expect(result).to include("Events:    1")
+            expect(result).not_to include("OrderShipped")
+          end
+
+          it "places aggregate header on first line" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            result = tool.call(event_store, "aggregate_type" => "Order", "aggregate_id" => "1")
+            expect(result.lines.first.chomp).to eq("Aggregate: Order$1")
+          end
+
+          it "places event count on second line" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            result = tool.call(event_store, "aggregate_type" => "Order", "aggregate_id" => "1")
+            expect(result.lines[1].chomp).to eq("Events:    1")
+          end
+        end
+      end
+    end
+  end
+end

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/event_show_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/event_show_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "ruby_event_store/mcp/tools/event_show"
+
+module RubyEventStore
+  module MCP
+    module Tools
+      ::RSpec.describe EventShow do
+        let(:event_store) { RubyEventStore::Client.new }
+        let(:tool) { EventShow.new }
+
+        class OrderCreated < RubyEventStore::Event; end
+
+        describe "#name" do
+          it { expect(tool.name).to eq("event_show") }
+        end
+
+        describe "#schema" do
+          it "requires event_id" do
+            expect(tool.schema[:inputSchema][:required]).to include("event_id")
+          end
+        end
+
+        describe "#call" do
+          it "shows event details" do
+            event = OrderCreated.new(data: { order_id: 42 })
+            event_store.publish(event, stream_name: "Order$42")
+
+            result = tool.call(event_store, "event_id" => event.event_id)
+
+            expect(result).to include("Event ID:   #{event.event_id}")
+            expect(result).to include("Type:       RubyEventStore::MCP::Tools::OrderCreated")
+            expect(result).to include("order_id")
+          end
+
+          it "raises for unknown event" do
+            expect { tool.call(event_store, "event_id" => SecureRandom.uuid) }
+              .to raise_error(RubyEventStore::EventNotFound)
+          end
+        end
+      end
+    end
+  end
+end

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/event_show_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/event_show_spec.rb
@@ -17,21 +17,50 @@ module RubyEventStore
         end
 
         describe "#schema" do
-          it "requires event_id" do
-            expect(tool.schema[:inputSchema][:required]).to include("event_id")
+          it "has expected structure" do
+            expect(tool.schema).to eq(
+              name: "event_show",
+              description: "Show full event details including data, metadata, and timestamps",
+              inputSchema: {
+                type: "object",
+                properties: { event_id: { type: "string", description: "Event ID (UUID)" } },
+                required: ["event_id"]
+              }
+            )
           end
         end
 
         describe "#call" do
-          it "shows event details" do
-            event = OrderCreated.new(data: { order_id: 42 })
-            event_store.publish(event, stream_name: "Order$42")
+          let(:event) { OrderCreated.new(data: { order_id: 42 }, metadata: { user_id: 1 }) }
+          let(:result) { event_store.publish(event, stream_name: "Order$42"); tool.call(event_store, "event_id" => event.event_id) }
 
-            result = tool.call(event_store, "event_id" => event.event_id)
-
+          it "shows event id" do
             expect(result).to include("Event ID:   #{event.event_id}")
+          end
+
+          it "shows event type" do
             expect(result).to include("Type:       RubyEventStore::MCP::Tools::OrderCreated")
-            expect(result).to include("order_id")
+          end
+
+          it "shows timestamp in iso8601 with exactly 3 decimal places" do
+            expect(result).to match(/Timestamp:  \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/)
+          end
+
+          it "shows valid_at in iso8601 with exactly 3 decimal places" do
+            expect(result).to match(/Valid at:   \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/)
+          end
+
+          it "shows data as formatted json" do
+            expect(result).to include('"order_id": 42')
+          end
+
+          it "shows metadata as formatted json" do
+            expect(result).to include('"user_id": 1')
+          end
+
+          it "separates fields with newlines between each field" do
+            expect(result.lines.first.chomp).to eq("Event ID:   #{event.event_id}")
+            expect(result.lines[1].chomp).to start_with("Type:")
           end
 
           it "raises for unknown event" do

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/event_streams_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/event_streams_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "ruby_event_store/mcp/tools/event_streams"
+
+module RubyEventStore
+  module MCP
+    module Tools
+      ::RSpec.describe EventStreams do
+        let(:event_store) { RubyEventStore::Client.new }
+        let(:tool) { EventStreams.new }
+
+        describe "#name" do
+          it { expect(tool.name).to eq("event_streams") }
+        end
+
+        describe "#schema" do
+          it "requires event_id" do
+            expect(tool.schema[:inputSchema][:required]).to include("event_id")
+          end
+        end
+
+        describe "#call" do
+          it "returns no streams message for unknown event" do
+            result = tool.call(event_store, "event_id" => SecureRandom.uuid)
+            expect(result).to include("no streams")
+          end
+
+          it "lists streams the event was published or linked to" do
+            event = RubyEventStore::Event.new
+            event_store.publish(event, stream_name: "Order$1")
+            event_store.link(event.event_id, stream_name: "Shipping$1")
+
+            result = tool.call(event_store, "event_id" => event.event_id)
+
+            expect(result).to include("Order$1")
+            expect(result).to include("Shipping$1")
+          end
+        end
+      end
+    end
+  end
+end

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/event_streams_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/event_streams_spec.rb
@@ -15,8 +15,16 @@ module RubyEventStore
         end
 
         describe "#schema" do
-          it "requires event_id" do
-            expect(tool.schema[:inputSchema][:required]).to include("event_id")
+          it "has expected structure" do
+            expect(tool.schema).to eq(
+              name: "event_streams",
+              description: "List all streams the event has been published or linked to",
+              inputSchema: {
+                type: "object",
+                properties: { event_id: { type: "string", description: "Event ID (UUID)" } },
+                required: ["event_id"]
+              }
+            )
           end
         end
 
@@ -35,6 +43,17 @@ module RubyEventStore
 
             expect(result).to include("Order$1")
             expect(result).to include("Shipping$1")
+          end
+
+          it "separates stream names with newlines" do
+            event = RubyEventStore::Event.new
+            event_store.publish(event, stream_name: "Order$1")
+            event_store.link(event.event_id, stream_name: "Shipping$1")
+
+            result = tool.call(event_store, "event_id" => event.event_id)
+            lines = result.lines.map(&:chomp)
+            expect(lines).to include("Order$1")
+            expect(lines).to include("Shipping$1")
           end
         end
       end

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/recent_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/recent_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "ruby_event_store/mcp/tools/recent"
+
+module RubyEventStore
+  module MCP
+    module Tools
+      ::RSpec.describe Recent do
+        let(:event_store) { RubyEventStore::Client.new }
+        let(:tool) { Recent.new }
+
+        class OrderPlaced < RubyEventStore::Event; end
+        class OrderShipped < RubyEventStore::Event; end
+
+        describe "#name" do
+          it { expect(tool.name).to eq("recent") }
+        end
+
+        describe "#schema" do
+          it "has expected structure" do
+            expect(tool.schema).to eq(
+              name: "recent",
+              description: "Show the most recent events across all streams",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  limit: { type: "integer", description: "Number of events to return (default: 20)" }
+                },
+                required: []
+              }
+            )
+          end
+        end
+
+        describe "#call" do
+          it "returns no events message for empty store" do
+            result = tool.call(event_store, {})
+            expect(result).to eq("(no events)")
+          end
+
+          it "returns events when present" do
+            event_store.publish(OrderPlaced.new, stream_name: "Order$1")
+            result = tool.call(event_store, {})
+            expect(result).not_to eq("(no events)")
+          end
+
+          it "returns events most recent first" do
+            event_store.publish(OrderPlaced.new, stream_name: "Order$1")
+            event_store.publish(OrderShipped.new, stream_name: "Order$1")
+            result = tool.call(event_store, {})
+            expect(result.index("OrderShipped")).to be < result.index("OrderPlaced")
+          end
+
+          it "respects the limit parameter" do
+            5.times { event_store.publish(OrderPlaced.new, stream_name: "Order$1") }
+            result = tool.call(event_store, "limit" => 3)
+            expect(result.lines.count).to eq(3)
+          end
+
+          it "accepts string limit by converting via to_i" do
+            5.times { event_store.publish(OrderPlaced.new, stream_name: "Order$1") }
+            result = tool.call(event_store, "limit" => "3")
+            expect(result.lines.count).to eq(3)
+          end
+
+          it "extracts leading digits from partial numeric string limit via to_i" do
+            5.times { event_store.publish(OrderPlaced.new, stream_name: "Order$1") }
+            result = tool.call(event_store, "limit" => "3abc")
+            expect(result.lines.count).to eq(3)
+          end
+
+          it "defaults to 20 events when no limit given" do
+            25.times { event_store.publish(OrderPlaced.new, stream_name: "Order$1") }
+            result = tool.call(event_store, {})
+            expect(result.lines.count).to eq(20)
+          end
+
+          it "includes event type" do
+            event_store.publish(OrderPlaced.new, stream_name: "Order$1")
+            result = tool.call(event_store, {})
+            expect(result).to include("OrderPlaced")
+          end
+
+          it "includes event id" do
+            e = OrderPlaced.new
+            event_store.publish(e, stream_name: "Order$1")
+            result = tool.call(event_store, {})
+            expect(result).to include("[#{e.event_id}]")
+          end
+
+          it "includes iso8601 timestamp" do
+            event_store.publish(OrderPlaced.new, stream_name: "Order$1")
+            result = tool.call(event_store, {})
+            expect(result).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/)
+          end
+
+          it "includes events from different streams" do
+            event_store.publish(OrderPlaced.new, stream_name: "Order$1")
+            event_store.publish(OrderShipped.new, stream_name: "Order$2")
+            result = tool.call(event_store, {})
+            expect(result).to include("OrderPlaced")
+            expect(result).to include("OrderShipped")
+          end
+
+          it "formats event type as plain class name without object notation" do
+            event_store.publish(OrderPlaced.new, stream_name: "Order$1")
+            result = tool.call(event_store, {})
+            expect(result).not_to include("#<")
+          end
+        end
+      end
+    end
+  end
+end

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/search_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/search_spec.rb
@@ -17,6 +17,25 @@ module RubyEventStore
           it { expect(tool.name).to eq("search") }
         end
 
+        describe "#schema" do
+          it "has expected structure" do
+            expect(tool.schema).to eq(
+              name: "search",
+              description: "Search events across all streams by type, time range, or stream name",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  type: { type: "string", description: "Filter by event type class name" },
+                  after: { type: "string", description: "Filter events newer than timestamp (ISO8601)" },
+                  before: { type: "string", description: "Filter events older than timestamp (ISO8601)" },
+                  stream: { type: "string", description: "Limit search to a specific stream" },
+                  limit: { type: "integer", description: "Max number of events (default: 50)" }
+                }
+              }
+            )
+          end
+        end
+
         describe "#call" do
           it "returns no events message when nothing matches" do
             expect(tool.call(event_store, {})).to eq("(no events found)")
@@ -28,6 +47,12 @@ module RubyEventStore
             result = tool.call(event_store, {})
             expect(result).to include("OrderCreated")
             expect(result).to include("OrderShipped")
+          end
+
+          it "formats events with iso8601 timestamp and id in brackets" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            result = tool.call(event_store, {})
+            expect(result).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z  \S.*OrderCreated.*\[.{36}\]/)
           end
 
           it "filters by event type" do
@@ -50,6 +75,26 @@ module RubyEventStore
             3.times { event_store.publish(RubyEventStore::Event.new, stream_name: "Order$1") }
             result = tool.call(event_store, "limit" => 2)
             expect(result.lines.count).to eq(2)
+          end
+
+          it "filters by after timestamp" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            future = (Time.now + 3600).iso8601
+            result = tool.call(event_store, "after" => future)
+            expect(result).to eq("(no events found)")
+          end
+
+          it "filters by before timestamp" do
+            past = (Time.now - 3600).iso8601
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            result = tool.call(event_store, "before" => past)
+            expect(result).to eq("(no events found)")
+          end
+
+          it "defaults to limit 50" do
+            51.times { event_store.publish(RubyEventStore::Event.new, stream_name: "Order$1") }
+            result = tool.call(event_store, {})
+            expect(result.lines.count).to eq(50)
           end
         end
       end

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/search_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/search_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "ruby_event_store/mcp/tools/search"
+
+module RubyEventStore
+  module MCP
+    module Tools
+      ::RSpec.describe Search do
+        let(:event_store) { RubyEventStore::Client.new }
+        let(:tool) { Search.new }
+
+        class OrderCreated < RubyEventStore::Event; end
+        class OrderShipped < RubyEventStore::Event; end
+
+        describe "#name" do
+          it { expect(tool.name).to eq("search") }
+        end
+
+        describe "#call" do
+          it "returns no events message when nothing matches" do
+            expect(tool.call(event_store, {})).to eq("(no events found)")
+          end
+
+          it "lists all events when no filters given" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            event_store.publish(OrderShipped.new, stream_name: "Order$1")
+            result = tool.call(event_store, {})
+            expect(result).to include("OrderCreated")
+            expect(result).to include("OrderShipped")
+          end
+
+          it "filters by event type" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            event_store.publish(OrderShipped.new, stream_name: "Order$1")
+            result = tool.call(event_store, "type" => "RubyEventStore::MCP::Tools::OrderCreated")
+            expect(result).to include("OrderCreated")
+            expect(result).not_to include("OrderShipped")
+          end
+
+          it "limits to a specific stream" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            event_store.publish(OrderShipped.new, stream_name: "Order$2")
+            result = tool.call(event_store, "stream" => "Order$1")
+            expect(result).to include("OrderCreated")
+            expect(result).not_to include("OrderShipped")
+          end
+
+          it "respects limit" do
+            3.times { event_store.publish(RubyEventStore::Event.new, stream_name: "Order$1") }
+            result = tool.call(event_store, "limit" => 2)
+            expect(result.lines.count).to eq(2)
+          end
+        end
+      end
+    end
+  end
+end

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/search_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/search_spec.rb
@@ -55,6 +55,12 @@ module RubyEventStore
             expect(result).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z  \S.*OrderCreated.*\[.{36}\]/)
           end
 
+          it "includes full event type name with double-space separator" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            result = tool.call(event_store, {})
+            expect(result).to include("  RubyEventStore::MCP::Tools::OrderCreated  [")
+          end
+
           it "filters by event type" do
             event_store.publish(OrderCreated.new, stream_name: "Order$1")
             event_store.publish(OrderShipped.new, stream_name: "Order$1")

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/stats_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/stats_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "ruby_event_store/mcp/tools/stats"
+
+module RubyEventStore
+  module MCP
+    module Tools
+      ::RSpec.describe Stats do
+        let(:event_store) { RubyEventStore::Client.new }
+        let(:tool) { Stats.new }
+
+        class OrderCreated < RubyEventStore::Event; end
+        class OrderShipped < RubyEventStore::Event; end
+
+        describe "#name" do
+          it { expect(tool.name).to eq("stats") }
+        end
+
+        describe "#call" do
+          it "shows total event count" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            event_store.publish(OrderShipped.new, stream_name: "Order$1")
+            result = tool.call(event_store, {})
+            expect(result).to include("Events:  2")
+          end
+
+          it "lists unique event types" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            event_store.publish(OrderShipped.new, stream_name: "Order$1")
+            result = tool.call(event_store, {})
+            expect(result).to include("OrderCreated")
+            expect(result).to include("OrderShipped")
+            expect(result.scan("OrderCreated").count).to eq(1)
+          end
+
+          it "shows per-stream stats when stream given" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            event_store.publish(OrderShipped.new, stream_name: "Order$2")
+            result = tool.call(event_store, "stream" => "Order$1")
+            expect(result).to include("Stream:  Order$1")
+            expect(result).to include("Events:  1")
+            expect(result).not_to include("OrderShipped")
+          end
+
+          it "omits event types section for empty store" do
+            result = tool.call(event_store, {})
+            expect(result).not_to include("Event types")
+          end
+        end
+      end
+    end
+  end
+end

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/stats_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/stats_spec.rb
@@ -17,6 +17,21 @@ module RubyEventStore
           it { expect(tool.name).to eq("stats") }
         end
 
+        describe "#schema" do
+          it "has expected structure" do
+            expect(tool.schema).to eq(
+              name: "stats",
+              description: "Show event count and unique event types. Use stream to get per-stream stats.",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  stream: { type: "string", description: "Show stats for a specific stream" }
+                }
+              }
+            )
+          end
+        end
+
         describe "#call" do
           it "shows total event count" do
             event_store.publish(OrderCreated.new, stream_name: "Order$1")
@@ -47,6 +62,45 @@ module RubyEventStore
           it "omits event types section for empty store" do
             result = tool.call(event_store, {})
             expect(result).not_to include("Event types")
+          end
+
+          it "includes Event types header when events exist" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            result = tool.call(event_store, {})
+            expect(result).to include("Event types:")
+          end
+
+          it "shows event types sorted alphabetically" do
+            event_store.publish(OrderShipped.new, stream_name: "Order$1")
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            result = tool.call(event_store, {})
+            created_pos = result.index("OrderCreated")
+            shipped_pos = result.index("OrderShipped")
+            expect(created_pos).to be < shipped_pos
+          end
+
+          it "indents each event type with two spaces" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            result = tool.call(event_store, {})
+            expect(result).to include("  RubyEventStore::MCP::Tools::OrderCreated")
+          end
+
+          it "does not show stream line when no stream given" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            result = tool.call(event_store, {})
+            expect(result).not_to include("Stream:")
+          end
+
+          it "separates event count from types section with blank line" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            result = tool.call(event_store, {})
+            expect(result).to include("\n\nEvent types:")
+          end
+
+          it "places stream on first line when given" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            result = tool.call(event_store, "stream" => "Order$1")
+            expect(result.lines.first.chomp).to eq("Stream:  Order$1")
           end
         end
       end

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/stream_events_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/stream_events_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "ruby_event_store/mcp/tools/stream_events"
+
+module RubyEventStore
+  module MCP
+    module Tools
+      ::RSpec.describe StreamEvents do
+        let(:event_store) { RubyEventStore::Client.new }
+        let(:tool) { StreamEvents.new }
+
+        class OrderCreated < RubyEventStore::Event; end
+        class OrderShipped < RubyEventStore::Event; end
+
+        describe "#name" do
+          it { expect(tool.name).to eq("stream_events") }
+        end
+
+        describe "#schema" do
+          it "requires stream_name" do
+            expect(tool.schema[:inputSchema][:required]).to include("stream_name")
+          end
+        end
+
+        describe "#call" do
+          it "returns no events message for empty stream" do
+            expect(tool.call(event_store, "stream_name" => "empty")).to eq("(no events)")
+          end
+
+          it "lists events with timestamp, type and id" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            result = tool.call(event_store, "stream_name" => "Order$1")
+            expect(result).to match(/OrderCreated/)
+            expect(result).to match(/\[.{36}\]/)
+          end
+
+          it "filters by event type" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            event_store.publish(OrderShipped.new, stream_name: "Order$1")
+            result = tool.call(event_store, "stream_name" => "Order$1", "type" => "RubyEventStore::MCP::Tools::OrderCreated")
+            expect(result).to include("OrderCreated")
+            expect(result).not_to include("OrderShipped")
+          end
+
+          it "limits number of events" do
+            3.times { event_store.publish(RubyEventStore::Event.new, stream_name: "Order$1") }
+            result = tool.call(event_store, "stream_name" => "Order$1", "limit" => 2)
+            expect(result.lines.count).to eq(2)
+          end
+
+          it "raises for unknown event type" do
+            expect { tool.call(event_store, "stream_name" => "Order$1", "type" => "NonExistentType") }
+              .to raise_error(/Unknown event type/)
+          end
+        end
+      end
+    end
+  end
+end

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/stream_events_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/stream_events_spec.rb
@@ -49,6 +49,12 @@ module RubyEventStore
             expect(result).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z  \S.*OrderCreated.*\[.{36}\]/)
           end
 
+          it "includes full event type name with double-space separator" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            result = tool.call(event_store, "stream_name" => "Order$1")
+            expect(result).to include("  RubyEventStore::MCP::Tools::OrderCreated  [")
+          end
+
           it "filters by event type" do
             event_store.publish(OrderCreated.new, stream_name: "Order$1")
             event_store.publish(OrderShipped.new, stream_name: "Order$1")

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/stream_events_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/stream_events_spec.rb
@@ -18,8 +18,23 @@ module RubyEventStore
         end
 
         describe "#schema" do
-          it "requires stream_name" do
-            expect(tool.schema[:inputSchema][:required]).to include("stream_name")
+          it "has expected structure" do
+            expect(tool.schema).to eq(
+              name: "stream_events",
+              description: "List events in a stream with optional filters",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  stream_name: { type: "string", description: "Stream name" },
+                  limit: { type: "integer", description: "Max number of events (default: 20)" },
+                  type: { type: "string", description: "Filter by event type class name" },
+                  after: { type: "string", description: "Filter events newer than timestamp (ISO8601)" },
+                  before: { type: "string", description: "Filter events older than timestamp (ISO8601)" },
+                  from: { type: "string", description: "Start reading from event ID (exclusive)" }
+                },
+                required: ["stream_name"]
+              }
+            )
           end
         end
 
@@ -28,11 +43,10 @@ module RubyEventStore
             expect(tool.call(event_store, "stream_name" => "empty")).to eq("(no events)")
           end
 
-          it "lists events with timestamp, type and id" do
+          it "formats events with iso8601 timestamp, type and id in brackets" do
             event_store.publish(OrderCreated.new, stream_name: "Order$1")
             result = tool.call(event_store, "stream_name" => "Order$1")
-            expect(result).to match(/OrderCreated/)
-            expect(result).to match(/\[.{36}\]/)
+            expect(result).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z  \S.*OrderCreated.*\[.{36}\]/)
           end
 
           it "filters by event type" do
@@ -49,9 +63,48 @@ module RubyEventStore
             expect(result.lines.count).to eq(2)
           end
 
+          it "filters by after timestamp" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            future = (Time.now + 3600).iso8601
+            event_store.publish(OrderShipped.new, stream_name: "Order$1")
+            result = tool.call(event_store, "stream_name" => "Order$1", "after" => future)
+            expect(result).to include("(no events)")
+          end
+
+          it "filters by before timestamp" do
+            past = (Time.now - 3600).iso8601
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            result = tool.call(event_store, "stream_name" => "Order$1", "before" => past)
+            expect(result).to include("(no events)")
+          end
+
+          it "reads from a given event id" do
+            first = OrderCreated.new
+            second = OrderShipped.new
+            event_store.publish(first, stream_name: "Order$1")
+            event_store.publish(second, stream_name: "Order$1")
+            result = tool.call(event_store, "stream_name" => "Order$1", "from" => first.event_id)
+            expect(result).to include("OrderShipped")
+            expect(result).not_to include("OrderCreated")
+          end
+
           it "raises for unknown event type" do
             expect { tool.call(event_store, "stream_name" => "Order$1", "type" => "NonExistentType") }
               .to raise_error(/Unknown event type/)
+          end
+
+          it "only returns events from the specified stream" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            event_store.publish(OrderShipped.new, stream_name: "Other$1")
+            result = tool.call(event_store, "stream_name" => "Order$1")
+            expect(result).to include("OrderCreated")
+            expect(result).not_to include("OrderShipped")
+          end
+
+          it "defaults to limit 20" do
+            21.times { event_store.publish(RubyEventStore::Event.new, stream_name: "Order$1") }
+            result = tool.call(event_store, "stream_name" => "Order$1")
+            expect(result.lines.count).to eq(20)
           end
         end
       end

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/stream_show_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/stream_show_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "ruby_event_store/mcp/tools/stream_show"
+
+module RubyEventStore
+  module MCP
+    module Tools
+      ::RSpec.describe StreamShow do
+        let(:event_store) { RubyEventStore::Client.new }
+        let(:tool) { StreamShow.new }
+
+        class OrderCreated < RubyEventStore::Event; end
+        class OrderShipped < RubyEventStore::Event; end
+
+        describe "#name" do
+          it { expect(tool.name).to eq("stream_show") }
+        end
+
+        describe "#schema" do
+          it "includes required stream_name property" do
+            expect(tool.schema[:inputSchema][:required]).to include("stream_name")
+          end
+        end
+
+        describe "#call" do
+          it "shows stream name and event count" do
+            event_store.publish(RubyEventStore::Event.new, stream_name: "Order$1")
+            result = tool.call(event_store, "stream_name" => "Order$1")
+            expect(result).to include("Stream:  Order$1")
+            expect(result).to include("Events:  1")
+          end
+
+          it "shows version as count minus one" do
+            event_store.publish(RubyEventStore::Event.new, stream_name: "Order$1")
+            event_store.publish(RubyEventStore::Event.new, stream_name: "Order$1")
+            result = tool.call(event_store, "stream_name" => "Order$1")
+            expect(result).to include("Version: 1")
+          end
+
+          it "shows first and last event types" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            event_store.publish(OrderShipped.new, stream_name: "Order$1")
+            result = tool.call(event_store, "stream_name" => "Order$1")
+            expect(result).to match(/First:.*OrderCreated/)
+            expect(result).to match(/Last:.*OrderShipped/)
+          end
+
+          it "omits version and timestamps for empty stream" do
+            result = tool.call(event_store, "stream_name" => "empty-stream")
+            expect(result).to include("Events:  0")
+            expect(result).not_to include("Version")
+          end
+        end
+      end
+    end
+  end
+end

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/stream_show_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/stream_show_spec.rb
@@ -18,8 +18,18 @@ module RubyEventStore
         end
 
         describe "#schema" do
-          it "includes required stream_name property" do
-            expect(tool.schema[:inputSchema][:required]).to include("stream_name")
+          it "has expected structure" do
+            expect(tool.schema).to eq(
+              name: "stream_show",
+              description: "Show event count, version, and first/last event for a stream",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  stream_name: { type: "string", description: "Stream name" }
+                },
+                required: ["stream_name"]
+              }
+            )
           end
         end
 
@@ -32,18 +42,43 @@ module RubyEventStore
           end
 
           it "shows version as count minus one" do
-            event_store.publish(RubyEventStore::Event.new, stream_name: "Order$1")
-            event_store.publish(RubyEventStore::Event.new, stream_name: "Order$1")
+            3.times { event_store.publish(RubyEventStore::Event.new, stream_name: "Order$1") }
             result = tool.call(event_store, "stream_name" => "Order$1")
-            expect(result).to include("Version: 1")
+            expect(result).to include("Version: 2")
           end
 
-          it "shows first and last event types" do
+          it "shows first and last event types with iso8601 timestamps" do
             event_store.publish(OrderCreated.new, stream_name: "Order$1")
             event_store.publish(OrderShipped.new, stream_name: "Order$1")
             result = tool.call(event_store, "stream_name" => "Order$1")
-            expect(result).to match(/First:.*OrderCreated/)
-            expect(result).to match(/Last:.*OrderShipped/)
+            expect(result).to match(/First:   \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z.*OrderCreated/)
+            expect(result).to match(/Last:    \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z.*OrderShipped/)
+          end
+
+          it "shows first event type as class name" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            result = tool.call(event_store, "stream_name" => "Order$1")
+            expect(result).to match(/First:   .* \(RubyEventStore::/)
+          end
+
+          it "shows last event type as class name" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            result = tool.call(event_store, "stream_name" => "Order$1")
+            expect(result).to match(/Last:    .* \(RubyEventStore::/)
+          end
+
+          it "places each field on its own line" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            result = tool.call(event_store, "stream_name" => "Order$1")
+            expect(result.lines.first.chomp).to eq("Stream:  Order$1")
+            expect(result.lines[1].chomp).to eq("Events:  1")
+          end
+
+          it "only counts events from the specified stream" do
+            event_store.publish(OrderCreated.new, stream_name: "Order$1")
+            event_store.publish(OrderShipped.new, stream_name: "Other$1")
+            result = tool.call(event_store, "stream_name" => "Order$1")
+            expect(result).to include("Events:  1")
           end
 
           it "omits version and timestamps for empty stream" do

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/trace_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/trace_spec.rb
@@ -19,8 +19,18 @@ module RubyEventStore
         end
 
         describe "#schema" do
-          it "requires correlation_id" do
-            expect(tool.schema[:inputSchema][:required]).to include("correlation_id")
+          it "has expected structure" do
+            expect(tool.schema).to eq(
+              name: "trace",
+              description: "Show the causation tree for all events sharing a correlation ID",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  correlation_id: { type: "string", description: "Correlation ID (UUID)" }
+                },
+                required: ["correlation_id"]
+              }
+            )
           end
         end
 
@@ -28,6 +38,12 @@ module RubyEventStore
           it "returns no events message for unknown correlation id" do
             result = tool.call(event_store, "correlation_id" => SecureRandom.uuid)
             expect(result).to include("no events found")
+          end
+
+          it "includes the correlation id in the no events message" do
+            correlation_id = SecureRandom.uuid
+            result = tool.call(event_store, "correlation_id" => correlation_id)
+            expect(result).to include("correlation ID #{correlation_id}")
           end
 
           it "shows root event" do
@@ -39,6 +55,31 @@ module RubyEventStore
             result = tool.call(event_store, "correlation_id" => correlation_id)
             expect(result).to include("OrderCreated")
             expect(result).to include(root.event_id)
+          end
+
+          it "shows root event without connector prefix" do
+            correlation_id = SecureRandom.uuid
+            root = OrderCreated.new(metadata: { correlation_id: correlation_id })
+            event_store.publish(root, stream_name: "Order$1")
+            event_store.link(root.event_id, stream_name: "$by_correlation_id_#{correlation_id}")
+
+            result = tool.call(event_store, "correlation_id" => correlation_id)
+            first_line = result.lines.first.chomp
+            expect(first_line).not_to include("└──")
+            expect(first_line).not_to include("├──")
+          end
+
+          it "only includes events from the given correlation id stream" do
+            correlation_id = SecureRandom.uuid
+            root = OrderCreated.new(metadata: { correlation_id: correlation_id })
+            unrelated = PaymentCharged.new
+            event_store.publish(root, stream_name: "Order$1")
+            event_store.publish(unrelated, stream_name: "Payment$1")
+            event_store.link(root.event_id, stream_name: "$by_correlation_id_#{correlation_id}")
+
+            result = tool.call(event_store, "correlation_id" => correlation_id)
+            expect(result).to include("OrderCreated")
+            expect(result).not_to include("PaymentCharged")
           end
 
           it "shows causation tree with children" do
@@ -57,9 +98,44 @@ module RubyEventStore
             result = tool.call(event_store, "correlation_id" => correlation_id)
             lines = result.lines.map(&:chomp)
 
-            expect(lines[0]).to match(/OrderCreated \[/)
-            expect(lines[1]).to match(/└──.*PaymentCharged \[/)
-            expect(lines[2]).to match(/    └──.*EmailSent \[/)
+            expect(lines.count).to eq(3)
+            expect(lines[0]).to match(/\A\S.*OrderCreated \[/)
+            expect(lines[1]).to match(/\A└──.*PaymentCharged \[/)
+            expect(lines[2]).to match(/\A    └──.*EmailSent \[/)
+          end
+
+          it "shows branch connector for non-last children" do
+            correlation_id = SecureRandom.uuid
+            root = OrderCreated.new(metadata: { correlation_id: correlation_id })
+            child1 = PaymentCharged.new(metadata: { correlation_id: correlation_id, causation_id: root.event_id })
+            child2 = EmailSent.new(metadata: { correlation_id: correlation_id, causation_id: root.event_id })
+
+            event_store.publish(root, stream_name: "Order$1")
+            event_store.publish(child1, stream_name: "Payment$1")
+            event_store.publish(child2, stream_name: "Email$1")
+            [root, child1, child2].each do |e|
+              event_store.link(e.event_id, stream_name: "$by_correlation_id_#{correlation_id}")
+            end
+
+            result = tool.call(event_store, "correlation_id" => correlation_id)
+            expect(result).to include("├──")
+            expect(result).to include("└──")
+          end
+
+          it "shows pipe prefix for children under non-last branch" do
+            correlation_id = SecureRandom.uuid
+            root = OrderCreated.new(metadata: { correlation_id: correlation_id })
+            child1 = PaymentCharged.new(metadata: { correlation_id: correlation_id, causation_id: root.event_id })
+            child2 = EmailSent.new(metadata: { correlation_id: correlation_id, causation_id: root.event_id })
+            grandchild = OrderCreated.new(metadata: { correlation_id: correlation_id, causation_id: child1.event_id })
+
+            [root, child1, child2, grandchild].each { |e| event_store.publish(e, stream_name: "Order$1") }
+            [root, child1, child2, grandchild].each do |e|
+              event_store.link(e.event_id, stream_name: "$by_correlation_id_#{correlation_id}")
+            end
+
+            result = tool.call(event_store, "correlation_id" => correlation_id)
+            expect(result).to include("│")
           end
         end
       end

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/trace_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/trace_spec.rb
@@ -122,6 +122,37 @@ module RubyEventStore
             expect(result).to include("└──")
           end
 
+          it "treats event with external causation_id as root" do
+            correlation_id = SecureRandom.uuid
+            root = OrderCreated.new(metadata: {
+              correlation_id: correlation_id,
+              causation_id: SecureRandom.uuid
+            })
+            event_store.publish(root, stream_name: "Order$1")
+            event_store.link(root.event_id, stream_name: "$by_correlation_id_#{correlation_id}")
+
+            result = tool.call(event_store, "correlation_id" => correlation_id)
+            expect(result).to include("OrderCreated")
+          end
+
+          it "preserves accumulated prefix for deeply nested nodes" do
+            correlation_id = SecureRandom.uuid
+            root = OrderCreated.new(metadata: { correlation_id: correlation_id })
+            child1 = PaymentCharged.new(metadata: { correlation_id: correlation_id, causation_id: root.event_id })
+            child2 = EmailSent.new(metadata: { correlation_id: correlation_id, causation_id: root.event_id })
+            grandchild = OrderCreated.new(metadata: { correlation_id: correlation_id, causation_id: child1.event_id })
+            great_grandchild = PaymentCharged.new(metadata: { correlation_id: correlation_id, causation_id: grandchild.event_id })
+
+            [root, child1, child2, grandchild, great_grandchild].each do |e|
+              event_store.publish(e, stream_name: "Order$1")
+              event_store.link(e.event_id, stream_name: "$by_correlation_id_#{correlation_id}")
+            end
+
+            result = tool.call(event_store, "correlation_id" => correlation_id)
+            lines = result.lines.map(&:chomp)
+            expect(lines[3]).to start_with("│")
+          end
+
           it "shows pipe prefix for children under non-last branch" do
             correlation_id = SecureRandom.uuid
             root = OrderCreated.new(metadata: { correlation_id: correlation_id })

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/trace_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/trace_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "ruby_event_store/mcp/tools/trace"
+
+module RubyEventStore
+  module MCP
+    module Tools
+      ::RSpec.describe Trace do
+        let(:event_store) { RubyEventStore::Client.new }
+        let(:tool) { Trace.new }
+
+        class OrderCreated < RubyEventStore::Event; end
+        class PaymentCharged < RubyEventStore::Event; end
+        class EmailSent < RubyEventStore::Event; end
+
+        describe "#name" do
+          it { expect(tool.name).to eq("trace") }
+        end
+
+        describe "#schema" do
+          it "requires correlation_id" do
+            expect(tool.schema[:inputSchema][:required]).to include("correlation_id")
+          end
+        end
+
+        describe "#call" do
+          it "returns no events message for unknown correlation id" do
+            result = tool.call(event_store, "correlation_id" => SecureRandom.uuid)
+            expect(result).to include("no events found")
+          end
+
+          it "shows root event" do
+            correlation_id = SecureRandom.uuid
+            root = OrderCreated.new(metadata: { correlation_id: correlation_id })
+            event_store.publish(root, stream_name: "Order$1")
+            event_store.link(root.event_id, stream_name: "$by_correlation_id_#{correlation_id}")
+
+            result = tool.call(event_store, "correlation_id" => correlation_id)
+            expect(result).to include("OrderCreated")
+            expect(result).to include(root.event_id)
+          end
+
+          it "shows causation tree with children" do
+            correlation_id = SecureRandom.uuid
+            root = OrderCreated.new(metadata: { correlation_id: correlation_id })
+            child = PaymentCharged.new(metadata: { correlation_id: correlation_id, causation_id: root.event_id })
+            grandchild = EmailSent.new(metadata: { correlation_id: correlation_id, causation_id: child.event_id })
+
+            event_store.publish(root, stream_name: "Order$1")
+            event_store.publish(child, stream_name: "Payment$1")
+            event_store.publish(grandchild, stream_name: "Email$1")
+            [root, child, grandchild].each do |e|
+              event_store.link(e.event_id, stream_name: "$by_correlation_id_#{correlation_id}")
+            end
+
+            result = tool.call(event_store, "correlation_id" => correlation_id)
+            lines = result.lines.map(&:chomp)
+
+            expect(lines[0]).to match(/OrderCreated \[/)
+            expect(lines[1]).to match(/└──.*PaymentCharged \[/)
+            expect(lines[2]).to match(/    └──.*EmailSent \[/)
+          end
+        end
+      end
+    end
+  end
+end

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/trace_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp/tools/trace_spec.rb
@@ -7,12 +7,32 @@ module RubyEventStore
   module MCP
     module Tools
       ::RSpec.describe Trace do
+        class OrderPlaced < RubyEventStore::Event; end
+        class PaymentProcessed < RubyEventStore::Event; end
+        class OrderShipped < RubyEventStore::Event; end
+        class UserRegistered < RubyEventStore::Event; end
+        class FraudCheckPassed < RubyEventStore::Event; end
+        class InventoryReserved < RubyEventStore::Event; end
+        class InventoryReleased < RubyEventStore::Event; end
+        class WarehouseNotified < RubyEventStore::Event; end
+        class InvoiceGenerated < RubyEventStore::Event; end
+        class LoyaltyPointsAwarded < RubyEventStore::Event; end
+        class EmailSent < RubyEventStore::Event; end
+
         let(:event_store) { RubyEventStore::Client.new }
         let(:tool) { Trace.new }
 
-        class OrderCreated < RubyEventStore::Event; end
-        class PaymentCharged < RubyEventStore::Event; end
-        class EmailSent < RubyEventStore::Event; end
+        def pub(event, stream)
+          event_store.publish(event, stream_name: stream)
+          event_store.link(event.event_id, stream_name: "$by_correlation_id_#{event.metadata[:correlation_id]}")
+          event
+        end
+
+        def tree_shape(cid)
+          tool.call(event_store, "correlation_id" => cid)
+            .lines.map(&:chomp)
+            .map { |l| l.sub(/(?:\w+::)+(\w+) \[/, '\1 [').sub(/\[.*?\]/, "[id]") }
+        end
 
         describe "#name" do
           it { expect(tool.name).to eq("trace") }
@@ -41,132 +61,110 @@ module RubyEventStore
           end
 
           it "includes the correlation id in the no events message" do
-            correlation_id = SecureRandom.uuid
-            result = tool.call(event_store, "correlation_id" => correlation_id)
-            expect(result).to include("correlation ID #{correlation_id}")
+            cid = SecureRandom.uuid
+            expect(tool.call(event_store, "correlation_id" => cid)).to include("correlation ID #{cid}")
           end
 
-          it "shows root event" do
-            correlation_id = SecureRandom.uuid
-            root = OrderCreated.new(metadata: { correlation_id: correlation_id })
-            event_store.publish(root, stream_name: "Order$1")
-            event_store.link(root.event_id, stream_name: "$by_correlation_id_#{correlation_id}")
+          context "chain: OrderPlaced → PaymentProcessed → OrderShipped" do
+            let(:cid) { SecureRandom.uuid }
+            let!(:order)   { pub(OrderPlaced.new(metadata: { correlation_id: cid }), "Order$1") }
+            let!(:payment) { pub(PaymentProcessed.new(metadata: { correlation_id: cid, causation_id: order.event_id }), "Payment$1") }
+            let!(:shipped) { pub(OrderShipped.new(metadata: { correlation_id: cid, causation_id: payment.event_id }), "Order$1") }
 
-            result = tool.call(event_store, "correlation_id" => correlation_id)
-            expect(result).to include("OrderCreated")
-            expect(result).to include(root.event_id)
-          end
-
-          it "shows root event without connector prefix" do
-            correlation_id = SecureRandom.uuid
-            root = OrderCreated.new(metadata: { correlation_id: correlation_id })
-            event_store.publish(root, stream_name: "Order$1")
-            event_store.link(root.event_id, stream_name: "$by_correlation_id_#{correlation_id}")
-
-            result = tool.call(event_store, "correlation_id" => correlation_id)
-            first_line = result.lines.first.chomp
-            expect(first_line).not_to include("└──")
-            expect(first_line).not_to include("├──")
-          end
-
-          it "only includes events from the given correlation id stream" do
-            correlation_id = SecureRandom.uuid
-            root = OrderCreated.new(metadata: { correlation_id: correlation_id })
-            unrelated = PaymentCharged.new
-            event_store.publish(root, stream_name: "Order$1")
-            event_store.publish(unrelated, stream_name: "Payment$1")
-            event_store.link(root.event_id, stream_name: "$by_correlation_id_#{correlation_id}")
-
-            result = tool.call(event_store, "correlation_id" => correlation_id)
-            expect(result).to include("OrderCreated")
-            expect(result).not_to include("PaymentCharged")
-          end
-
-          it "shows causation tree with children" do
-            correlation_id = SecureRandom.uuid
-            root = OrderCreated.new(metadata: { correlation_id: correlation_id })
-            child = PaymentCharged.new(metadata: { correlation_id: correlation_id, causation_id: root.event_id })
-            grandchild = EmailSent.new(metadata: { correlation_id: correlation_id, causation_id: child.event_id })
-
-            event_store.publish(root, stream_name: "Order$1")
-            event_store.publish(child, stream_name: "Payment$1")
-            event_store.publish(grandchild, stream_name: "Email$1")
-            [root, child, grandchild].each do |e|
-              event_store.link(e.event_id, stream_name: "$by_correlation_id_#{correlation_id}")
+            it "renders the causation chain" do
+              expect(tree_shape(cid)).to eq([
+                "OrderPlaced [id]",
+                "└── PaymentProcessed [id]",
+                "    └── OrderShipped [id]"
+              ])
             end
 
-            result = tool.call(event_store, "correlation_id" => correlation_id)
-            lines = result.lines.map(&:chomp)
-
-            expect(lines.count).to eq(3)
-            expect(lines[0]).to match(/\A\S.*OrderCreated \[/)
-            expect(lines[1]).to match(/\A└──.*PaymentCharged \[/)
-            expect(lines[2]).to match(/\A    └──.*EmailSent \[/)
-          end
-
-          it "shows branch connector for non-last children" do
-            correlation_id = SecureRandom.uuid
-            root = OrderCreated.new(metadata: { correlation_id: correlation_id })
-            child1 = PaymentCharged.new(metadata: { correlation_id: correlation_id, causation_id: root.event_id })
-            child2 = EmailSent.new(metadata: { correlation_id: correlation_id, causation_id: root.event_id })
-
-            event_store.publish(root, stream_name: "Order$1")
-            event_store.publish(child1, stream_name: "Payment$1")
-            event_store.publish(child2, stream_name: "Email$1")
-            [root, child1, child2].each do |e|
-              event_store.link(e.event_id, stream_name: "$by_correlation_id_#{correlation_id}")
+            it "root and last-child lines include the actual event_id" do
+              lines = tool.call(event_store, "correlation_id" => cid).lines.map(&:chomp)
+              expect(lines[0]).to match(/OrderPlaced \[#{order.event_id}\]/)
+              expect(lines[1]).to match(/└── .*PaymentProcessed \[#{payment.event_id}\]/)
             end
 
-            result = tool.call(event_store, "correlation_id" => correlation_id)
-            expect(result).to include("├──")
-            expect(result).to include("└──")
+            it "only includes events from the given correlation id stream" do
+              pub(OrderPlaced.new(metadata: { correlation_id: SecureRandom.uuid }), "Other$1")
+              expect(tool.call(event_store, "correlation_id" => cid).lines.count).to eq(3)
+            end
           end
 
-          it "treats event with external causation_id as root" do
-            correlation_id = SecureRandom.uuid
-            root = OrderCreated.new(metadata: {
-              correlation_id: correlation_id,
-              causation_id: SecureRandom.uuid
-            })
-            event_store.publish(root, stream_name: "Order$1")
-            event_store.link(root.event_id, stream_name: "$by_correlation_id_#{correlation_id}")
+          context "branching: OrderPlaced → [PaymentProcessed → OrderShipped, UserRegistered]" do
+            let(:cid) { SecureRandom.uuid }
+            let!(:order)      { pub(OrderPlaced.new(metadata: { correlation_id: cid }), "Order$2") }
+            let!(:payment)    { pub(PaymentProcessed.new(metadata: { correlation_id: cid, causation_id: order.event_id }), "Payment$2") }
+            let!(:registered) { pub(UserRegistered.new(metadata: { correlation_id: cid, causation_id: order.event_id }), "User$2") }
+            let!(:shipped)    { pub(OrderShipped.new(metadata: { correlation_id: cid, causation_id: payment.event_id }), "Order$2") }
 
-            result = tool.call(event_store, "correlation_id" => correlation_id)
-            expect(result).to include("OrderCreated")
-          end
-
-          it "preserves accumulated prefix for deeply nested nodes" do
-            correlation_id = SecureRandom.uuid
-            root = OrderCreated.new(metadata: { correlation_id: correlation_id })
-            child1 = PaymentCharged.new(metadata: { correlation_id: correlation_id, causation_id: root.event_id })
-            child2 = EmailSent.new(metadata: { correlation_id: correlation_id, causation_id: root.event_id })
-            grandchild = OrderCreated.new(metadata: { correlation_id: correlation_id, causation_id: child1.event_id })
-            great_grandchild = PaymentCharged.new(metadata: { correlation_id: correlation_id, causation_id: grandchild.event_id })
-
-            [root, child1, child2, grandchild, great_grandchild].each do |e|
-              event_store.publish(e, stream_name: "Order$1")
-              event_store.link(e.event_id, stream_name: "$by_correlation_id_#{correlation_id}")
+            it "renders the branching tree" do
+              expect(tree_shape(cid)).to eq([
+                "OrderPlaced [id]",
+                "├── PaymentProcessed [id]",
+                "│   └── OrderShipped [id]",
+                "└── UserRegistered [id]"
+              ])
             end
 
-            result = tool.call(event_store, "correlation_id" => correlation_id)
-            lines = result.lines.map(&:chomp)
-            expect(lines[3]).to start_with("│")
+            it "non-last branch line contains event_type and event_id" do
+              lines = tool.call(event_store, "correlation_id" => cid).lines.map(&:chomp)
+              non_last_line = lines.find { |l| l.include?("├──") }
+              expect(non_last_line).to match(/├── .*PaymentProcessed \[#{payment.event_id}\]/)
+            end
           end
 
-          it "shows pipe prefix for children under non-last branch" do
-            correlation_id = SecureRandom.uuid
-            root = OrderCreated.new(metadata: { correlation_id: correlation_id })
-            child1 = PaymentCharged.new(metadata: { correlation_id: correlation_id, causation_id: root.event_id })
-            child2 = EmailSent.new(metadata: { correlation_id: correlation_id, causation_id: root.event_id })
-            grandchild = OrderCreated.new(metadata: { correlation_id: correlation_id, causation_id: child1.event_id })
+          context "full order flow with deep branching" do
+            let(:cid) { SecureRandom.uuid }
+            let!(:order)         { pub(OrderPlaced.new(metadata: { correlation_id: cid }), "Order$3") }
+            let!(:fraud)         { pub(FraudCheckPassed.new(metadata: { correlation_id: cid, causation_id: order.event_id }), "Fraud$3") }
+            let!(:inv_reserved)  { pub(InventoryReserved.new(metadata: { correlation_id: cid, causation_id: order.event_id }), "Inventory$3") }
+            let!(:payment)       { pub(PaymentProcessed.new(metadata: { correlation_id: cid, causation_id: fraud.event_id }), "Payment$3") }
+            let!(:invoice)       { pub(InvoiceGenerated.new(metadata: { correlation_id: cid, causation_id: payment.event_id }), "Invoice$3") }
+            let!(:loyalty)       { pub(LoyaltyPointsAwarded.new(metadata: { correlation_id: cid, causation_id: payment.event_id }), "Loyalty$3") }
+            let!(:warehouse)     { pub(WarehouseNotified.new(metadata: { correlation_id: cid, causation_id: payment.event_id }), "Warehouse$3") }
+            let!(:shipped)       { pub(OrderShipped.new(metadata: { correlation_id: cid, causation_id: warehouse.event_id }), "Order$3") }
+            let!(:email_confirm) { pub(EmailSent.new(metadata: { correlation_id: cid, causation_id: warehouse.event_id }), "Email$3") }
+            let!(:inv_released)  { pub(InventoryReleased.new(metadata: { correlation_id: cid, causation_id: shipped.event_id }), "Inventory$3") }
+            let!(:email_delivery){ pub(EmailSent.new(metadata: { correlation_id: cid, causation_id: shipped.event_id }), "Email$3") }
 
-            [root, child1, child2, grandchild].each { |e| event_store.publish(e, stream_name: "Order$1") }
-            [root, child1, child2, grandchild].each do |e|
-              event_store.link(e.event_id, stream_name: "$by_correlation_id_#{correlation_id}")
+            it "renders the full order flow tree" do
+              expect(tree_shape(cid)).to eq([
+                "OrderPlaced [id]",
+                "├── FraudCheckPassed [id]",
+                "│   └── PaymentProcessed [id]",
+                "│       ├── InvoiceGenerated [id]",
+                "│       ├── LoyaltyPointsAwarded [id]",
+                "│       └── WarehouseNotified [id]",
+                "│           ├── OrderShipped [id]",
+                "│           │   ├── InventoryReleased [id]",
+                "│           │   └── EmailSent [id]",
+                "│           └── EmailSent [id]",
+                "└── InventoryReserved [id]"
+              ])
             end
 
-            result = tool.call(event_store, "correlation_id" => correlation_id)
-            expect(result).to include("│")
+            it "accumulates prefix across deeply nested non-last nodes" do
+              lines = tool.call(event_store, "correlation_id" => cid).lines.map(&:chomp)
+              inv_released_line = lines.find { |l| l.include?(inv_released.event_id) }
+              expect(inv_released_line).to start_with("│           │   ├──")
+            end
+          end
+
+          it "treats event with external causation_id as a root" do
+            cid = SecureRandom.uuid
+            pub(OrderPlaced.new(metadata: { correlation_id: cid, causation_id: SecureRandom.uuid }), "Order$4")
+            expect(tree_shape(cid)).to eq(["OrderPlaced [id]"])
+          end
+
+          it "shows multiple root events each without connector prefix" do
+            cid = SecureRandom.uuid
+            pub(OrderPlaced.new(metadata: { correlation_id: cid }), "Order$5")
+            pub(PaymentProcessed.new(metadata: { correlation_id: cid }), "Payment$5")
+
+            lines = tool.call(event_store, "correlation_id" => cid).lines.map(&:chomp)
+            expect(lines.count).to eq(2)
+            lines.each { |l| expect(l).not_to match(/[├└]/) }
           end
         end
       end

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp_spec.rb
@@ -18,10 +18,10 @@ module RubyEventStore
         expect(server.event_store).to eq(event_store)
       end
 
-      it "registers exactly the 7 standard tools" do
+      it "registers exactly the 8 standard tools" do
         expect(server.tools.map(&:name)).to contain_exactly(
           "stream_show", "stream_events", "event_show",
-          "event_streams", "search", "stats", "trace"
+          "event_streams", "search", "stats", "trace", "aggregate_history"
         )
       end
 

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp_spec.rb
@@ -18,10 +18,10 @@ module RubyEventStore
         expect(server.event_store).to eq(event_store)
       end
 
-      it "registers exactly the 8 standard tools" do
+      it "registers exactly the 9 standard tools" do
         expect(server.tools.map(&:name)).to contain_exactly(
           "stream_show", "stream_events", "event_show",
-          "event_streams", "search", "stats", "trace", "aggregate_history"
+          "event_streams", "search", "stats", "trace", "aggregate_history", "recent"
         )
       end
 

--- a/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp_spec.rb
+++ b/contrib/ruby_event_store-mcp/spec/ruby_event_store/mcp_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "ruby_event_store/mcp"
+
+module RubyEventStore
+  ::RSpec.describe MCP do
+    let(:event_store) { RubyEventStore::Client.new }
+
+    describe ".server" do
+      subject(:server) { MCP.server(event_store) }
+
+      it "returns a Server instance" do
+        expect(server).to be_a(MCP::Server)
+      end
+
+      it "configures the given event store" do
+        expect(server.event_store).to eq(event_store)
+      end
+
+      it "registers exactly the 7 standard tools" do
+        expect(server.tools.map(&:name)).to contain_exactly(
+          "stream_show", "stream_events", "event_show",
+          "event_streams", "search", "stats", "trace"
+        )
+      end
+
+      it "includes stream_show tool" do
+        expect(server.tools.map(&:name)).to include("stream_show")
+      end
+
+      it "includes stream_events tool" do
+        expect(server.tools.map(&:name)).to include("stream_events")
+      end
+
+      it "includes event_show tool" do
+        expect(server.tools.map(&:name)).to include("event_show")
+      end
+
+      it "includes event_streams tool" do
+        expect(server.tools.map(&:name)).to include("event_streams")
+      end
+
+      it "includes search tool" do
+        expect(server.tools.map(&:name)).to include("search")
+      end
+
+      it "includes stats tool" do
+        expect(server.tools.map(&:name)).to include("stats")
+      end
+
+      it "includes trace tool" do
+        expect(server.tools.map(&:name)).to include("trace")
+      end
+    end
+  end
+end

--- a/contrib/ruby_event_store-mcp/spec/spec_helper.rb
+++ b/contrib/ruby_event_store-mcp/spec/spec_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require_relative "../../../support/helpers/rspec_defaults"
+require "ruby_event_store/mcp"

--- a/contrib/ruby_event_store-mcp/spec/spec_helper.rb
+++ b/contrib/ruby_event_store-mcp/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 require_relative "../../../support/helpers/rspec_defaults"
+require "ruby_event_store"
 require "ruby_event_store/mcp"


### PR DESCRIPTION
 New contrib gem exposing RubyEventStore as an MCP (Model Context Protocol) server. Allows AI assistants
  (Claude, etc.) to inspect the event store directly — without a terminal, without writing SQL, without leaving
  the conversation.

  How it works

  The server runs as a stdio process started by the MCP client (Claude Desktop, Claude Code). It reads JSON-RPC
  requests from stdin and writes responses to stdout. The MCP client decides which tool to call based on the
  user's question.

  Claude ←→ MCP protocol (stdio JSON-RPC) ←→ res-mcp ←→ Rails.configuration.event_store

  Usage

  Add to your Gemfile:

  gem "ruby_event_store-mcp"

Configure in your MCP client. Add the snippet to the appropriate config file:

  Claude Code
  - Project-local: .claude/settings.json
  - Global: ~/.claude/settings.json

  Claude Desktop
  - macOS: ~/Library/Application Support/Claude/claude_desktop_config.json
  - Windows: %APPDATA%\Claude\claude_desktop_config.json
 ``` 
 {
    "mcpServers": {
      "res": {
        "command": "bundle",
        "args": ["exec", "res-mcp"],
        "cwd": "/path/to/rails/app"
      }
    }
  }
  ```

  After that Claude can answer questions like:

  - "What happened to order 123? Show me the causation tree."
  - "How many events do we have and what types?"
  - "Find all OrderShipped events from last week."
  - "Show me the full lifecycle of Order abc-123."
  - "What are the 20 most recent events across all streams?"

  Available tools

  - recent — most recent events across all streams (default: 20, newest first)
  - stream_show — event count, version, first/last event for a stream
  - stream_events — events in a stream with filters (type, time range, limit)
  - event_show — full event details: data, metadata, timestamps
  - event_streams — all streams an event was published or linked to
  - aggregate_history — full event history of an aggregate instance by type and ID
  - search — search across all streams by type, time range, stream
  - stats — total event count and unique event types
  - trace — causation tree for all events sharing a correlation ID

  Architecture

  - No external dependencies — MCP protocol implemented from scratch (~80 lines of JSON-RPC over stdio)
  - Tools use only public event_store.* API — adapter-agnostic (InMemory, AR, Sequel, ROM)
  - Each tool is an independent class: name, schema, call(event_store, args) → String
  - MCP.server(event_store) builds a fully configured server with all tools registered
  - Full mutation test coverage with Mutant (all surviving mutations are documented equivalent mutations)
