### PR TITLE
Add extension points to the browser

### DIFF
--- a/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
+++ b/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
@@ -13,7 +13,8 @@ module RubyEventStore
         path: nil,
         api_url: nil,
         environment: nil,
-        related_streams_query: DEFAULT_RELATED_STREAMS_QUERY
+        related_streams_query: DEFAULT_RELATED_STREAMS_QUERY,
+        extensions: []
       )
         warn(<<~WARN) if environment
           Passing :environment to RubyEventStore::Browser::App.for is deprecated.
@@ -69,13 +70,41 @@ module RubyEventStore
                 related_streams_query: related_streams_query,
                 host: host,
                 root_path: path,
+                extensions: extensions,
               )
         end
       end
 
-      def initialize(event_store_locator:, related_streams_query:, host:, root_path:)
+      class ExtensionContext
+        attr_reader :event_store
+
+        def initialize(event_store, extensions)
+          @event_store = event_store
+          @extensions = extensions
+        end
+
+        def render(template, views_root:, urls:, **locals)
+          renderer = Renderer.new([views_root, Renderer::VIEWS_ROOT])
+          content = renderer.render(template, urls: urls, **locals)
+          [
+            200,
+            { "content-type" => "text/html;charset=utf-8" },
+            [
+              renderer.render(
+                "layout",
+                content: content,
+                urls: urls,
+                extension_stylesheets: @extensions.flat_map { |e| e.respond_to?(:stylesheets) ? e.stylesheets(urls) : [] },
+              ),
+            ],
+          ]
+        end
+      end
+
+      def initialize(event_store_locator:, related_streams_query:, host:, root_path:, extensions: [])
         @event_store_locator = event_store_locator
         @related_streams_query = related_streams_query
+        @extensions = extensions
         @routing = Urls.from_configuration(host, root_path)
       end
 
@@ -100,6 +129,7 @@ module RubyEventStore
                      urls.stream_page_url(stream_name, cursor, reader.count)
                    },
                  related_streams: related_streams_query.call(stream_name),
+                 extension_links: extension_links(stream_name, urls),
                )
         end
 
@@ -121,6 +151,8 @@ module RubyEventStore
                )
         end
 
+        extensions.each { |extension| extension.register_routes(router, ExtensionContext.new(event_store, extensions)) }
+
         router.handle(request)
       rescue EventNotFound
         not_found(routing.with_request(request))
@@ -130,10 +162,20 @@ module RubyEventStore
 
       private
 
-      attr_reader :event_store_locator, :related_streams_query, :routing
+      attr_reader :event_store_locator, :related_streams_query, :routing, :extensions
 
       def event_store
         event_store_locator.call
+      end
+
+      def extension_links(stream_name, urls)
+        extensions.flat_map do |extension|
+          extension.respond_to?(:stream_links) ? extension.stream_links(stream_name, urls) : []
+        end
+      end
+
+      def extension_stylesheets(urls)
+        extensions.flat_map { |extension| extension.respond_to?(:stylesheets) ? extension.stylesheets(urls) : [] }
       end
 
       def format_event_metadata(event)
@@ -147,7 +189,7 @@ module RubyEventStore
       def render(template, urls:, **locals)
         renderer = Renderer.new
         content = renderer.render(template, urls: urls, **locals)
-        renderer.render("layout", content: content, urls: urls)
+        renderer.render("layout", content: content, urls: urls, extension_stylesheets: extension_stylesheets(urls))
       end
 
       def html(body)
@@ -158,7 +200,7 @@ module RubyEventStore
         renderer = Renderer.new
         content = renderer.render("not_found")
         [404, { "content-type" => "text/html;charset=utf-8" },
-         [renderer.render("layout", content: content, urls: urls)]]
+         [renderer.render("layout", content: content, urls: urls, extension_stylesheets: extension_stylesheets(urls))]]
       end
     end
   end

--- a/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
+++ b/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
@@ -78,9 +78,9 @@ module RubyEventStore
       class ExtensionContext
         attr_reader :event_store
 
-        def initialize(event_store, extensions)
+        def initialize(event_store, stylesheets_resolver)
           @event_store = event_store
-          @extensions = extensions
+          @stylesheets_resolver = stylesheets_resolver
         end
 
         def render(template, views_root:, urls:, **locals)
@@ -94,7 +94,7 @@ module RubyEventStore
                 "layout",
                 content: content,
                 urls: urls,
