### PR TITLE
Let browser extensions contribute scripts to the layout

### DIFF
--- a/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
+++ b/ruby_event_store-browser/lib/ruby_event_store/browser/app.rb
@@ -78,9 +78,10 @@ module RubyEventStore
       class ExtensionContext
         attr_reader :event_store
 
-        def initialize(event_store, stylesheets_resolver)
+        def initialize(event_store, stylesheets_resolver, scripts_resolver)
           @event_store = event_store
           @stylesheets_resolver = stylesheets_resolver
+          @scripts_resolver = scripts_resolver
         end
 
         def render(template, views_root:, urls:, **locals)
@@ -95,6 +96,7 @@ module RubyEventStore
                 content: content,
                 urls: urls,
                 extension_stylesheets: @stylesheets_resolver.call(urls),
+                extension_scripts: @scripts_resolver.call(urls),
               ),
             ],
           ]
@@ -152,7 +154,7 @@ module RubyEventStore
         end
 
         extensions.each do |extension|
-          extension.register_routes(router, ExtensionContext.new(event_store, method(:extension_stylesheets)))
+          extension.register_routes(router, ExtensionContext.new(event_store, method(:extension_stylesheets), method(:extension_scripts)))
         end
 
         router.handle(request)
@@ -182,6 +184,12 @@ module RubyEventStore
           .flat_map { |extension| extension.stylesheets(urls) }
       end
 
+      def extension_scripts(urls)
+        extensions
+          .select { |extension| extension.respond_to?(:scripts) }
+          .flat_map { |extension| extension.scripts(urls) }
+      end
+
       def format_event_metadata(event)
         event.metadata.to_h.tap do |metadata|
           %i[timestamp valid_at].each do |key|
@@ -193,7 +201,13 @@ module RubyEventStore
       def render(template, urls:, **locals)
         renderer = Renderer.new
         content = renderer.render(template, urls: urls, **locals)
-        renderer.render("layout", content: content, urls: urls, extension_stylesheets: extension_stylesheets(urls))
+        renderer.render(
+          "layout",
+          content: content,
+          urls: urls,
+          extension_stylesheets: extension_stylesheets(urls),
+          extension_scripts: extension_scripts(urls),
+        )
       end
 
       def html(body)
@@ -203,8 +217,19 @@ module RubyEventStore
       def not_found(urls)
         renderer = Renderer.new
         content = renderer.render("not_found")
-        [404, { "content-type" => "text/html;charset=utf-8" },
-         [renderer.render("layout", content: content, urls: urls, extension_stylesheets: extension_stylesheets(urls))]]
+        [
+          404,
+          { "content-type" => "text/html;charset=utf-8" },
+          [
+            renderer.render(
+              "layout",
+              content: content,
+              urls: urls,
+              extension_stylesheets: extension_stylesheets(urls),
+              extension_scripts: extension_scripts(urls),
+            ),
+          ],
+        ]
       end
     end
   end

--- a/ruby_event_store-browser/lib/ruby_event_store/browser/views/layout.html.erb
+++ b/ruby_event_store-browser/lib/ruby_event_store/browser/views/layout.html.erb
@@ -58,5 +58,8 @@
     </div>
 
     <script type="module" src="<%= urls.browser_js_url %>"></script>
+    <% extension_scripts.each do |src| -%>
+    <script type="module" src="<%= src %>"></script>
+    <% end -%>
   </body>
 </html>

--- a/ruby_event_store-browser/spec/renderer_spec.rb
+++ b/ruby_event_store-browser/spec/renderer_spec.rb
@@ -35,7 +35,7 @@ module RubyEventStore
         specify "passes locals to nested render" do
           urls = Urls.from_configuration("http://example.com", nil)
           expect(
-            context.render("layout", content: "marker-content", urls: urls, extension_stylesheets: []),
+            context.render("layout", content: "marker-content", urls: urls, extension_stylesheets: [], extension_scripts: []),
           ).to include("marker-content")
         end
       end
@@ -67,7 +67,7 @@ module RubyEventStore
         let(:urls) { Urls.from_configuration("http://example.com", nil) }
 
         specify "makes locals accessible as methods in template" do
-          result = renderer.render("layout", content: "body-text", urls: urls, extension_stylesheets: [])
+          result = renderer.render("layout", content: "body-text", urls: urls, extension_stylesheets: [], extension_scripts: [])
           expect(result).to include("body-text")
           expect(result).to include("http://example.com")
         end

--- a/ruby_event_store-browser/spec/web_spec.rb
+++ b/ruby_event_store-browser/spec/web_spec.rb
@@ -219,6 +219,40 @@ module RubyEventStore
       expect(response.body).to include('href="http://example.org/extension.css"')
     end
 
+    specify "extensions can contribute scripts to the layout" do
+      extension =
+        Class.new do
+          def register_routes(router, context)
+          end
+
+          def scripts(urls)
+            ["#{urls.app_url}/extension.js"]
+          end
+        end.new
+      app = Browser::App.for(event_store_locator: -> { event_store }, extensions: [extension])
+
+      response = Rack::MockRequest.new(app).get("/streams/all")
+      expect(response.status).to eq(200)
+      expect(response.body).to include('<script type="module" src="http://example.org/extension.js"></script>')
+    end
+
+    specify "extension scripts are linked on the not found page" do
+      extension =
+        Class.new do
+          def register_routes(router, context)
+          end
+
+          def scripts(urls)
+            ["#{urls.app_url}/extension.js"]
+          end
+        end.new
+      app = Browser::App.for(event_store_locator: -> { event_store }, extensions: [extension])
+
+      response = Rack::MockRequest.new(app).get("/events/00000000-0000-0000-0000-000000000000")
+      expect(response).to be_not_found
+      expect(response.body).to include('<script type="module" src="http://example.org/extension.js"></script>')
+    end
+
     specify "extension can render its own views wrapped in the layout" do
       Dir.mktmpdir do |views_root|
         File.write(File.join(views_root, "hello.html.erb"), "<p>hello <%= h(name) %> from <%= urls.app_url %></p>")
@@ -238,6 +272,10 @@ module RubyEventStore
             def stylesheets(urls)
               ["#{urls.app_url}/extension.css"]
             end
+
+            def scripts(urls)
+              ["#{urls.app_url}/extension.js"]
+            end
           end.new(views_root)
         app = Browser::App.for(event_store_locator: -> { event_store }, extensions: [extension])
 
@@ -247,6 +285,7 @@ module RubyEventStore
         expect(response.body).to include("<p>hello world from http://example.org</p>")
         expect(response.body.scan("<!DOCTYPE").size).to eq(1)
         expect(response.body).to include('href="http://example.org/extension.css"')
+        expect(response.body).to include('<script type="module" src="http://example.org/extension.js"></script>')
       end
     end
 


### PR DESCRIPTION
## Summary

Mirror of the `stylesheets` extension point: an extension responding to `scripts(urls)` gets its urls rendered as `<script type="module">` tags after the core bundle — on regular pages, extension-rendered pages (`ExtensionContext#render`) and the not found page alike. Same-origin urls satisfy the `script-src 'self'` CSP the browser is run under.

Groundwork for extracting UI features that need their own Stimulus controllers into extension gems.

## Test plan

- [x] Specs mirroring the stylesheets extension point coverage (layout, not found page, extension-rendered page)
- [x] `ruby_event_store-browser` suite — green
- [x] Mutation testing on the diff — 100%