### PR TITLE
Apply limit after time filters in the in-memory repository

### DIFF
--- a/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
+++ b/ruby_event_store/lib/ruby_event_store/in_memory_repository.rb
@@ -148,7 +148,6 @@ module RubyEventStore
       serialized_records = serialized_records.reverse if spec.backward?
       serialized_records = serialized_records.drop(index_of(serialized_records, spec.start) + 1) if spec.start
       serialized_records = serialized_records.take(index_of(serialized_records, spec.stop)) if spec.stop
-      serialized_records = serialized_records.take(spec.limit) if spec.limit?
       serialized_records =
         serialized_records.select do |sr|
           Time.iso8601(time_comparison_field(spec, sr)) < spec.older_than
@@ -165,6 +164,7 @@ module RubyEventStore
         serialized_records.select do |sr|
           Time.iso8601(time_comparison_field(spec, sr)) >= spec.newer_than_or_equal
         end if spec.newer_than_or_equal
+      serialized_records = serialized_records.take(spec.limit) if spec.limit?
       serialized_records
     end
 

--- a/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
+++ b/ruby_event_store/lib/ruby_event_store/spec/event_repository_lint.rb
@@ -1309,6 +1309,19 @@ module RubyEventStore
       )
     end
 
+    specify "limit applies to records matching the time filter, not before it" do
+      event_1 = SRecord.new(event_id: "8a6f053e-3ce2-4c82-a55b-4d02c66ae6ea", timestamp: Time.utc(2020, 1, 1))
+      event_2 = SRecord.new(event_id: "8cee1139-4f96-483a-a175-2b947283c3c7", timestamp: Time.utc(2020, 1, 2))
+      event_3 = SRecord.new(event_id: "d345f86d-b903-4d78-803f-38990c078d9e", timestamp: Time.utc(2020, 1, 3))
+      repository.append_to_stream([event_1, event_2, event_3], Stream.new("whatever"), version_any)
+
+      expect(
+        repository.read(
+          specification.stream("whatever").backward.older_than_or_equal(Time.utc(2020, 1, 2)).limit(2).result,
+        ).to_a,
+      ).to eq([event_2, event_1])
+    end
+
     specify "fetching records older than or equal to specified date in stream" do
       event_1 = SRecord.new(event_id: "8a6f053e-3ce2-4c82-a55b-4d02c66ae6ea", timestamp: Time.utc(2020, 1, 1))
       event_2 = SRecord.new(event_id: "8cee1139-4f96-483a-a175-2b947283c3c7", timestamp: Time.utc(2020, 1, 2))


### PR DESCRIPTION
## Summary

The in-memory read applied `take(limit)` before the `older_than`/`newer_than` filters, so `limit` combined with a time filter returned fewer records than asked for even when more matched — unlike the SQL repositories, where `WHERE` inherently precedes `LIMIT`.

```ruby
# 3 events at Jan 1, Jan 2, Jan 3
read.backward.older_than_or_equal(Jan 2).limit(2)
# in-memory before: [Jan 2]           (takes 2 newest, then filters)
# SQL repositories: [Jan 2, Jan 1]    (filters, then limits)
```

Move the cut after the filters and pin the ordering with a shared lint example — ActiveRecord, Sequel and ROM already passed it.

## Test plan

- [x] New lint example red on the in-memory repository before the fix, green after; green on ActiveRecord, Sequel and ROM without changes
- [x] `ruby_event_store`, `ruby_event_store-active_record`, `contrib/ruby_event_store-sequel`, `contrib/ruby_event_store-rom` suites — green
- [x] Mutation testing on the diff — 100%