-                extension_stylesheets: @extensions.flat_map { |e| e.respond_to?(:stylesheets) ? e.stylesheets(urls) : [] },
+                extension_stylesheets: @stylesheets_resolver.call(urls),
               ),
             ],
           ]
@@ -151,7 +151,9 @@ module RubyEventStore
                )
         end
 
-        extensions.each { |extension| extension.register_routes(router, ExtensionContext.new(event_store, extensions)) }
+        extensions.each do |extension|
+          extension.register_routes(router, ExtensionContext.new(event_store, method(:extension_stylesheets)))
+        end
 
         router.handle(request)
       rescue EventNotFound
@@ -169,13 +171,15 @@ module RubyEventStore
       end
 
       def extension_links(stream_name, urls)
-        extensions.flat_map do |extension|
-          extension.respond_to?(:stream_links) ? extension.stream_links(stream_name, urls) : []
-        end
+        extensions
+          .select { |extension| extension.respond_to?(:stream_links) }
+          .flat_map { |extension| extension.stream_links(stream_name, urls) }
       end
 
       def extension_stylesheets(urls)
-        extensions.flat_map { |extension| extension.respond_to?(:stylesheets) ? extension.stylesheets(urls) : [] }
+        extensions
+          .select { |extension| extension.respond_to?(:stylesheets) }
+          .flat_map { |extension| extension.stylesheets(urls) }
       end
 
       def format_event_metadata(event)

--- a/ruby_event_store-browser/lib/ruby_event_store/browser/renderer.rb
+++ b/ruby_event_store-browser/lib/ruby_event_store/browser/renderer.rb
@@ -44,10 +44,20 @@ module RubyEventStore
         end
       end
 
+      def initialize(views_roots = [VIEWS_ROOT])
+        @views_roots = views_roots
+      end
+
       def render(template, **locals)
-        path = File.join(VIEWS_ROOT, "#{template}.html.erb")
         context = Context.new(self, locals)
-        ERB.new(File.read(path), trim_mode: "-").result(context.get_binding)
+        ERB.new(File.read(template_path(template)), trim_mode: "-").result(context.get_binding)
+      end
+
+      private
+
+      def template_path(template)
+        @views_roots.map { |root| File.join(root, "#{template}.html.erb") }.find { |path| File.exist?(path) } ||
+          raise(ArgumentError, "Template not found: #{template}")
       end
     end
   end

--- a/ruby_event_store-browser/lib/ruby_event_store/browser/views/layout.html.erb
+++ b/ruby_event_store-browser/lib/ruby_event_store/browser/views/layout.html.erb
@@ -3,6 +3,9 @@
   <head>
     <title>RubyEventStore::Browser</title>
     <link type="text/css" rel="stylesheet" href="<%= urls.browser_css_url %>">
+    <% extension_stylesheets.each do |href| -%>
+    <link type="text/css" rel="stylesheet" href="<%= href %>">
+    <% end -%>
     <meta name="robots" content="noindex, nofollow">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">

--- a/ruby_event_store-browser/lib/ruby_event_store/browser/views/streams/show.html.erb
+++ b/ruby_event_store-browser/lib/ruby_event_store/browser/views/streams/show.html.erb
@@ -15,6 +15,13 @@
       </ul>
     </div>
   </div>
+  <% if extension_links.any? -%>
+    <div class="pt-3 flex gap-2">
+      <% extension_links.each do |link| -%>
+        <a class="inline-block text-center text-sm bg-red-700 text-gray-100 border border-red-700 rounded px-2 py-1" href="<%= link[:url] %>"><%= h(link[:label]) %></a>
+      <% end -%>
+    </div>
+  <% end -%>
   <div>
     <div class="overflow-x-scroll sm:overflow-visible w-full">
       <table class="my-10 w-full lg:table-fixed text-left">

--- a/ruby_event_store-browser/spec/renderer_spec.rb
+++ b/ruby_event_store-browser/spec/renderer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "tmpdir"
 
 module RubyEventStore
   module Browser
@@ -36,6 +37,29 @@ module RubyEventStore
           expect(
             context.render("layout", content: "marker-content", urls: urls, extension_stylesheets: []),
           ).to include("marker-content")
