### PR TITLE
Use `.lease_connection` instead of `.connection` in Rails 7.2+

### DIFF
--- a/rails_event_store/lib/rails_event_store/after_commit_dispatcher.rb
+++ b/rails_event_store/lib/rails_event_store/after_commit_dispatcher.rb
@@ -11,7 +11,8 @@ module RailsEventStore
     end
 
     def run(&schedule_proc)
-      transaction = ActiveRecord::Base.connection.current_transaction
+      connection = ActiveRecord::Base.try(:lease_connection) || ActiveRecord::Base.connection
+      transaction = connection.current_transaction
 
       if transaction.joinable?
         transaction.add_record(async_record(schedule_proc))

--- a/rails_event_store/spec/after_commit_dispatcher_spec.rb
+++ b/rails_event_store/spec/after_commit_dispatcher_spec.rb
@@ -45,6 +45,16 @@ module RailsEventStore
       expect(MyActiveJobAsyncHandler2.received).to eq(serialized_record)
     end
 
+    it "uses ActiveRecord::Base.connection when .lease_connection is not available (ActiveRecord <7.2)" do
+      allow(ActiveRecord::Base).to receive(:lease_connection).and_return(nil)
+      allow(ActiveRecord::Base).to receive(:connection).and_call_original
+
+      dispatcher.call(MyActiveJobAsyncHandler2, event, record)
+
+      expect(ActiveRecord::Base).to have_received(:lease_connection)
+      expect(ActiveRecord::Base).to have_received(:connection)
+    end
+
     context "when transaction is rolledback" do
       it "does not dispatch job" do
         expect_no_enqueued_job(MyActiveJobAsyncHandler2) do


### PR DESCRIPTION
This allows applications to set `config.active_record.permanent_connection_checkout = :disallowed` without errors being raised.

https://guides.rubyonrails.org/configuring.html#config-active-record-permanent-connection-checkout