### PR TITLE
Fix missing OnDSL when include `AggregateRoot.with`

### DIFF
--- a/aggregate_root/.mutant.yml
+++ b/aggregate_root/.mutant.yml
@@ -16,3 +16,4 @@ matcher:
     - AggregateRoot*
   ignore:
     - AggregateRoot::DefaultApplyStrategy#event_type
+    - AggregateRoot::DefaultApplyStrategy#uses_on_dsl?

--- a/aggregate_root/lib/aggregate_root.rb
+++ b/aggregate_root/lib/aggregate_root.rb
@@ -80,7 +80,7 @@ module AggregateRoot
     Module.new do
       define_singleton_method :included do |host_class|
         host_class.extend Constructor
-        host_class.extend OnDSL if strategy.call.is_a?(DefaultApplyStrategy)
+        host_class.extend OnDSL if strategy.call.respond_to?(:uses_on_dsl?)
         host_class.include AggregateMethods
         host_class.define_singleton_method :event_type_for do |value|
           event_type_resolver.call(value)

--- a/aggregate_root/lib/aggregate_root.rb
+++ b/aggregate_root/lib/aggregate_root.rb
@@ -80,6 +80,7 @@ module AggregateRoot
     Module.new do
       define_singleton_method :included do |host_class|
         host_class.extend Constructor
+        host_class.extend OnDSL if strategy.call.is_a?(DefaultApplyStrategy)
         host_class.include AggregateMethods
         host_class.define_singleton_method :event_type_for do |value|
           event_type_resolver.call(value)
@@ -93,7 +94,6 @@ module AggregateRoot
   end
 
   def self.included(host_class)
-    host_class.extend OnDSL
     host_class.include with
   end
 end

--- a/aggregate_root/lib/aggregate_root/default_apply_strategy.rb
+++ b/aggregate_root/lib/aggregate_root/default_apply_strategy.rb
@@ -13,6 +13,8 @@ module AggregateRoot
       on_handler(aggregate, event.event_type)[event]
     end
 
+    def uses_on_dsl? = true
+
     private
 
     def on_handler(aggregate, event_type)

--- a/aggregate_root/spec/aggregate_root_spec.rb
+++ b/aggregate_root/spec/aggregate_root_spec.rb
@@ -135,6 +135,24 @@ require "spec_helper"
     expect(order.status).to eq :created
   end
 
+  it "does not include on methods DSL when using custom strategy" do
+    strategy = -> { ->(aggregate, event) { } }
+    klass =
+      Class.new do
+        include AggregateRoot.with(strategy: strategy)
+      end
+    expect(klass.respond_to?(:on_methods)).to eq(false)
+  end
+
+  it 'custom strategy inherited from DefaultApplyStrategy adds On~DSL' do
+    strategy = -> { Class.new(AggregateRoot::DefaultApplyStrategy).new }
+    klass =
+      Class.new do
+        include AggregateRoot.with(strategy: strategy)
+      end
+    expect(klass.respond_to?(:on_methods)).to eq(true)
+  end
+
   it "included modules" do
     klass = Class.new { include AggregateRoot }
 

--- a/aggregate_root/spec/aggregate_root_spec.rb
+++ b/aggregate_root/spec/aggregate_root_spec.rb
@@ -56,6 +56,33 @@ require "spec_helper"
     expect(order.status).to eq :created
   end
 
+  it "receives a method call based on a non-strict default apply strategy" do
+    order_klass = Class.new do
+      include AggregateRoot.with(strategy: -> { AggregateRoot::DefaultApplyStrategy.new(strict: false) })
+
+      def initialize(uuid)
+        @status = :draft
+        @uuid = uuid
+      end
+
+      def create
+        apply Orders::Events::OrderCreated.new
+      end
+
+      attr_accessor :status
+
+      on Orders::Events::OrderCreated do |_event|
+        @status = :created
+      end
+    end
+
+    order = order_klass.new(uuid)
+    order_created = Orders::Events::OrderCreated.new
+
+    order.apply(order_created)
+    expect(order.status).to eq :created
+  end
+
   it "raises error for missing apply method based on a default apply strategy" do
     order = order_klass.new(uuid)
     spanish_inquisition = Orders::Events::SpanishInquisition.new

--- a/aggregate_root/spec/aggregate_root_spec.rb
+++ b/aggregate_root/spec/aggregate_root_spec.rb
@@ -153,6 +153,33 @@ require "spec_helper"
     expect(klass.respond_to?(:on_methods)).to eq(true)
   end
 
+  it 'when using InstrumentedApplyStrategy still adds On~DSL' do
+    strategy = -> { AggregateRoot::InstrumentedApplyStrategy.new(AggregateRoot::DefaultApplyStrategy.new, ActiveSupport::Notifications) }
+    klass =
+      Class.new do
+        include AggregateRoot.with(strategy: strategy)
+      end
+    expect(klass.respond_to?(:on_methods)).to eq(true)
+  end
+
+  it 'when using InstrumentedApplyStrategy with custom internal strategy does not add On~DSL' do
+    strategy = -> { AggregateRoot::InstrumentedApplyStrategy.new(->(aggregate, event) { }, ActiveSupport::Notifications) }
+    klass =
+      Class.new do
+        include AggregateRoot.with(strategy: strategy)
+      end
+    expect(klass.respond_to?(:on_methods)).to eq(false)
+  end
+
+  it 'custom strategy inherited from InstrumentedApplyStrategy adds On~DSL' do
+    strategy = -> { Class.new(AggregateRoot::InstrumentedApplyStrategy).new(AggregateRoot::DefaultApplyStrategy.new, ActiveSupport::Notifications) }
+    klass =
+      Class.new do
+        include AggregateRoot.with(strategy: strategy)
+      end
+    expect(klass.respond_to?(:on_methods)).to eq(true)
+  end
+
   it "included modules" do
     klass = Class.new { include AggregateRoot }
 


### PR DESCRIPTION
- **Failing test case**
- **Fix missing OnDSL when using DefaultApplyStrategy**
- **Failing tests for instrumented strategies**
- **Handle all cases when OnDSL is required**