+        end
+      end
+
+      describe "multiple view roots" do
+        specify "renders template from an additional root, falling back to the default one" do
+          Dir.mktmpdir do |root|
+            File.write(File.join(root, "custom.html.erb"), "custom content")
+            renderer = Renderer.new([root, Renderer::VIEWS_ROOT])
+            expect(renderer.render("custom")).to eq("custom content")
+            expect(renderer.render("not_found")).to include("There's no event with given ID")
+          end
+        end
+
+        specify "earlier roots take precedence" do
+          Dir.mktmpdir do |root|
+            File.write(File.join(root, "not_found.html.erb"), "overridden")
+            renderer = Renderer.new([root, Renderer::VIEWS_ROOT])
+            expect(renderer.render("not_found")).to eq("overridden")
+          end
+        end
+
+        specify "raises when template is not found in any root" do
+          expect { renderer.render("nonexistent") }.to raise_error(ArgumentError, /nonexistent/)
         end
       end
 

--- a/ruby_event_store-browser/spec/renderer_spec.rb
+++ b/ruby_event_store-browser/spec/renderer_spec.rb
@@ -33,7 +33,9 @@ module RubyEventStore
 
         specify "passes locals to nested render" do
           urls = Urls.from_configuration("http://example.com", nil)
-          expect(context.render("layout", content: "marker-content", urls: urls)).to include("marker-content")
+          expect(
+            context.render("layout", content: "marker-content", urls: urls, extension_stylesheets: []),
+          ).to include("marker-content")
         end
       end
 
@@ -41,7 +43,7 @@ module RubyEventStore
         let(:urls) { Urls.from_configuration("http://example.com", nil) }
 
         specify "makes locals accessible as methods in template" do
-          result = renderer.render("layout", content: "body-text", urls: urls)
+          result = renderer.render("layout", content: "body-text", urls: urls, extension_stylesheets: [])
           expect(result).to include("body-text")
           expect(result).to include("http://example.com")
         end
@@ -61,6 +63,7 @@ module RubyEventStore
               events: [event],
               pagination: { prev: nil, first: nil, next: nil, last: nil },
               related_streams: [],
+              extension_links: [],
             )
           expect(result).not_to match(/\n\s*\n\s*\n/)
         end

--- a/ruby_event_store-browser/spec/web_spec.rb
+++ b/ruby_event_store-browser/spec/web_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "tmpdir"
 
 module RubyEventStore
   ::RSpec.describe Browser do
@@ -196,8 +197,80 @@ module RubyEventStore
         end.new
       app = Browser::App.for(event_store_locator: -> { event_store }, extensions: [extension])
 
-      body = Rack::MockRequest.new(app).get("/streams/all").body
-      expect(body).to include('href="http://example.org/extension.css"')
+      response = Rack::MockRequest.new(app).get("/streams/all")
+      expect(response.status).to eq(200)
+      expect(response.body).to include('href="http://example.org/extension.css"')
+    end
+
+    specify "extension stylesheets are linked on the not found page" do
+      extension =
+        Class.new do
+          def register_routes(router, context)
+          end
+
+          def stylesheets(urls)
+            ["#{urls.app_url}/extension.css"]
+          end
+        end.new
+      app = Browser::App.for(event_store_locator: -> { event_store }, extensions: [extension])
+
+      response = Rack::MockRequest.new(app).get("/events/00000000-0000-0000-0000-000000000000")
+      expect(response).to be_not_found
+      expect(response.body).to include('href="http://example.org/extension.css"')
+    end
+
+    specify "extension can render its own views wrapped in the layout" do
+      Dir.mktmpdir do |views_root|
+        File.write(File.join(views_root, "hello.html.erb"), "<p>hello <%= h(name) %> from <%= urls.app_url %></p>")
+        extension =
+          Class.new do
+            def initialize(views_root)
+              @views_root = views_root
+            end
+
+            def register_routes(router, context)
+              views_root = @views_root
+              router.add_route("GET", "/hello") do |_, urls|
+                context.render("hello", views_root: views_root, urls: urls, name: "world")
+              end
+            end
+
+            def stylesheets(urls)
+              ["#{urls.app_url}/extension.css"]
+            end
+          end.new(views_root)
+        app = Browser::App.for(event_store_locator: -> { event_store }, extensions: [extension])
+
+        response = WebClient.new(app, "example.org").get("/hello")
+        expect(response.status).to eq(200)
+        expect(response.content_type).to eq("text/html;charset=utf-8")
+        expect(response.body).to include("<p>hello world from http://example.org</p>")
+        expect(response.body.scan("<!DOCTYPE").size).to eq(1)
+        expect(response.body).to include('href="http://example.org/extension.css"')
+      end
+    end
+
+    specify "extensions without optional hooks leave pages untouched" do
+      bare_extension =
+        Class.new do
+          def register_routes(router, context)
+          end
+        end.new
+      linking_extension =
+        Class.new do
+          def register_routes(router, context)
+          end
+
+          def stream_links(stream_name, urls)
+            [{ label: "Inspect stream", url: "#{urls.app_url}/inspect/#{stream_name}" }]
+          end
+        end.new
+      app = Browser::App.for(event_store_locator: -> { event_store }, extensions: [bare_extension, linking_extension])
+
+      response = Rack::MockRequest.new(app).get("/streams/special")
+      expect(response.status).to eq(200)
+      expect(response.body).to include("Inspect stream")
+      expect(response.body).not_to include('href=""')
     end
 
     specify "uses configured host for generated URLs" do

