### PR TITLE
Respect time sort when reading a stream backward in Sequel repository

### DIFF
--- a/contrib/ruby_event_store-sequel/lib/ruby_event_store/sequel/event_repository.rb
+++ b/contrib/ruby_event_store-sequel/lib/ruby_event_store/sequel/event_repository.rb
@@ -220,7 +220,6 @@ module RubyEventStore
               :valid_at,
             )
             .where(stream: specification.stream.name)
-            .order(::Sequel[:event_store_events_in_streams][:id])
 
         dataset = dataset.where(event_type: specification.with_types) if specification.with_types?
         dataset =
@@ -264,10 +263,16 @@ module RubyEventStore
             )
         end
 
-        dataset = dataset.order(::Sequel[:event_store_events][:created_at]) if specification.time_sort_by_as_at?
-        dataset = dataset.order(::Sequel.lit(coalesced_date)) if specification.time_sort_by_as_of?
+        dataset =
+          if specification.time_sort_by_as_at?
+            dataset.order(::Sequel[:event_store_events][:created_at])
+          elsif specification.time_sort_by_as_of?
+            dataset.order(::Sequel.lit(coalesced_date))
+          else
+            dataset.order(::Sequel[:event_store_events_in_streams][:id])
+          end
         dataset = dataset.limit(specification.limit) if specification.limit?
-        dataset = dataset.order(::Sequel[:event_store_events_in_streams][:id]).reverse if specification.backward?
+        dataset = dataset.reverse if specification.backward?
 
         dataset
       end

--- a/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
@@ -1578,6 +1578,35 @@ module RubyEventStore
       )
     end
 
+    specify "named stream order is respected also when reading backward" do
+      repository.append_to_stream(
+        records = [
+          RubyEventStore::SRecord.new(timestamp: with_precision(Time.new(2023, 1, 1, 12, 29, 0))),
+          RubyEventStore::SRecord.new(timestamp: with_precision(Time.new(2023, 1, 1, 12, 28, 0))),
+          RubyEventStore::SRecord.new(timestamp: with_precision(Time.new(2023, 1, 1, 12, 27, 0))),
+          RubyEventStore::SRecord.new(
+            timestamp: with_precision(Time.new(2023, 1, 1, 12, 26, 0)),
+            valid_at: with_precision(Time.new(2023, 1, 1, 12, 30, 0)),
+          ),
+        ],
+        RubyEventStore::Stream.new("stream"),
+        RubyEventStore::ExpectedVersion.any,
+      )
+
+      expect(repository.read(specification.stream("stream").backward.result).to_a).to eq(
+        [records[3], records[2], records[1], records[0]],
+      )
+      expect(repository.read(specification.stream("stream").as_at.backward.result).to_a).to eq(
+        [records[0], records[1], records[2], records[3]],
+      )
+      expect(repository.read(specification.stream("stream").as_at.backward.limit(2).result).to_a).to eq(
+        [records[0], records[1]],
+      )
+      expect(repository.read(specification.stream("stream").as_of.backward.result).to_a).to eq(
+        [records[3], records[0], records[1], records[2]],
+      )
+    end
+
     specify "reading last event sorted by valid_at" do
       repository.append_to_stream(
         records = [


### PR DESCRIPTION
## Summary

`read.stream(name).as_at.backward` (and `as_of.backward`) on the Sequel repository returned events in reversed *position* order instead of reversed *time* order. In `read_from_specific_stream` the backward branch called

```ruby
dataset.order(::Sequel[:event_store_events_in_streams][:id]).reverse
```

and Sequel's `#order` *replaces* the previous order clause, so the `created_at` / `COALESCE(valid_at, created_at)` ordering set a few lines earlier was silently discarded. Forward reads were unaffected, and `read_from_global_stream` already handled this correctly (`order(...) unless time_sort_by` + plain `reverse`).

The ordering tail is now a single `if/elsif/else` picking exactly one order clause per read, followed by `reverse` for backward reads — mirroring the global-stream read.

A repro on sqlite (event appended later but with an earlier timestamp):

```ruby
publish(at: t + 2, stream: "a")
publish(at: t + 1, stream: "a")   # backdated
client.read.stream("a").as_at.backward.to_a
# before: [t+1, t+2] (position order), after: [t+2, t+1] (time order)
```

A shared lint example now pins backward time-sorted reads (with and without `limit`) for every repository — in-memory, ActiveRecord and ROM already passed it.

## Test plan

- [x] New lint example red on Sequel before the fix, green after; green on in-memory, ActiveRecord and ROM without changes
- [x] `contrib/ruby_event_store-sequel` suite — green
- [x] `ruby_event_store`, `ruby_event_store-active_record`, `contrib/ruby_event_store-rom` suites — green
- [x] Mutation testing on the diff — 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)