--- a/ruby_event_store-browser/spec/web_spec.rb
+++ b/ruby_event_store-browser/spec/web_spec.rb
@@ -150,6 +150,56 @@ module RubyEventStore
       expect(response.body.scan("<!DOCTYPE").size).to eq(1)
     end
 
+    specify "extensions can register their own routes" do
+      extension =
+        Class.new do
+          def register_routes(router, context)
+            router.add_route("GET", "/custom") do |_, _|
+              [200, { "content-type" => "text/plain" }, ["events: #{context.event_store.read.count}"]]
+            end
+          end
+        end.new
+      app = Browser::App.for(event_store_locator: -> { event_store }, extensions: [extension])
+      event_store.append(DummyEvent.new)
+
+      response = Rack::MockRequest.new(app).get("/custom")
+      expect(response.status).to eq(200)
+      expect(response.body).to eq("events: 1")
+    end
+
+    specify "extensions can contribute links on the stream page" do
+      extension =
+        Class.new do
+          def register_routes(router, context)
+          end
+
+          def stream_links(stream_name, urls)
+            return [] unless stream_name.eql?("special")
+            [{ label: "Inspect stream", url: "#{urls.app_url}/inspect/#{stream_name}" }]
+          end
+        end.new
+      app = Browser::App.for(event_store_locator: -> { event_store }, extensions: [extension])
+
+      expect(Rack::MockRequest.new(app).get("/streams/special").body).to include("Inspect stream")
+      expect(Rack::MockRequest.new(app).get("/streams/other").body).not_to include("Inspect stream")
+    end
+
+    specify "extensions can contribute stylesheets to the layout" do
+      extension =
+        Class.new do
+          def register_routes(router, context)
+          end
+
+          def stylesheets(urls)
+            ["#{urls.app_url}/extension.css"]
+          end
+        end.new
+      app = Browser::App.for(event_store_locator: -> { event_store }, extensions: [extension])
+
+      body = Rack::MockRequest.new(app).get("/streams/all").body
+      expect(body).to include('href="http://example.org/extension.css"')
+    end
+
     specify "uses configured host for generated URLs" do
       app =
         Browser::App.new(


### PR DESCRIPTION
Allows sibling gems to plug into the browser UI without the browser knowing anything about them.

`App.for` accepts an `extensions:` array. Each extension is a plain object (duck-typed, no dependency on browser internals required) that may implement:

- `register_routes(router, context)` — add its own routes; `context` exposes `event_store` and `render`, which renders ERB views from the extension's own views directory while reusing the browser layout and partials (`Renderer` now resolves templates across multiple view roots)
- `stream_links(stream_name, urls)` — contribute links displayed under the header of a stream page
- `stylesheets(urls)` — contribute stylesheets linked in the layout, so an extension can serve and ship its own CSS (built from its own views, keeping the browser's Tailwind build untouched)

First consumer: `ruby_event_store-process_manager` will ship a `BrowserExtension` that detects process manager streams by the `ClassName$id` naming convention, links to a "Process state" page from the stream view, and renders the process state rebuilt step by step (via `initial_state` + `apply`, never `act`, so browsing is side-effect free). That part will come as a follow-up PR.

Example wiring in a Rails app:

```ruby
mount RubyEventStore::Browser::App.for(
  event_store_locator: -> { Rails.configuration.event_store },
  extensions: [RubyEventStore::ProcessManager::BrowserExtension.new],
) => "/res", as: :ruby_event_store_browser_app
```